### PR TITLE
Only create one Injector during testing, and shut it down properly

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -30,7 +30,7 @@ class Api @Inject() (val dataStore: DataStore,
     extends AtomController
     with MediaAtomImplicits {
 
-  import authActions.{APIAuthAction, AuthAction}
+  import authActions.APIAuthAction
 
   private def atomUrl(id: String) = s"/atom/$id"
 

--- a/app/data/DataStore.scala
+++ b/app/data/DataStore.scala
@@ -4,6 +4,8 @@ import cats.data.Xor
 import com.google.inject.ImplementedBy
 import com.gu.contentatom.thrift.Atom
 
+import com.typesafe.scalalogging.LazyLogging
+
 sealed abstract class DataStoreError(val msg: String) extends Exception(msg)
 
 case object IDConflictError extends DataStoreError("Atom ID already exists")

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomPublisher.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomPublisher.scala
@@ -3,13 +3,14 @@ package com.gu.atom.publish
 import com.gu.contentatom.thrift.ContentAtomEvent
 import com.amazonaws.services.kinesis.AmazonKinesisClient
 
+import com.typesafe.scalalogging.LazyLogging
 
 import scala.util.Try
 
 class KinesisAtomPublisher (val streamName: String, val kinesis: AmazonKinesisClient)
     extends AtomPublisher
     with ThriftSerializer[ContentAtomEvent]
-    with com.typesafe.scalalogging.LazyLogging
+    with LazyLogging
 {
 
   logger.info(s"KinsisAtomPublisher started with streamName $streamName")

--- a/build.sbt
+++ b/build.sbt
@@ -55,4 +55,5 @@ lazy val root = (project in file("."))
   .enablePlugins(PlayScala, RiffRaffArtifact, UniversalPlugin)
   .settings(appDistSettings)
   .dependsOn(atomPublisher)
-
+  .aggregate(atomPublisher)
+  .settings(aggregate := false, aggregate in Test := true)

--- a/test/ApiSpec.scala
+++ b/test/ApiSpec.scala
@@ -36,9 +36,9 @@ class ApiSpec
     with MockitoSugar
     with MediaAtomImplicits {
 
-  implicit lazy val materializer = app.materializer
+//  implicit lazy val materializer = app.materializer
 
-  def initialDataStore = new MemoryStore(Map("1" -> testAtom))
+  override def initialDataStore = new MemoryStore(Map("1" -> testAtom))
 
   val youtubeId  =  "7H9Z4sn8csA"
   val youtubeUrl = s"https://www.youtube.com/watch?v=${youtubeId}"
@@ -61,74 +61,54 @@ class ApiSpec
     p
   }
 
-  def testUser: AuthenticatedUser = AuthenticatedUser(
-    user = User("Homer", "Simpson", "homer.simpson@guardian.co.uk", None),
-    authenticatingSystem = "test",
-    authenticatedIn = Set("test"),
-    expires = new Date().getTime + oneHour,
-    multiFactor = true
-  )
-
-  def requestWithCookies(api: Api, user: AuthenticatedUser = testUser) =
-    FakeRequest().withCookies(api.authActions.generateCookies(testUser): _*)
-
-  def withApi(dataStore: DataStore = initialDataStore,
-              livePublisher: LiveAtomPublisher = defaultMockPublisher,
-               previewPublisher: PreviewAtomPublisher = defaultPreviewMockPublisher)
-             (block: Api => Unit) =
-    block(getApi(dataStore, livePublisher, previewPublisher))
-
   "api" should {
-    "return a media atom" in withApi() { api =>
-      val result = api.getMediaAtom("1").apply(requestWithCookies(api))
-      status(result) mustEqual OK
-      val json = contentAsJson(result)
-                              (json \ "id").as[String] mustEqual "1"
-        (json \ "data" \ "assets").as[List[JsValue]] must have size 2
 
-    }
-    "return NotFound for missing atom" in withApi() { api =>
-      val result = api.getMediaAtom("xyzzy").apply(requestWithCookies(api))
-      status(result) mustEqual NOT_FOUND
-    }
-    "return not found when adding asset to a non-existant atom" in withApi() { api =>
-      val req = requestWithCookies(api).withFormUrlEncodedBody("uri" -> youtubeUrl, "version" -> "3")
+      "return a media atom" in AtomTestConf() { implicit conf =>
+        val result = api.getMediaAtom("1").apply(requestWithCookies)
+        status(result) mustEqual OK
+        val json = contentAsJson(result)
+                                (json \ "id").as[String] mustEqual "1"
+          (json \ "data" \ "assets").as[List[JsValue]] must have size 2
+
+      }
+
+      "return NotFound for missing atom" in AtomTestConf() { implicit conf =>
+        val result = api.getMediaAtom("xyzzy").apply(requestWithCookies)
+        status(result) mustEqual NOT_FOUND
+      }
+
+    "return not found when adding asset to a non-existant atom" in AtomTestConf() { implicit conf =>
+      val req = requestWithCookies.withFormUrlEncodedBody("uri" -> youtubeUrl, "version" -> "3")
       val result = call(api.addAsset("xyzzy"), req)
       status(result) mustEqual NOT_FOUND
     }
 
-    "complain when catching simultaenous update from datastore" in {
-      val mockDataStore = mock[DataStore]
+    "complain when catching simultaenous update from datastore" in
+    AtomTestConf(dataStore = mock[DataStore]) { implicit conf =>
+      val mockDataStore = conf.dataStore
       when(mockDataStore.getMediaAtom(any())).thenReturn(Some(testAtom))
       when(mockDataStore.updateMediaAtom(any())).thenReturn(Xor.Left(VersionConflictError(1)))
-      withApi(dataStore = mockDataStore) { api =>
-        val req = requestWithCookies(api)
-          .withFormUrlEncodedBody("uri" -> youtubeUrl, "version" -> "1")
-        val result = call(api.addAsset("1"), req)
+      val req = requestWithCookies
+        .withFormUrlEncodedBody("uri" -> youtubeUrl, "version" -> "1")
+      val result = call(api.addAsset("1"), req)
 
-        status(result) mustEqual INTERNAL_SERVER_ERROR
-        verify(mockDataStore).updateMediaAtom(any())
-      }
+      status(result) mustEqual INTERNAL_SERVER_ERROR
+      verify(mockDataStore).updateMediaAtom(any())
     }
 
-    "add an asset to an atom" in {
-      val dataStore = initialDataStore
-      withApi(dataStore = dataStore) { api =>
-        val req = requestWithCookies(api).withFormUrlEncodedBody("uri" -> youtubeUrl, "version" -> "1")
-        val result = call(api.addAsset("1"), req)
-        withClue(s"(body: [${contentAsString(result)}])") { status(result) mustEqual CREATED }
-        dataStore.getMediaAtom("1").value.tdata.assets must have size 3
-      }
+    "add an asset to an atom" in AtomTestConf() { implicit conf =>
+      val req = requestWithCookies.withFormUrlEncodedBody("uri" -> youtubeUrl, "version" -> "1")
+      val result = call(api.addAsset("1"), req)
+      withClue(s"(body: [${contentAsString(result)}])") { status(result) mustEqual CREATED }
+      conf.dataStore.getMediaAtom("1").value.tdata.assets must have size 3
     }
-    "create an atom" in {
-      val dataStore = initialDataStore
-      withApi(dataStore = dataStore) { api =>
-        val req = requestWithCookies(api).withFormUrlEncodedBody("id" -> "2")
-        val result = call(api.createMediaAtom(), req)
-        withClue(s"(body: [${contentAsString(result)}])") { status(result) mustEqual CREATED  }
-        val createdAtom = dataStore.getMediaAtom("2").value
-        createdAtom.id mustEqual "2"
-      }
+
+    "create an atom" in AtomTestConf() { implicit conf =>
+      val req = requestWithCookies.withFormUrlEncodedBody("id" -> "2")
+      val result = call(api.createMediaAtom(), req)
+      withClue(s"(body: [${contentAsString(result)}])") { status(result) mustEqual CREATED  }
+      val createdAtom = conf.dataStore.getMediaAtom("2").value
+      createdAtom.id mustEqual "2"
     }
     "call out to live publisher to publish an atom" in withApi() { api =>
       val result = call(api.publishAtom("1"), requestWithCookies(api))
@@ -165,33 +145,25 @@ class ApiSpec
       val result = call(api.publishAtom("1"), requestWithCookies(api))
       status(result) mustEqual INTERNAL_SERVER_ERROR
     }
-    "should list atoms" in {
-      val dataStore = initialDataStore
-      dataStore.createMediaAtom(testAtom.copy(id = "2"))
-      withApi(dataStore = dataStore) { api =>
-        val result = call(api.listAtoms(), requestWithCookies(api))
-        status(result) mustEqual OK
-        contentAsJson(result).as[List[JsValue]] must have size 2
-      }
+    "should list atoms" in AtomTestConf() { implicit conf =>
+      conf.dataStore.createMediaAtom(testAtom.copy(id = "2"))
+      val result = call(api.listAtoms(), requestWithCookies)
+      status(result) mustEqual OK
+      contentAsJson(result).as[List[JsValue]] must have size 2
     }
-    "should change version of atom" in {
-      val dataStore = initialDataStore
-      withApi(dataStore = dataStore) { api =>
-        // before...
-        dataStore.getMediaAtom("1").value.tdata.activeVersion mustEqual 2L
-        val result = call(api.revertAtom("1", 1L), requestWithCookies(api))
-        status(result) mustEqual OK
-        // after ...
-        dataStore.getMediaAtom("1").value.tdata.activeVersion mustEqual 1L
-      }
+    "should change version of atom" in AtomTestConf() { implicit conf =>
+      // before...
+      conf.dataStore.getMediaAtom("1").value.tdata.activeVersion mustEqual 2L
+      val result = call(api.revertAtom("1", 1L), requestWithCookies)
+      status(result) mustEqual OK
+      // after ...
+      conf.dataStore.getMediaAtom("1").value.tdata.activeVersion mustEqual 1L
     }
-    "should complain if revert to version without asset" in {
-      val dataStore = initialDataStore
-      withApi(dataStore = dataStore) { api =>
-        // before...
-        val result = call(api.revertAtom("1", 10L), requestWithCookies(api))
-        status(result) mustEqual INTERNAL_SERVER_ERROR
-      }
+    "should complain if revert to version without asset" in
+    AtomTestConf() { implicit conf =>
+      // before...
+      val result = call(api.revertAtom("1", 10L), requestWithCookies)
+      status(result) mustEqual INTERNAL_SERVER_ERROR
     }
   }
 }

--- a/test/ApiSpec.scala
+++ b/test/ApiSpec.scala
@@ -8,24 +8,16 @@ import org.mockito.ArgumentCaptor
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito._
 import org.mockito.Matchers._
-import play.api.mvc.{ AnyContent, Cookie, Request }
 
 import util.atom.MediaAtomImplicits
 
 import play.api.libs.json._
-import controllers.Api
-import org.scalatestplus.play._
-import play.api.test._
 import play.api.http.HttpVerbs
 import play.api.test.Helpers._
 import data.MemoryStore
 
 import org.scalatest.AppendedClues
 import scala.util.{ Success, Failure }
-
-import com.gu.pandomainauth.model._
-
-import java.util.Date
 
 import TestData._
 

--- a/test/MediaAtomSuite.scala
+++ b/test/MediaAtomSuite.scala
@@ -8,10 +8,9 @@ import play.api.libs.ws.WSClient
 import com.gu.atom.publish.AtomPublisher
 import com.gu.pandomainauth.model.{ AuthenticatedUser, User }
 import java.util.Date
-import org.scalatest.{ TestData => ScalaTestData }
 import play.api.inject.guice.{ GuiceApplicationBuilder, GuiceableModule, GuiceableModuleConversions }
 
-import org.scalatestplus.play.{ PlaySpec, OneAppPerTest }
+import org.scalatestplus.play.PlaySpec
 
 import com.gu.pandomainauth.action.AuthActions
 
@@ -39,8 +38,6 @@ trait MediaAtomSuite extends PlaySpec with GuiceableModuleConversions {
   def initialPublisher = mock[AtomPublisher]
 
   private def ibind[A : ClassTag](a: A): Binding[A] = bind[A] toInstance a
-
-  private def ibind[A : ClassTag](aOpt: Option[A]): Option[Binding[_]] = aOpt.map(a => ibind(a))
 
   case class AtomTestConf(
     dataStore: DataStore = initialDataStore,

--- a/test/MediaAtomSuite.scala
+++ b/test/MediaAtomSuite.scala
@@ -5,8 +5,13 @@ import com.gu.atom.publish.{LiveAtomPublisher, PreviewAtomPublisher}
 import play.api.Configuration
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.WSClient
+import com.gu.atom.publish.AtomPublisher
+import com.gu.pandomainauth.model.{ AuthenticatedUser, User }
+import java.util.Date
+import org.scalatest.{ TestData => ScalaTestData }
+import play.api.inject.guice.{ GuiceApplicationBuilder, GuiceableModule, GuiceableModuleConversions }
 
-import org.scalatestplus.play.{ PlaySpec, OneAppPerSuite }
+import org.scalatestplus.play.{ PlaySpec, OneAppPerTest }
 
 import com.gu.pandomainauth.action.AuthActions
 
@@ -14,22 +19,63 @@ import data._
 
 import controllers.Api
 
-import play.api.inject.bind
+import play.api.inject.{ bind, Binding }
+import play.api.test.FakeRequest
+import scala.reflect.ClassTag
 
-trait MediaAtomSuite extends PlaySpec with OneAppPerSuite {
+import org.scalatest.mock.MockitoSugar.mock
 
-  val guicer = new GuiceApplicationBuilder()
-    .overrides(bind(classOf[AuthActions]).to(classOf[TestPandaAuth]))
+trait MediaAtomSuite extends PlaySpec with GuiceableModuleConversions {
 
-  override lazy val app = guicer.build
+  def testUser: AuthenticatedUser = AuthenticatedUser(
+    user = User("Homer", "Simpson", "homer.simpson@guardian.co.uk", None),
+    authenticatingSystem = "test",
+    authenticatedIn = Set("test"),
+    expires = new Date().getTime + oneHour,
+    multiFactor = true
+  )
+
+  def initialDataStore = mock[DataStore]
+  def initialPublisher = mock[AtomPublisher]
+
+  private def ibind[A : ClassTag](a: A): Binding[A] = bind[A] toInstance a
+
+  private def ibind[A : ClassTag](aOpt: Option[A]): Option[Binding[_]] = aOpt.map(a => ibind(a))
+
+  case class AtomTestConf(
+    dataStore: DataStore = initialDataStore,
+    publisher: AtomPublisher = initialPublisher,
+    shutDownHook: AtomTestConf => Unit = _.app.stop) {
+
+    private def makeOverrides: GuiceableModule = Seq(
+      ibind(dataStore),
+      ibind(publisher)
+    )
+
+    lazy val guicer = new GuiceApplicationBuilder()
+      .overrides(bind(classOf[AuthActions]).to(classOf[TestPandaAuth]))
+      .overrides(makeOverrides)
+
+    lazy val app = guicer.build()
+    lazy val api = app.injector.instanceOf(classOf[Api])
+
+    def shutdown = shutDownHook(this)
+
+    def apply(block: AtomTestConf => Unit) =
+      try {
+        block(this)
+      } finally {
+        shutdown
+      }
+  }
+
+  def requestWithCookies(implicit conf: AtomTestConf) =
+    FakeRequest().withCookies(api.authActions.generateCookies(testUser): _*)
+
+  implicit def app(implicit atomConf: AtomTestConf) = atomConf.app
+  implicit def materializer(implicit atomConf: AtomTestConf) = app.materializer
+
+  def api(implicit atomConf: AtomTestConf) = atomConf.api
 
   val oneHour = 3600000L
-  def getApi(dataStore: DataStore, livePublisher: LiveAtomPublisher, previewPublisher: PreviewAtomPublisher) = {
-    guicer
-      .overrides(bind(classOf[DataStore]).toInstance(dataStore))
-      .overrides(bind(classOf[LiveAtomPublisher]).toInstance(livePublisher))
-      .overrides(bind(classOf[PreviewAtomPublisher]).toInstance(previewPublisher))
-      .injector
-      .instanceOf(classOf[Api])
-  }
 }

--- a/test/MediaAtomSuite.scala
+++ b/test/MediaAtomSuite.scala
@@ -35,18 +35,21 @@ trait MediaAtomSuite extends PlaySpec with GuiceableModuleConversions {
   )
 
   def initialDataStore = mock[DataStore]
-  def initialPublisher = mock[AtomPublisher]
+  def initialLivePublisher = mock[LiveAtomPublisher]
+  def initialPreviewPublisher = mock[PreviewAtomPublisher]
 
   private def ibind[A : ClassTag](a: A): Binding[A] = bind[A] toInstance a
 
   case class AtomTestConf(
     dataStore: DataStore = initialDataStore,
-    publisher: AtomPublisher = initialPublisher,
+    livePublisher: LiveAtomPublisher = initialLivePublisher,
+    previewPublisher: PreviewAtomPublisher = initialPreviewPublisher,
     shutDownHook: AtomTestConf => Unit = _.app.stop) {
 
     private def makeOverrides: GuiceableModule = Seq(
       ibind(dataStore),
-      ibind(publisher)
+      ibind(livePublisher),
+      ibind(previewPublisher)
     )
 
     lazy val guicer = new GuiceApplicationBuilder()

--- a/test/TestApi.scala
+++ b/test/TestApi.scala
@@ -4,22 +4,15 @@ package test
 // settings to use it's own test key (which is not used for anything
 // else and so does not need to be kept secure
 
-import com.gu.pandomainauth.PanDomainAuth
-import data._
+import akka.actor.{ Actor, Props }
+import controllers.PanDomainAuthActions
 
 import play.api.Configuration
+import play.api.inject.ApplicationLifecycle
 import play.api.libs.ws.WSClient
 
 import javax.inject.Inject
 
-import com.gu.pandomainauth.model.PanDomainAuthSettings
-
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
-
-import akka.actor.{Props, Actor, ActorSystem}
-import akka.agent.Agent
-
-import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
 import play.api.libs.ws.WSClient
 
@@ -31,10 +24,13 @@ class DummyActor extends Actor {
   }
 }
 
-class TestPandaAuth @Inject() (val wsClient: WSClient) extends AuthActions {
+class TestPandaAuth @Inject() (
+  wsClient: WSClient, conf: Configuration,
+  applicationLifeCycle: ApplicationLifecycle)
+    extends PanDomainAuthActions (wsClient, conf, applicationLifeCycle) {
 
-  def authCallbackUrl = ""
-  def validateUser(user: AuthenticatedUser) = true
+  override def authCallbackUrl = ""
+  override def validateUser(user: AuthenticatedUser) = true
 
   override lazy val domainSettingsRefreshActor =
     actorSystem.actorOf(Props[DummyActor])
@@ -48,13 +44,6 @@ class TestPandaAuth @Inject() (val wsClient: WSClient) extends AuthActions {
     )
   }
 
-  val domain = "test"
-  def system = "test"
+  override lazy val domain = "test"
+  override lazy val system = "test"
 }
-
-// class TestApiController @Inject() (dataStore: DataStore,
-//                          publisher: AtomPublisher,
-//                          conf: Configuration,
-//                          wsClient: WSClient)
-//     extends controllers.Api(dataStore, publisher, conf, wsClient)
-//     with TestPandaAuth


### PR DESCRIPTION
This reorganises the tests so that we only create one Injector for each test, while still allowing us to override the bindings for some tests (you can only override once, so you can't just add overrides to the existing module).

In addition, this runs shtudown code after each test, which fixes issue #7.