### PR TITLE
Add organization field to build.sbt.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ scalaVersion := "2.11.8"
 
 name := "media-atom-maker"
 
+organization in ThisBuild := "com.gu"
+
 version := "1.0.0-SNAPSHOT"
 
 lazy val contentAtomVersion = "1.0.1"


### PR DESCRIPTION
This changes the directory that the library is published to and should make it easier to find in maven.