### PR TITLE
Update media atom model

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -70,7 +70,7 @@ class Api @Inject() (val dataStore: DataStore,
         val assets = ma.assets
         val newAtom = atom
           .withData(ma.copy(
-                      activeVersion = newAsset.version,
+                      activeVersion = Some(newAsset.version),
                       assets = newAsset +: assets
                     ))
           .withRevision(_ + 1)
@@ -115,7 +115,7 @@ class Api @Inject() (val dataStore: DataStore,
           dataStore.updateMediaAtom(
             atom
               .withRevision(_ + 1)
-              .updateData { media => media.copy(activeVersion = version) }
+              .updateData { media => media.copy(activeVersion = Some(version)) }
           )
           Ok(s"updated to $version")
         }

--- a/app/data/JsonConversions.scala
+++ b/app/data/JsonConversions.scala
@@ -2,27 +2,43 @@ package data
 
 import com.gu.contentatom.thrift._
 import com.gu.contentatom.thrift.atom.media._
-import play.api.libs.json._
 import play.api.libs.functional.syntax._
+import play.api.libs.json._
 
 object JsonConversions {
 
   implicit val atomType = Writes[AtomType](at => JsString(at.name.toLowerCase))
 
+  implicit val category = Writes[Category](category => JsString(category.name.toLowerCase))
+
   implicit val mediaAsset = (
     (__ \ "id").write[String] and
-      (__ \ "version").write[Long] and
-      (__ \ "platform").write[String] and
-      (__ \ "assetType").write[String]
+    (__ \ "version").write[Long] and
+    (__ \ "platform").write[String] and
+    (__ \ "assetType").write[String] and
+    (__ \ "mimeType").writeNullable[String]
   ) { asset: Asset =>
-    asset match { case Asset(assetType, version, id, platform) => (id, version, platform.name, assetType.name) }
+    asset match {
+      case Asset(assetType, version, id, platform, mimeType) => (id, version, platform.name, assetType.name, mimeType)
+    }
   }
 
   implicit val atomDataMedia = (
     (__ \ "assets").write[Seq[Asset]] and
-      (__ \ "activeVersion").write[Long]
-  ) { mediaAtom: MediaAtom =>
-    (mediaAtom.assets, mediaAtom.activeVersion)
+    (__ \ "activeVersion").writeNullable[Long] and
+    (__ \ "title").write[String] and
+    (__ \ "category").write[Category] and
+    (__ \ "plutoProjectId").writeNullable[String] and
+    (__ \ "duration").writeNullable[Long]
+    ) { mediaAtom: MediaAtom =>
+    (
+      mediaAtom.assets,
+      mediaAtom.activeVersion,
+      mediaAtom.title,
+      mediaAtom.category,
+      mediaAtom.plutoProjectId,
+      mediaAtom.duration
+      )
   }
 
   implicit val atomData = Writes[AtomData] {
@@ -30,7 +46,34 @@ object JsonConversions {
     case _ => JsString("unknown")
   }
 
-  implicit val atomWrites = (
+  implicit val userWrites = (
+    (__ \ "email").write[String] and
+    (__ \ "firstName").writeNullable[String] and
+    (__ \ "lastName").writeNullable[String]
+    ) { user: User => (user.email, user.firstName, user.lastName) }
+
+  implicit val changeRecordWrites = (
+    (__ \ "date").write[Long] and
+    (__ \ "user").writeNullable[User]
+    ) { changeRecord: ChangeRecord => (changeRecord.date, changeRecord.user) }
+
+  implicit val contentChangeDetailsWrites = (
+    (__ \ "lastModified").writeNullable[ChangeRecord] and
+    (__ \ "created").writeNullable[ChangeRecord] and
+    (__ \ "published").writeNullable[ChangeRecord] and
+    (__ \ "revision").write[Long]
+    ) { contentChangeDetails: ContentChangeDetails =>
+    (
+      contentChangeDetails.lastModified,
+      contentChangeDetails.created,
+      contentChangeDetails.published,
+      contentChangeDetails.revision
+      )
+  }
+
+  implicit val flagsWrites = Writes[Flags] { flags: Flags => Json.toJson(flags.suppressFurniture) }
+
+  implicit val atomWrites: Writes[Atom] = (
     (__ \ "id").write[String] and
       (__ \ "type").write[AtomType] and
       (__ \ "labels").write[Seq[String]] and
@@ -39,11 +82,4 @@ object JsonConversions {
   ) { atom: Atom =>
     (atom.id, atom.atomType, atom.labels, atom.defaultHtml, atom.data)
   }
-  // implicit val atomWrites = (
-  //   (__ \ "id").write[String] and
-  //     (__ \ "atomType").write[String] and
-  //     (__ \ "labels").write[Seq[String]] and
-  // )
-
-  
 }

--- a/app/util/atom/AtomUtils.scala
+++ b/app/util/atom/AtomUtils.scala
@@ -1,7 +1,7 @@
 package util.atom
 
 import com.gu.contentatom.thrift._
-import atom.media._
+import com.gu.contentatom.thrift.atom.media._
 
 trait AtomDataTyper[D] {
   def getData(a: Atom): D
@@ -34,9 +34,9 @@ trait MediaAtomImplicits extends AtomImplicits[MediaAtom] {
     def makeDefaultHtml(a: Atom) = {
       val data = getData(a)
       data.assets
-        .find(_.version == data.activeVersion)
-        .map(asset => views.html.MediaAtom.embedAsset(asset).toString)
-        .getOrElse(s"<div></div>")
+      .find(asset => data.activeVersion.contains(asset.version))
+      .map(asset => views.html.MediaAtom.embedAsset(asset).toString)
+      .getOrElse("<div></div>")
     }
   }
 }

--- a/app/views/MediaAtom/atomTable.scala.html
+++ b/app/views/MediaAtom/atomTable.scala.html
@@ -1,4 +1,4 @@
-@import com.gu.contentatom.thrift._
+@import com.gu.contentatom.thrift.Atom
 @import util.atom.MediaAtomImplicits._
 @(atom: Atom)
         <h1>Atom Data</h1>
@@ -15,7 +15,7 @@
                 <td class="label">platform</td>
                 <td class="label">version</td>
             </tr>
-            @for(asset <- atom.tdata.assets; activeclass = if(asset.version == atom.tdata.activeVersion) "-active" else "") {
+            @for(asset <- atom.tdata.assets; activeclass = if(atom.tdata.activeVersion.contains(asset.version)) "-active" else "") {
                           <tr class="assetRow@activeclass" onClick="AtomUtil.revertAtom('@atom.id', '@asset.version')">
                               <td>@asset.assetType</td>
                               <td>@asset.id</td>

--- a/app/views/MediaAtom/displayAtom.scala.html
+++ b/app/views/MediaAtom/displayAtom.scala.html
@@ -1,5 +1,6 @@
-@import com.gu.contentatom.thrift._
+@import com.gu.contentatom.thrift.Atom
 @import util.atom.MediaAtomImplicits._
+@import views.html.MediaAtom.{addAssetForm, atomTable, publishUI, showDefaultHtml}
 @(atom: Atom)
 <html>
     <head>
@@ -17,7 +18,7 @@
         </p>
         @atomTable(atom)
         @publishUI(atom.id)
-        @addAssetForm(atom.id, atom.tdata.activeVersion + (if(atom.tdata.assets.length == 0) 0 else 1))
+        @addAssetForm(atom.id, atom.tdata.activeVersion.map(_ + (if(atom.tdata.assets.length == 0) 0 else 1)) getOrElse 1)
         @showDefaultHtml(atom)
     </body>
 </html>

--- a/atom-manager-play-lib/src/main/scala/com.gu.atom/data/DataStore.scala
+++ b/atom-manager-play-lib/src/main/scala/com.gu.atom/data/DataStore.scala
@@ -12,7 +12,7 @@ case object IDNotFound extends DataStoreError("Atom ID not in datastore")
 case object ReadError extends DataStoreError("Read error")
 
 case class  DataError(info: String) extends DataStoreError(info)
-case class  VersionConflictError(requestVer: Long)
+case class  VersionConflictError(requestVer: Option[Long])
     extends DataStoreError(s"Update has version $requestVer, which is earlier or equal to data store version")
 
 trait DataStore extends DataStoreResult {

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization in ThisBuild := "com.gu"
 
 version := "1.0.0-SNAPSHOT"
 
-lazy val contentAtomVersion = "1.0.1"
+lazy val contentAtomVersion = "2.2.0"
 lazy val scroogeVersion     = "4.2.0"
 lazy val AwsSdkVersion      = "1.10.74"
 lazy val pandaVer           = "0.3.0"

--- a/test/ApiSpec.scala
+++ b/test/ApiSpec.scala
@@ -1,29 +1,24 @@
 package test
 
-import controllers.Api
-
 import cats.data.Xor
-import com.gu.atom.publish.{PreviewAtomPublisher, LiveAtomPublisher}
-import com.gu.contentatom.thrift.ContentAtomEvent
-import com.gu.atom.data.{ DataStore, VersionConflictError }
-import org.mockito.ArgumentCaptor
-import org.scalatest.mock.MockitoSugar
-import org.mockito.Mockito._
-import org.mockito.Matchers._
-
-import util.atom.MediaAtomImplicits
-
-import play.api.libs.json._
-import play.api.http.HttpVerbs
-import play.api.test.Helpers._
-import data.MemoryStore
-
+import com.gu.atom.data.{DataStore, VersionConflictError}
 import com.gu.atom.play.test.AtomSuite
-
+import com.gu.atom.publish.{LiveAtomPublisher, PreviewAtomPublisher}
+import com.gu.contentatom.thrift.ContentAtomEvent
+import controllers.Api
+import data.MemoryStore
+import org.mockito.ArgumentCaptor
+import org.mockito.Matchers._
+import org.mockito.Mockito._
 import org.scalatest.AppendedClues
-import scala.util.{ Success, Failure }
+import org.scalatest.mock.MockitoSugar
+import play.api.http.HttpVerbs
+import util.atom.MediaAtomImplicits
+import play.api.libs.json._
+import play.api.test.Helpers._
+import test.TestData._
 
-import TestData._
+import scala.util.{Failure, Success}
 
 class ApiSpec
     extends AtomSuite
@@ -86,7 +81,7 @@ class ApiSpec
     AtomTestConf(dataStore = mock[DataStore]) { implicit conf =>
       val mockDataStore = conf.dataStore
       when(mockDataStore.getMediaAtom(any())).thenReturn(Some(testAtom))
-      when(mockDataStore.updateMediaAtom(any())).thenReturn(Xor.Left(VersionConflictError(1)))
+      when(mockDataStore.updateMediaAtom(any())).thenReturn(Xor.Left(VersionConflictError(Some(1))))
       val req = requestWithCookies
         .withFormUrlEncodedBody("uri" -> youtubeUrl, "version" -> "1")
       val result = call(api.addAsset("1"), req)
@@ -142,21 +137,21 @@ class ApiSpec
       status(result) mustEqual INTERNAL_SERVER_ERROR
     }
 
-    "should list atoms" in AtomTestConf() { implicit conf =>
+    "list atoms" in AtomTestConf() { implicit conf =>
       conf.dataStore.createMediaAtom(testAtom.copy(id = "2"))
       val result = call(api.listAtoms(), requestWithCookies)
       status(result) mustEqual OK
       contentAsJson(result).as[List[JsValue]] must have size 2
     }
-    "should change version of atom" in AtomTestConf() { implicit conf =>
+    "change version of atom" in AtomTestConf() { implicit conf =>
       // before...
-      conf.dataStore.getMediaAtom("1").value.tdata.activeVersion mustEqual 2L
+      conf.dataStore.getMediaAtom("1").value.tdata.activeVersion mustEqual Some(2L)
       val result = call(api.revertAtom("1", 1L), requestWithCookies)
       status(result) mustEqual OK
       // after ...
-      conf.dataStore.getMediaAtom("1").value.tdata.activeVersion mustEqual 1L
+      conf.dataStore.getMediaAtom("1").value.tdata.activeVersion mustEqual Some(1L)
     }
-    "should complain if revert to version without asset" in
+    "complain if revert to version without asset" in
     AtomTestConf() { implicit conf =>
       // before...
       val result = call(api.revertAtom("1", 10L), requestWithCookies)

--- a/test/TestData.scala
+++ b/test/TestData.scala
@@ -1,8 +1,9 @@
 package test
 
-import com.gu.contentatom.thrift.{ ContentAtomEvent, _ }
-import com.gu.contentatom.thrift.atom.media._
 import java.util.Date
+
+import com.gu.contentatom.thrift.atom.media._
+import com.gu.contentatom.thrift.{ContentAtomEvent, _}
 
 object TestData {
   val testAtom = Atom(
@@ -11,7 +12,7 @@ object TestData {
     defaultHtml = "<div></div>",
     data = AtomData.Media(
       MediaAtom(
-        activeVersion = 2L,
+        activeVersion = Some(2L),
         assets = List(
           Asset(
             assetType = AssetType.Video,
@@ -25,7 +26,12 @@ object TestData {
             id = "fizzbuzz",
             platform = Platform.Youtube
           )
-        )
+        ),
+        title = "title",
+        category = Category.News,
+        plutoProjectId = None,
+        duration = None,
+        source = None
       )
     ),
     contentChangeDetails = ContentChangeDetails(revision = 1)

--- a/test/ThriftUtilSpec.scala
+++ b/test/ThriftUtilSpec.scala
@@ -1,9 +1,10 @@
 package model
 
 import com.gu.contentatom.thrift._
-import atom.media._
-import org.scalatest.{ FunSpec, Matchers, Inside }
-import scala.xml.{ Text, XML }
+import com.gu.contentatom.thrift.atom.media._
+import org.scalatest.{FunSpec, Inside, Matchers}
+
+import scala.xml.XML
 
 class ThriftUtilSpec extends FunSpec
     with Matchers
@@ -30,19 +31,19 @@ class ThriftUtilSpec extends FunSpec
 
     it("should correctly generate media atom data") {
       inside(parseMediaAtom(makeParams("uri" -> youtubeUrl))) {
-        case Right(MediaAtom(assets, 1L, None)) =>
+        case Right(MediaAtom(assets, Some(1L), "unknown", Category.News, None, None, None)) =>
           assets should have length 1
           assets.head should equal(Asset(AssetType.Video, 1L, youtubeId, Platform.Youtube))
       }
     }
 
     it("should create empty assets without uri") {
-      parseMediaAtom(Map.empty) should matchPattern { case Right(MediaAtom(Nil, _, _)) => }
+      parseMediaAtom(Map.empty) should matchPattern { case Right(MediaAtom(Nil, _, _, _, _, _, _)) => }
     }
 
     it("should create multiple assets with multiple uri params") {
       inside(parseMediaAtom(Map("uri" -> List(youtubeUrl, youtubeUrl)))) {
-        case Right(MediaAtom(assets, _, _)) =>
+        case Right(MediaAtom(assets, _, _, _, _, _, _)) =>
           assets should have length 2
       }
     }


### PR DESCRIPTION
These are just the changes necessary to support model v2.2.0.

NB. As `activeVersion` is now optional, this is going to break any atoms currently in storage.

/cc @guardian/labs-beta 
