### PR TITLE
Add initial reindex endpoint

### DIFF
--- a/app/controllers/ReindexController.scala
+++ b/app/controllers/ReindexController.scala
@@ -2,6 +2,8 @@ package controllers
 
 import akka.actor.{ ActorSystem, Props }
 import com.gu.atom.publish.AtomReindexer
+import com.gu.contentatom.thrift.{ ContentAtomEvent, EventType }
+import play.api.Configuration
 
 import play.api.mvc._
 import javax.inject.Inject
@@ -15,13 +17,18 @@ import akka.pattern.ask
 import akka.util.Timeout
 import scala.concurrent.duration._
 import util.ReindexActor._
+import java.util.Date
+import scala.concurrent.Future
 
 import play.api.libs.json.{ util => _, _ } // util shadows our package util
 
 @Singleton
 class ReindexController @Inject() (dataStore: DataStore,
                                    reindexer: AtomReindexer,
+                                   config: Configuration,
                                    system: ActorSystem) extends Controller {
+
+  def now() = (new Date()).getTime()
 
   implicit val ec = system.dispatcher
 
@@ -31,15 +38,37 @@ class ReindexController @Inject() (dataStore: DataStore,
 
   implicit val statusWrites = Json.writes[JobStatus]
 
-  def newReindexJob = Action.async { implicit req =>
-    (reindexActor ? CreateJob(Iterator.empty, 0)) map {
-      case RSuccess      => Ok("")
-      case RFailure(msg) => InternalServerError(s"could't create job: $msg")
-      case _ => InternalServerError("unknown error")
+  object ApiKeyAction extends ActionBuilder[Request] {
+    lazy val apiKey = config.getString("reindexApiKey").get
+
+    def invokeBlock[A](request: Request[A], block: (Request[A] => Future[Result])) = {
+      if(request.getQueryString("api").filter(_ == apiKey).isDefined)
+        block(request)
+      else
+        Future.successful(Unauthorized(""))
     }
   }
 
-  def reindexJobStatus = Action.async { implicit req =>
+  def newReindexJob = ApiKeyAction.async { implicit req =>
+    dataStore.listAtoms.fold(
+
+      { err =>
+        Future.successful(InternalServerError(err.toString))
+      },
+
+      { atoms =>
+        val events = atoms.map(atom => ContentAtomEvent(atom, EventType.Update, now())).toList
+        (reindexActor ? CreateJob(events.iterator, events.size)) map {
+          case RSuccess      => Ok("")
+          case RFailure(msg) => InternalServerError(s"could't create job: $msg")
+          case _ => InternalServerError("unknown error")
+        }
+      }
+
+    )
+  }
+
+  def reindexJobStatus = ApiKeyAction.async { implicit req =>
     (reindexActor ? GetStatus) map {
       case None => NotFound("")
       case Some(job: JobStatus) => Ok(Json.toJson(job))

--- a/app/controllers/ReindexController.scala
+++ b/app/controllers/ReindexController.scala
@@ -1,0 +1,50 @@
+package controllers
+
+import akka.actor.{ ActorSystem, Props }
+import com.gu.atom.publish.AtomReindexer
+
+import play.api.mvc._
+import javax.inject.Inject
+
+import data._
+import util._
+
+import javax.inject.Singleton
+
+import akka.pattern.ask
+import akka.util.Timeout
+import scala.concurrent.duration._
+import util.ReindexActor._
+
+import play.api.libs.json.{ util => _, _ } // util shadows our package util
+
+@Singleton
+class ReindexController @Inject() (dataStore: DataStore,
+                                   reindexer: AtomReindexer,
+                                   system: ActorSystem) extends Controller {
+
+  implicit val ec = system.dispatcher
+
+  val reindexActor = system.actorOf(Props(classOf[ReindexActor], reindexer))
+
+  implicit val timeout = Timeout(5.seconds)
+
+  implicit val statusWrites = Json.writes[JobStatus]
+
+  def newReindexJob = Action.async { implicit req =>
+    (reindexActor ? CreateJob(Iterator.empty, 0)) map {
+      case RSuccess      => Ok("")
+      case RFailure(msg) => InternalServerError(s"could't create job: $msg")
+      case _ => InternalServerError("unknown error")
+    }
+  }
+
+  def reindexJobStatus = Action.async { implicit req =>
+    (reindexActor ? GetStatus) map {
+      case None => NotFound("")
+      case Some(job: JobStatus) => Ok(Json.toJson(job))
+      case _ => InternalServerError("unknown-error")
+    }
+  }
+
+}

--- a/app/data/AtomReindexerProvider.scala
+++ b/app/data/AtomReindexerProvider.scala
@@ -1,0 +1,13 @@
+package data
+
+import javax.inject.{Inject, Provider}
+
+import com.gu.atom.publish.{ KinesisAtomReindexer, AtomReindexer }
+import util.AWSConfig
+
+class AtomReindexerProvider @Inject() (awsConfig: AWSConfig)
+    extends Provider[AtomReindexer] {
+  def get() = new KinesisAtomReindexer(
+    awsConfig.kinesisReindexStreamName, awsConfig.kinesisClient
+  )
+}

--- a/app/data/DataStore.scala
+++ b/app/data/DataStore.scala
@@ -32,6 +32,6 @@ trait DataStore {
    * it as a version conflict error */
   def updateMediaAtom(newAtom: Atom): DataStoreResult[Unit]
 
-  def listAtoms: DataStoreResult[TraversableOnce[Atom]]
+  def listAtoms: DataStoreResult[Iterator[Atom]]
 
 }

--- a/app/data/DynamoDataStore.scala
+++ b/app/data/DynamoDataStore.scala
@@ -54,7 +54,7 @@ class DynamoDataStore(dynamo: AmazonDynamoDBClient, tableName: String)
 
   // useful shortcuts
   private val get  = Scanamo.get[Atom](dynamo)(tableName) _
-  private val put  = Scanamo.put[Atom ](dynamo)(tableName) _
+  private val put  = Scanamo.put[Atom](dynamo)(tableName) _
 
   // this should probably return an Either so we can report an error,
   // e.g. if the atom exists, but it can't be deseralised
@@ -76,8 +76,10 @@ class DynamoDataStore(dynamo: AmazonDynamoDBClient, tableName: String)
       .leftMap(_ => VersionConflictError(newAtom.tdata.activeVersion))
   }
 
-  def listAtoms: DataStoreResult[TraversableOnce[Atom]] =
+  private def findAtoms: DataStoreResult[List[Atom]] =
     Scanamo.scan[Atom](dynamo)(tableName).sequenceU.leftMap {
       _ => ReadError
     }
+
+  def listAtoms: DataStoreResult[Iterator[Atom]] = findAtoms.rightMap(_.iterator)
 }

--- a/app/data/MemoryStore.scala
+++ b/app/data/MemoryStore.scala
@@ -40,6 +40,6 @@ class MemoryStore extends DataStore
     }
   }
 
-  def listAtoms = Xor.right(dataStore.values)
+  def listAtoms = Xor.right(dataStore.values.iterator)
 
 }

--- a/app/di.scala
+++ b/app/di.scala
@@ -1,14 +1,17 @@
 import com.google.inject.AbstractModule
-import com.gu.atom.publish.AtomPublisher
+import com.gu.atom.publish.{ AtomPublisher, AtomReindexer }
 import com.gu.pandomainauth.action.AuthActions
-import data.AtomPublisherProvider
+import data._
 
 class Module extends AbstractModule {
   def configure() = {
     bind(classOf[AuthActions])
-    .to(classOf[controllers.PanDomainAuthActions])
+      .to(classOf[controllers.PanDomainAuthActions])
 
     bind(classOf[AtomPublisher])
-    .toProvider(classOf[AtomPublisherProvider])
+      .toProvider(classOf[AtomPublisherProvider])
+
+    bind(classOf[AtomReindexer])
+      .toProvider(classOf[AtomReindexerProvider])
   }
 }

--- a/app/di.scala
+++ b/app/di.scala
@@ -1,7 +1,7 @@
 import com.google.inject.AbstractModule
-import com.gu.atom.publish.{LiveAtomPublisher, PreviewAtomPublisher}
+import com.gu.atom.publish._
 import com.gu.pandomainauth.action.AuthActions
-import data.{PreviewAtomPublisherProvider, LiveAtomPublisherProvider}
+import data._
 
 class Module extends AbstractModule {
   def configure() = {
@@ -13,5 +13,9 @@ class Module extends AbstractModule {
 
     bind(classOf[PreviewAtomPublisher])
       .toProvider(classOf[PreviewAtomPublisherProvider])
+
+    bind(classOf[AtomReindexer])
+      .toProvider(classOf[AtomReindexerProvider])
+
   }
 }

--- a/app/util/AWS.scala
+++ b/app/util/AWS.scala
@@ -34,6 +34,8 @@ class AWSConfig @Inject() (config: Configuration) {
 
   lazy val kinesisStreamName = config.getString("aws.kinesis.streamName").get
 
+  lazy val kinesisReindexStreamName = config.getString("aws.kinesis.reindexStreamName").get
+
   lazy val kinesisClient = region.createClient(
     classOf[AmazonKinesisClient],
     credProvider,

--- a/app/util/ReindexActor.scala
+++ b/app/util/ReindexActor.scala
@@ -1,0 +1,76 @@
+package util
+
+import scala.util.Success
+import akka.actor.Actor
+import com.gu.atom.publish.{ AtomReindexJob, AtomReindexer }
+import com.gu.contentatom.thrift.ContentAtomEvent
+
+/*
+ * In here we find the Actor that is responsible for initialising,
+ * monitoring, and finishing the reindex job.
+ * 
+ * The controller will send it messages to get a status update and so on.
+ */
+
+class ReindexActor(reindexer: AtomReindexer) extends Actor {
+  import ReindexActor._
+
+  implicit val ec = context.dispatcher
+
+  /* this is the initial, idle state. In this state we will accept new jobs */
+  def idleState(lastJob: Option[AtomReindexJob]): Receive = {
+    case CreateJob(atoms, expectedSize) =>
+      val job = reindexer.startReindexJob(atoms, expectedSize)
+      context.become(inProgressState(job))
+      job.execute.onComplete {
+        case _ => context.become(idleState(Some(job)), true)
+      }
+      sender ! RSuccess
+
+    case GetStatus =>
+      sender ! lastJob.map(statusReply _)
+  }
+
+  def inProgressState(job: AtomReindexJob): Receive = {
+    case CreateJob(_, _) =>
+      sender ! RFailure("in progress")
+    case GetStatus =>
+      sender ! Some(statusReply(job))
+  }
+
+  /* start off in idle state with no record of a previous job */
+  def receive = idleState(None)
+
+}
+
+/* the messages that we will send and recieve */
+object ReindexActor {
+  /* requests */
+  case class CreateJob(atoms: Iterator[ContentAtomEvent], expectedSize: Int)
+  case object GetStatus
+
+  /* responses */
+  case object RSuccess
+  case class RFailure(reason: String)
+
+  /* matches response expected by CAPI */
+  object StatusType extends Enumeration {
+    val inProgress = Value("in progress")
+    val failed     = Value("failed")
+    val completed  = Value("completed")
+    val cancelled  = Value("cancelled")
+  }
+
+  case class JobStatus(
+    status: StatusType.Value,
+    documentsIndexed: Int,
+    documentsExpected: Int
+  )
+
+  def statusReply(job: AtomReindexJob): JobStatus =
+    JobStatus(
+      if(job.isComplete) StatusType.completed else StatusType.inProgress,
+      job.completedCount,
+      job.expectedSize
+    )
+}

--- a/app/util/ReindexActor.scala
+++ b/app/util/ReindexActor.scala
@@ -8,7 +8,7 @@ import com.gu.contentatom.thrift.ContentAtomEvent
 /*
  * In here we find the Actor that is responsible for initialising,
  * monitoring, and finishing the reindex job.
- * 
+ *
  * The controller will send it messages to get a status update and so on.
  */
 

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -7,13 +7,16 @@ version := "1.0.0-SNAPSHOT"
 lazy val contentAtomVersion = "1.0.1"
 lazy val scroogeVersion     = "4.2.0"
 lazy val AwsSdkVersion      = "1.10.74"
+lazy val akkaVersion        = "2.4.8"
 
 libraryDependencies ++= Seq(
-  "com.gu"                     %% "content-atom-model"           % contentAtomVersion,
-  "com.amazonaws"              %  "aws-java-sdk-kinesis"         % AwsSdkVersion,
-  "com.typesafe.scala-logging" %% "scala-logging"                % "3.4.0",
-  "com.twitter"                %% "scrooge-serializer"           % scroogeVersion,
-  "com.twitter"                %% "scrooge-core"                 % scroogeVersion,
-  "org.mockito"                %  "mockito-core"                 % "1.10.19" % "test",
-  "org.scalatest"              %% "scalatest"                    % "2.2.6"   % "test"
+  "com.gu"                     %% "content-atom-model"   % contentAtomVersion,
+  "com.amazonaws"              %  "aws-java-sdk-kinesis" % AwsSdkVersion,
+  "com.typesafe.scala-logging" %% "scala-logging"        % "3.4.0",
+  "com.twitter"                %% "scrooge-serializer"   % scroogeVersion,
+  "com.twitter"                %% "scrooge-core"         % scroogeVersion,
+  "com.typesafe.akka"          %% "akka-actor"           % akkaVersion,
+  "org.mockito"                %  "mockito-core"         % "1.10.19"   % "test",
+  "org.scalatest"              %% "scalatest"            % "2.2.6"     % "test",
+  "com.typesafe.akka"          %% "akka-testkit"         % akkaVersion % "test"
 )

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/AtomReindexer.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/AtomReindexer.scala
@@ -3,12 +3,6 @@ package com.gu.atom.publish
 import com.gu.contentatom.thrift.ContentAtomEvent
 import scala.concurrent.{ ExecutionContext, Future }
 
-// sealed trait ReindexResult[A]
-// sealed abstract class ReindexError(msg: String) extends ReindexResult
-// case object JobAlreadyInProgress
-//     extends ReindexError("A job is already in progress")
-// case class Success[A](value: A) extends ReindexResult
-
 sealed trait ReindexJobStatus
 case class Completed(completedCount: Int) extends ReindexJobStatus
 case class InProgress(completedCount: Int) extends ReindexJobStatus
@@ -28,6 +22,5 @@ trait AtomReindexer {
 
   def startReindexJob(atomsToReindex: Iterator[ContentAtomEvent], expectedSize: Int)
                      (implicit ec: ExecutionContext): AtomReindexJob
-  def reindexStatus: Option[AtomReindexJob]
 
 }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/AtomReindexer.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/AtomReindexer.scala
@@ -3,11 +3,6 @@ package com.gu.atom.publish
 import com.gu.contentatom.thrift.ContentAtomEvent
 import scala.concurrent.{ ExecutionContext, Future }
 
-sealed trait ReindexJobStatus
-case class Completed(completedCount: Int) extends ReindexJobStatus
-case class InProgress(completedCount: Int) extends ReindexJobStatus
-// case class Failed(reason: ReindexError, completedCount: Int) extends ReindexJobStatus
-
 abstract class AtomReindexJob(atomEvents: Iterator[ContentAtomEvent], val expectedSize: Int) {
   protected var _isComplete: Boolean = false
   protected var _completedCount: Int = 0

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/AtomReindexer.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/AtomReindexer.scala
@@ -15,12 +15,11 @@ abstract class AtomReindexJob(atomEvents: Iterator[ContentAtomEvent], val expect
   def isComplete = _isComplete
   def completedCount: Int = _completedCount
 
-  def execute: Future[Int]
+  def execute(implicit ec: ExecutionContext): Future[Int]
 }
 
 trait AtomReindexer {
 
-  def startReindexJob(atomsToReindex: Iterator[ContentAtomEvent], expectedSize: Int)
-                     (implicit ec: ExecutionContext): AtomReindexJob
+  def startReindexJob(atomsToReindex: Iterator[ContentAtomEvent], expectedSize: Int): AtomReindexJob
 
 }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/AtomReindexer.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/AtomReindexer.scala
@@ -1,7 +1,7 @@
 package com.gu.atom.publish
 
-import com.gu.contentatom.thrift.Atom
-import scala.concurrent.Future
+import com.gu.contentatom.thrift.ContentAtomEvent
+import scala.concurrent.{ ExecutionContext, Future }
 
 // sealed trait ReindexResult[A]
 // sealed abstract class ReindexError(msg: String) extends ReindexResult
@@ -14,9 +14,20 @@ case class Completed(completedCount: Int) extends ReindexJobStatus
 case class InProgress(completedCount: Int) extends ReindexJobStatus
 // case class Failed(reason: ReindexError, completedCount: Int) extends ReindexJobStatus
 
+abstract class AtomReindexJob(atomEvents: Iterator[ContentAtomEvent], val expectedSize: Int) {
+  protected var _isComplete: Boolean = false
+  protected var _completedCount: Int = 0
+
+  def isComplete = _isComplete
+  def completedCount: Int = _completedCount
+
+  def execute: Future[Int]
+}
+
 trait AtomReindexer {
 
-  def startReindexJob(atomsToReindex: Iterator[Atom]): Future[Unit]
-  def reindexStatus: Future[ReindexJobStatus]
+  def startReindexJob(atomsToReindex: Iterator[ContentAtomEvent], expectedSize: Int)
+                     (implicit ec: ExecutionContext): AtomReindexJob
+  def reindexStatus: Option[AtomReindexJob]
 
 }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/AtomReindexer.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/AtomReindexer.scala
@@ -1,0 +1,22 @@
+package com.gu.atom.publish
+
+import com.gu.contentatom.thrift.Atom
+import scala.concurrent.Future
+
+// sealed trait ReindexResult[A]
+// sealed abstract class ReindexError(msg: String) extends ReindexResult
+// case object JobAlreadyInProgress
+//     extends ReindexError("A job is already in progress")
+// case class Success[A](value: A) extends ReindexResult
+
+sealed trait ReindexJobStatus
+case class Completed(completedCount: Int) extends ReindexJobStatus
+case class InProgress(completedCount: Int) extends ReindexJobStatus
+// case class Failed(reason: ReindexError, completedCount: Int) extends ReindexJobStatus
+
+trait AtomReindexer {
+
+  def startReindexJob(atomsToReindex: Iterator[Atom]): Future[Unit]
+  def reindexStatus: Future[ReindexJobStatus]
+
+}

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
@@ -12,13 +12,16 @@ class KinesisAtomReindexer(
 
   def makeParititionKey(event: ContentAtomEvent): String = event.atom.atomType.name
 
-  def startReindexJob(atomEventsToReindex: Iterator[ContentAtomEvent], expectedSize: Int)(implicit ec: ExecutionContext) =
+  def startReindexJob(atomEventsToReindex: Iterator[ContentAtomEvent], expectedSize: Int) =
     new AtomReindexJob(atomEventsToReindex, expectedSize) {
-      def execute = Future {
+      def execute(implicit ec: ExecutionContext) = Future {
         atomEventsToReindex foreach { atomEvent =>
-          kinesis.putRecord(streamName, serializeEvent(atomEvent), makeParititionKey(atomEvent))
+          println(s"PMR putting record (${completedCount})")
+          //kinesis.putRecord(streamName, serializeEvent(atomEvent), makeParititionKey(atomEvent))
+          Thread.sleep(1000)
           _completedCount += 1
         }
+        println(s"PMR complete (${completedCount})")
         _isComplete = true
         _completedCount
       }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
@@ -16,11 +16,9 @@ class KinesisAtomReindexer(
     new AtomReindexJob(atomEventsToReindex, expectedSize) {
       def execute(implicit ec: ExecutionContext) = Future {
         atomEventsToReindex foreach { atomEvent =>
-          println(s"PMR putting record (${completedCount})")
           kinesis.putRecord(streamName, serializeEvent(atomEvent), makeParititionKey(atomEvent))
           _completedCount += 1
         }
-        println(s"PMR complete (${completedCount})")
         _isComplete = true
         _completedCount
       }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
@@ -2,44 +2,85 @@ package com.gu.atom.publish
 
 import akka.actor.{ Actor, Props, ActorSystem }
 import akka.util.Timeout
-import com.gu.contentatom.thrift.Atom
+import com.gu.contentatom.thrift.{ Atom, ContentAtomEvent }
 import com.amazonaws.services.kinesis.AmazonKinesisClient
 import akka.pattern.ask
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ Future, ExecutionContext }
 
 import scala.concurrent.duration._
 
-import KinesisAtomActor._
+// class KinesisAtomActor(streamName: String,
+//                        kinesis: AmazonKinesisClient,
+//                        executionContext: ExecutionContext)
+//     extends Actor {
 
-class KinesisAtomActor(streamName: String, kinesis: AmazonKinesisClient)
-    extends Actor {
+//   implicit val ec = executionContext
 
-  def receive = {
-    case StartJob(atoms) => sender ! OK
-  }
+//   def processJob(atoms: Iterator[Atom]) = Future {
+//     atoms.foldLeft(0) { (count, atom) =>
+//       println(atom)
+//       count + 1
+//     }
+//   }
 
-  //   // def busy: Receive = {
-  //   //   case msg => println(msg)
-  //   // }
+//   val inProgress: Receive = { case _ => InProgress }
 
-  // }
+//   def waiting(lastStatus: Option[Status]): Receive = {
+//     case StartJob(atoms) =>
+//       context.become(inProgress, true)
+//       processJob(atoms) onSuccess {
+//         case completedCount => context.become(waiting(Some(Status.Completed(completedCount))), true)
+//       }
+//       sender ! Submitted
+//     case GetJobStatus => sender ! lastStatus
+//   }
 
-}
+//   def receive = waiting(None)
 
-object KinesisAtomActor {
-  case class StartJob(atoms: Iterator[Atom])
-  case object OK
-}
+//   //   // def busy: Receive = {
+//   //   //   case msg => println(msg)
+//   //   // }
+
+//   // }
+
+// }
+
+// object KinesisAtomActor {
+
+//   case class StartJob(atoms: Iterator[Atom])
+//   case object GetJobStatus
+
+//   case object Submitted
+
+//   sealed trait Status
+//   object Status {
+//     case class Completed(completedCount: Int) extends Status
+//     case class Error(msg: String, completedCount: Int) extends Status
+//   }
+
+// }
 
 class KinesisAtomReindexer(
-  streamName: String, kinesis: AmazonKinesisClient,
-  system: ActorSystem
-)(implicit ec: ExecutionContext) extends AtomReindexer {
+  streamName: String,
+  kinesis: AmazonKinesisClient)
+    extends AtomReindexer
+    with ThriftSerializer[ContentAtomEvent] {
 
-  implicit val timeout = Timeout(5.seconds)
-  val actor = system.actorOf(Props(classOf[KinesisAtomActor], streamName, kinesis))
+  def makeParititionKey(event: ContentAtomEvent): String = event.atom.atomType.name
 
-  def startReindexJob(atomsToReindex: Iterator[Atom]) = (actor ? StartJob(atomsToReindex)) map (_ => ())
+  def startReindexJob(atomEventsToReindex: Iterator[ContentAtomEvent], expectedSize: Int)(implicit ec: ExecutionContext) =
+    new AtomReindexJob(atomEventsToReindex, expectedSize) {
+      def execute = Future {
+        atomEventsToReindex foreach { atomEvent =>
+          kinesis.putRecord(streamName, serializeEvent(atomEvent), makeParititionKey(atomEvent))
+          _completedCount += 1
+          Thread.sleep(1000)
+        }
+        _isComplete = true
+        _completedCount
+      }
+    }
+
   def reindexStatus = ???
 
 }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
@@ -17,8 +17,7 @@ class KinesisAtomReindexer(
       def execute(implicit ec: ExecutionContext) = Future {
         atomEventsToReindex foreach { atomEvent =>
           println(s"PMR putting record (${completedCount})")
-          //kinesis.putRecord(streamName, serializeEvent(atomEvent), makeParititionKey(atomEvent))
-          Thread.sleep(1000)
+          kinesis.putRecord(streamName, serializeEvent(atomEvent), makeParititionKey(atomEvent))
           _completedCount += 1
         }
         println(s"PMR complete (${completedCount})")

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
@@ -1,64 +1,8 @@
 package com.gu.atom.publish
 
-import akka.actor.{ Actor, Props, ActorSystem }
-import akka.util.Timeout
-import com.gu.contentatom.thrift.{ Atom, ContentAtomEvent }
 import com.amazonaws.services.kinesis.AmazonKinesisClient
-import akka.pattern.ask
+import com.gu.contentatom.thrift.ContentAtomEvent
 import scala.concurrent.{ Future, ExecutionContext }
-
-import scala.concurrent.duration._
-
-// class KinesisAtomActor(streamName: String,
-//                        kinesis: AmazonKinesisClient,
-//                        executionContext: ExecutionContext)
-//     extends Actor {
-
-//   implicit val ec = executionContext
-
-//   def processJob(atoms: Iterator[Atom]) = Future {
-//     atoms.foldLeft(0) { (count, atom) =>
-//       println(atom)
-//       count + 1
-//     }
-//   }
-
-//   val inProgress: Receive = { case _ => InProgress }
-
-//   def waiting(lastStatus: Option[Status]): Receive = {
-//     case StartJob(atoms) =>
-//       context.become(inProgress, true)
-//       processJob(atoms) onSuccess {
-//         case completedCount => context.become(waiting(Some(Status.Completed(completedCount))), true)
-//       }
-//       sender ! Submitted
-//     case GetJobStatus => sender ! lastStatus
-//   }
-
-//   def receive = waiting(None)
-
-//   //   // def busy: Receive = {
-//   //   //   case msg => println(msg)
-//   //   // }
-
-//   // }
-
-// }
-
-// object KinesisAtomActor {
-
-//   case class StartJob(atoms: Iterator[Atom])
-//   case object GetJobStatus
-
-//   case object Submitted
-
-//   sealed trait Status
-//   object Status {
-//     case class Completed(completedCount: Int) extends Status
-//     case class Error(msg: String, completedCount: Int) extends Status
-//   }
-
-// }
 
 class KinesisAtomReindexer(
   streamName: String,
@@ -74,14 +18,10 @@ class KinesisAtomReindexer(
         atomEventsToReindex foreach { atomEvent =>
           kinesis.putRecord(streamName, serializeEvent(atomEvent), makeParititionKey(atomEvent))
           _completedCount += 1
-          Thread.sleep(1000)
         }
         _isComplete = true
         _completedCount
       }
     }
-
-  def reindexStatus = ???
-
 }
  

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
@@ -1,0 +1,46 @@
+package com.gu.atom.publish
+
+import akka.actor.{ Actor, Props, ActorSystem }
+import akka.util.Timeout
+import com.gu.contentatom.thrift.Atom
+import com.amazonaws.services.kinesis.AmazonKinesisClient
+import akka.pattern.ask
+import scala.concurrent.ExecutionContext
+
+import scala.concurrent.duration._
+
+import KinesisAtomActor._
+
+class KinesisAtomActor(streamName: String, kinesis: AmazonKinesisClient)
+    extends Actor {
+
+  def receive = {
+    case StartJob(atoms) => sender ! OK
+  }
+
+  //   // def busy: Receive = {
+  //   //   case msg => println(msg)
+  //   // }
+
+  // }
+
+}
+
+object KinesisAtomActor {
+  case class StartJob(atoms: Iterator[Atom])
+  case object OK
+}
+
+class KinesisAtomReindexer(
+  streamName: String, kinesis: AmazonKinesisClient,
+  system: ActorSystem
+)(implicit ec: ExecutionContext) extends AtomReindexer {
+
+  implicit val timeout = Timeout(5.seconds)
+  val actor = system.actorOf(Props(classOf[KinesisAtomActor], streamName, kinesis))
+
+  def startReindexJob(atomsToReindex: Iterator[Atom]) = (actor ? StartJob(atomsToReindex)) map (_ => ())
+  def reindexStatus = ???
+
+}
+ 

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
@@ -11,11 +11,9 @@ import org.scalatest.{ FunSpecLike, Matchers }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.Matchers.{ eq => meq, _ }
 
 // import akka.testkit.TestKit
-
-// //import com.gu.atom.publish.KinesisAtomActor._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -37,7 +35,7 @@ class KinesisAtomReindexerSpec
         completedCount should equal(expectedCount)
         job.completedCount should equal(expectedCount)
         job.isComplete should equal(true)
-        verify(kinesis, times(expectedCount)).putRecord(any())
+        verify(kinesis, times(expectedCount)).putRecord(meq("testStream"), any(), meq("Media"))
       }
     }
   }

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
@@ -1,0 +1,43 @@
+package com.gu.atom.publish.test
+
+import akka.actor.{ ActorRef, ActorSystem, Props }
+import akka.testkit.ImplicitSender
+import com.gu.atom.publish._
+
+import com.amazonaws.services.kinesis.AmazonKinesisClient
+import org.scalatest.{ BeforeAndAfterAll, fixture, Matchers }
+import org.scalatest.mock.MockitoSugar
+
+import akka.testkit.TestKit
+
+import com.gu.atom.publish.KinesisAtomActor._
+
+class KinesisAtomReindexerSpec
+    extends TestKit(ActorSystem("KinesisAtomReindexerSpec"))
+    with ImplicitSender
+    with fixture.FunSpecLike
+    with Matchers
+    with MockitoSugar
+    with BeforeAndAfterAll {
+
+  val kinesis = mock[AmazonKinesisClient]
+
+  type FixtureParam = ActorRef
+
+  def withFixture(test: OneArgTest) = {
+    val actorRef = system.actorOf(Props(classOf[KinesisAtomActor], "test", kinesis))
+    super.withFixture(test.toNoArgTest(actorRef))
+  }
+
+  override def afterAll = {
+    shutdown(system)
+  }
+
+  describe("Kinesis Atom Reindexer") {
+    it("should call putRecords() for each atom") { actor =>
+      actor ! StartJob(Iterator.empty)
+      expectMsg(OK)
+    }
+  }
+
+}

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
@@ -1,43 +1,62 @@
 package com.gu.atom.publish.test
 
-import akka.actor.{ ActorRef, ActorSystem, Props }
-import akka.testkit.ImplicitSender
-import com.gu.atom.publish._
+import com.gu.atom.publish.KinesisAtomReindexer
+
+// import akka.actor.{ ActorRef, ActorSystem, Props }
+// import akka.testkit.ImplicitSender
+// import com.gu.atom.publish._
 
 import com.amazonaws.services.kinesis.AmazonKinesisClient
-import org.scalatest.{ BeforeAndAfterAll, fixture, Matchers }
+import org.scalatest.{ FunSpecLike, Matchers }
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mock.MockitoSugar
+import org.mockito.Mockito._
+import org.mockito.Matchers._
 
-import akka.testkit.TestKit
+// import akka.testkit.TestKit
 
-import com.gu.atom.publish.KinesisAtomActor._
+// //import com.gu.atom.publish.KinesisAtomActor._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
 
 class KinesisAtomReindexerSpec
-    extends TestKit(ActorSystem("KinesisAtomReindexerSpec"))
-    with ImplicitSender
-    with fixture.FunSpecLike
+    extends FunSpecLike
     with Matchers
-    with MockitoSugar
-    with BeforeAndAfterAll {
+    with ScalaFutures
+    with MockitoSugar {
 
-  val kinesis = mock[AmazonKinesisClient]
+  //     extends TestKit(ActorSystem("KinesisAtomReindexerSpec"))
+  //     with ImplicitSender
+  
 
-  type FixtureParam = ActorRef
 
-  def withFixture(test: OneArgTest) = {
-    val actorRef = system.actorOf(Props(classOf[KinesisAtomActor], "test", kinesis))
-    super.withFixture(test.toNoArgTest(actorRef))
-  }
+  //   val ec = scala.concurrent.ExecutionContext.Implicits.global
 
-  override def afterAll = {
-    shutdown(system)
-  }
+  //   type FixtureParam = ActorRef
+
+  //   def withFixture(test: OneArgTest) = {
+  //     val actorRef = system.actorOf(Props(classOf[KinesisAtomActor], "test", kinesis, ec))
+  //     super.withFixture(test.toNoArgTest(actorRef))
+  //   }
+
+  //   override def afterAll = {
+  //     shutdown(system)
+  //   }
 
   describe("Kinesis Atom Reindexer") {
-    it("should call putRecords() for each atom") { actor =>
-      actor ! StartJob(Iterator.empty)
-      expectMsg(OK)
+    it("should call putRecords() for each atom") {
+      val kinesis = mock[AmazonKinesisClient]
+      val reindexer = new KinesisAtomReindexer("testStream", kinesis)
+      val expectedCount = TestData.testAtoms.size
+      val job = reindexer.startReindexJob(TestData.testAtomEvents.iterator, expectedCount)
+      job.expectedSize should equal(expectedCount)
+      whenReady(job.execute, timeout(13.seconds)) { completedCount =>
+        completedCount should equal(expectedCount)
+        job.completedCount should equal(expectedCount)
+        job.isComplete should equal(true)
+        verify(kinesis, times(expectedCount)).putRecord(any())
+      }
     }
   }
-
 }

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
@@ -26,24 +26,6 @@ class KinesisAtomReindexerSpec
     with ScalaFutures
     with MockitoSugar {
 
-  //     extends TestKit(ActorSystem("KinesisAtomReindexerSpec"))
-  //     with ImplicitSender
-  
-
-
-  //   val ec = scala.concurrent.ExecutionContext.Implicits.global
-
-  //   type FixtureParam = ActorRef
-
-  //   def withFixture(test: OneArgTest) = {
-  //     val actorRef = system.actorOf(Props(classOf[KinesisAtomActor], "test", kinesis, ec))
-  //     super.withFixture(test.toNoArgTest(actorRef))
-  //   }
-
-  //   override def afterAll = {
-  //     shutdown(system)
-  //   }
-
   describe("Kinesis Atom Reindexer") {
     it("should call putRecords() for each atom") {
       val kinesis = mock[AmazonKinesisClient]

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/TestData.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/TestData.scala
@@ -6,31 +6,60 @@ import com.gu.contentatom.thrift.atom.media._
 import com.gu.contentatom.thrift.{ContentAtomEvent, _}
 
 object TestData {
-  val testAtom = Atom(
-    id = "1",
-    atomType = AtomType.Media,
-    defaultHtml = "<div></div>",
-    data = AtomData.Media(
-      MediaAtom(
-        activeVersion = 2L,
-        assets = List(
-          Asset(
-            assetType = AssetType.Video,
-            version = 1L,
-            id = "xyzzy",
-            platform = Platform.Youtube
-          ),
-          Asset(
-            assetType = AssetType.Video,
-            version = 2L,
-            id = "fizzbuzz",
-            platform = Platform.Youtube
+  val testAtoms = Seq(
+    Atom(
+      id = "1",
+      atomType = AtomType.Media,
+      defaultHtml = "<div></div>",
+      data = AtomData.Media(
+        MediaAtom(
+          activeVersion = 2L,
+          assets = List(
+            Asset(
+              assetType = AssetType.Video,
+              version = 1L,
+              id = "xyzzy",
+              platform = Platform.Youtube
+            ),
+            Asset(
+              assetType = AssetType.Video,
+              version = 2L,
+              id = "fizzbuzz",
+              platform = Platform.Youtube
+            )
           )
         )
-      )
+      ),
+      contentChangeDetails = ContentChangeDetails(revision = 1)
     ),
-    contentChangeDetails = ContentChangeDetails(revision = 1)
+    Atom(
+      id = "2",
+      atomType = AtomType.Media,
+      defaultHtml = "<div></div>",
+      data = AtomData.Media(
+        MediaAtom(
+          activeVersion = 1L,
+          assets = List(
+            Asset(
+              assetType = AssetType.Video,
+              version = 1L,
+              id = "jdklsajflka",
+              platform = Platform.Youtube
+            ),
+            Asset(
+              assetType = AssetType.Video,
+              version = 2L,
+              id = "afkdljlwe",
+              platform = Platform.Youtube
+            )
+          )
+        )
+      ),
+      contentChangeDetails = ContentChangeDetails(revision = 1)
+    )
   )
+
+  val testAtom = testAtoms.head
 
   def testAtomEvent(atom: Atom = testAtom) =
     ContentAtomEvent(testAtom, EventType.Update, (new Date()).getTime())

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/TestData.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/TestData.scala
@@ -59,6 +59,8 @@ object TestData {
     )
   )
 
+  def testAtomEvents = testAtoms.map(testAtomEvent _)
+
   val testAtom = testAtoms.head
 
   def testAtomEvent(atom: Atom = testAtom) =

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ dependencies:
 
 test:
   override:
-    - sbt test
+    - sbt test 'project atomPublisher' test
 
 deployment:
   riffraff_upload:

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ dependencies:
 
 test:
   override:
-    - sbt test 'project atomPublisher' test
+    - sbt test
 
 deployment:
   riffraff_upload:

--- a/conf/reference.conf
+++ b/conf/reference.conf
@@ -16,4 +16,10 @@ aws {
    }
 }
 
+# this will need to be set for reindex to work, and the requester will
+# be required to submit this as a query string parameter to access the
+# reindex API endpoints
+
+# reindexApiKey = "foo"
+
 host = "media-atom-maker.gutools.co.uk"

--- a/conf/reference.conf
+++ b/conf/reference.conf
@@ -9,7 +9,7 @@ aws {
    kinesis {
         liveStreamName = "won't you fill me in"
         previewStreamName = "won't you fill me in"
-        reindexStreamName = "???"
+        reindexStreamName = "???"   # in mostcase this should be the same as liveStreamName
    }
 
    dynamo {

--- a/conf/reference.conf
+++ b/conf/reference.conf
@@ -7,7 +7,8 @@ aws {
    profile = "composer"
    
    kinesis {
-        streamName = "won't you fill me in"
+        streamName = "???"
+        reindexStreamName = "???"
    }
 
    dynamo {

--- a/conf/routes
+++ b/conf/routes
@@ -11,5 +11,10 @@ POST    /api/atom/:id/revert/:version   controllers.Api.revertAtom(id, version: 
 
 POST    /api/atom/:id/publish           controllers.Api.publishAtom(id)
 
+# reindex
+
+POST    /reindex                        controllers.ReindexController.newReindexJob()
+GET     /reindex                        controllers.ReindexController.reindexJobStatus()
+
 #static assets
 GET  /assets/*file                      controllers.Assets.at(path="/public", file)


### PR DESCRIPTION
This is an initial implementation of the required reindex endpoint, which will allow [CAPI Floodgate](https://floodgate.capi.gutools.co.uk/) to trigger the atom maker to resend all of it's atoms onto a separate re-indexing stream.

This is part of the the contract that CAPI defines for incoming content sources, and which is described [here](https://github.com/guardian/floodgate/blob/master/docs/implementing-a-content-source.md).

This PR is a minimal implementation, it does not include the optional items (cancelling a request and limiting the query by start and end date). However, what's included here should be sufficient for an MVP.

I have included support for the API authentication option (as described in the doc).

The implementation of the reindexing is quite simple, as it just pushes a list of atoms to kinesis. Most of the work (including reporting status of an ongoing job, and reporting an error if a new job is requested while one is already in progress) is done in the API endpoints which are still part of the main application (not yet separated out into a separate library). Creating a separate `atom-manager-play` library is still a very good idea I think to allow reuse of these standard endpoints.