### PR TITLE
use Cats's `Xor` instead of returning unit and throwing exceptions

### DIFF
--- a/app/controllers/MainApp.scala
+++ b/app/controllers/MainApp.scala
@@ -38,7 +38,9 @@ class MainApp @Inject() (dataStore: DataStore,
   }
 
   def listAtoms = AuthAction { implicit req =>
-    Ok(displayAtomList(dataStore.listAtoms))
+    dataStore.listAtoms.fold(
+      err => InternalServerError(err.msg),
+      atoms => Ok(displayAtomList(atoms.toList))
+    )
   }
-
 }

--- a/app/data/DataStore.scala
+++ b/app/data/DataStore.scala
@@ -1,5 +1,6 @@
 package data
 
+import cats.data.Xor
 import com.google.inject.ImplementedBy
 import com.gu.contentatom.thrift.Atom
 
@@ -7,6 +8,8 @@ sealed abstract class DataStoreError(val msg: String) extends Exception(msg)
 
 case object IDConflictError extends DataStoreError("Atom ID already exists")
 case object IDNotFound extends DataStoreError("Atom ID not in datastore")
+case object ReadError extends DataStoreError("Read error")
+
 case class  DataError(info: String) extends DataStoreError(info)
 case class  VersionConflictError(requestVer: Long)
     extends DataStoreError(s"Update has version $requestVer, which is earlier or equal to data store version")
@@ -14,15 +17,21 @@ case class  VersionConflictError(requestVer: Long)
 //@ImplementedBy(classOf[MemoryStore])
 @ImplementedBy(classOf[DynamoDataStore])
 trait DataStore {
+
+  type DataStoreResult[R] = Xor[DataStoreError, R]
+
+  def fail(error: DataStoreError): DataStoreResult[Nothing] = Xor.left(error)
+  def succeed[R](result: => R): DataStoreResult[R] = Xor.right(result)
+
   def getMediaAtom(id: String): Option[Atom]
 
-  def createMediaAtom(atom: Atom): Unit
+  def createMediaAtom(atom: Atom): DataStoreResult[Unit]
 
   /* this will only allow the update if the version in atom is later
    * than the version stored in the database, otherwise it will report
    * it as a version conflict error */
-  def updateMediaAtom(newAtom: Atom): Unit
+  def updateMediaAtom(newAtom: Atom): DataStoreResult[Unit]
 
-  def listAtoms: TraversableOnce[Atom]
+  def listAtoms: DataStoreResult[TraversableOnce[Atom]]
 
 }

--- a/app/data/DynamoDataStore.scala
+++ b/app/data/DynamoDataStore.scala
@@ -23,8 +23,6 @@ class DynamoDataStore(dynamo: AmazonDynamoDBClient, tableName: String)
   sealed trait DynamoResult
   implicit class DynamoPutResult(res: PutItemResult) extends DynamoResult
 
-  type Result = DynamoResult
-
   case class AtomRow(
     id: String,
     version: Long,

--- a/app/data/DynamoDataStore.scala
+++ b/app/data/DynamoDataStore.scala
@@ -1,5 +1,6 @@
 package data
 
+import com.amazonaws.services.dynamodbv2.model.PutItemResult
 import util.atom.MediaAtomImplicits
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
@@ -10,11 +11,19 @@ import com.gu.scanamo.{ Scanamo, DynamoFormat, Table }
 import com.gu.scanamo.query._
 import com.twitter.scrooge.CompactThriftSerializer
 import cats.data.Xor
+import cats.implicits._
+
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
 
 class DynamoDataStore(dynamo: AmazonDynamoDBClient, tableName: String)
     extends DataStore
     with MediaAtomImplicits {
   @Inject() def this(awsConfig: util.AWSConfig) = this(awsConfig.dynamoDB, awsConfig.dynamoTableName)
+
+  sealed trait DynamoResult
+  implicit class DynamoPutResult(res: PutItemResult) extends DynamoResult
+
+  type Result = DynamoResult
 
   case class AtomRow(
     id: String,
@@ -56,25 +65,21 @@ class DynamoDataStore(dynamo: AmazonDynamoDBClient, tableName: String)
     case _ => None
   }
 
-  def createMediaAtom(atom: Atom): Unit =
+  def createMediaAtom(atom: Atom) =
     if(get(UniqueKey(KeyEquals('id, atom.id))).isDefined)
-      throw IDConflictError
+      fail(IDConflictError)
     else
-      put(atom)
+      succeed(put(atom))
 
-  def updateMediaAtom(newAtom: Atom): Unit = {
+  def updateMediaAtom(newAtom: Atom) = {
     val validationCheck = KeyIs('version, LT, newAtom.contentChangeDetails.revision)
-    Scanamo.exec(dynamo)(Table[Atom](tableName).given(validationCheck).put(newAtom)) match {
-      case Xor.Left(_: com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException) =>
-        throw new VersionConflictError(newAtom.tdata.activeVersion)
-      case _ => ()
-    }
+    val res = (Scanamo.exec(dynamo)(Table[Atom](tableName).given(validationCheck).put(newAtom)))
+    res.map(_ => ())
+      .leftMap(_ => VersionConflictError(newAtom.tdata.activeVersion))
   }
 
-  def listAtoms: TraversableOnce[Atom] = {
-    Scanamo.scan[Atom](dynamo)(tableName) map {
-      case Xor.Right(atom) => atom
-      case Xor.Left(err) => throw DataError(DynamoReadError.describe(err))
+  def listAtoms: DataStoreResult[TraversableOnce[Atom]] =
+    Scanamo.scan[Atom](dynamo)(tableName).sequenceU.leftMap {
+      _ => ReadError
     }
-  }
 }

--- a/app/data/MemoryStore.scala
+++ b/app/data/MemoryStore.scala
@@ -1,5 +1,6 @@
 package data
 
+import cats.data.Xor
 import com.gu.contentatom.thrift.Atom
 import javax.inject.Singleton
 
@@ -8,6 +9,8 @@ import util.atom.MediaAtomImplicits
 @Singleton
 class MemoryStore extends DataStore
     with MediaAtomImplicits {
+
+  type Result = Unit
 
   def this(initial: Map[String, Atom] = Map.empty) = {
     this()
@@ -19,22 +22,26 @@ class MemoryStore extends DataStore
   def getMediaAtom(id: String) = dataStore.get(id)
 
   def createMediaAtom(atom: Atom) = dataStore.synchronized {
-    if(dataStore.get(atom.id).isDefined)
-      throw IDConflictError
-    else
-      dataStore(atom.id) = atom
+    if(dataStore.get(atom.id).isDefined) {
+      fail(IDConflictError)
+    } else {
+      succeed(dataStore(atom.id) = atom)
+    }
   }
 
   def updateMediaAtom(newAtom: Atom) = dataStore.synchronized {
     getMediaAtom(newAtom.id) match {
       case Some(oldAtom) =>
-        if(oldAtom.contentChangeDetails.revision >= newAtom.contentChangeDetails.revision)
-          throw new VersionConflictError(newAtom.tdata.activeVersion)
-        dataStore(newAtom.id) = newAtom
-      case None => throw IDNotFound
+        if(oldAtom.contentChangeDetails.revision >=
+             newAtom.contentChangeDetails.revision) {
+          fail(VersionConflictError(newAtom.tdata.activeVersion))
+        } else {
+          succeed(dataStore(newAtom.id) = newAtom)
+        }
+      case None => fail(IDNotFound)
     }
   }
 
-  def listAtoms = dataStore.values
+  def listAtoms = Xor.right(dataStore.values)
 
 }

--- a/app/data/MemoryStore.scala
+++ b/app/data/MemoryStore.scala
@@ -10,8 +10,6 @@ import util.atom.MediaAtomImplicits
 class MemoryStore extends DataStore
     with MediaAtomImplicits {
 
-  type Result = Unit
-
   def this(initial: Map[String, Atom] = Map.empty) = {
     this()
     dataStore ++= initial


### PR DESCRIPTION
Provides better code-documentation of the errors that might result from the API interactions, and makes the code easier to read due to less surprises.

Thanks @philwills for the suggestion. (Would appreciate you casting your eye over this to make sure I have done it right ...)
