### PR TITLE
Fix revision check of update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ application.conf
 logs
 .idea/
 target/
+.dynamodb-local

--- a/app/util/atom/MediaAtomUtils.scala
+++ b/app/util/atom/MediaAtomUtils.scala
@@ -1,31 +1,9 @@
 package util.atom
 
+import com.gu.atom.util._
 import com.gu.contentatom.thrift._
 import com.gu.contentatom.thrift.atom.media.Platform.{Url, Youtube}
 import com.gu.contentatom.thrift.atom.media._
-
-trait AtomDataTyper[D] {
-  def getData(a: Atom): D
-  def setData(a: Atom, newData: D): Atom
-  def makeDefaultHtml(a: Atom): String
-}
-
-trait AtomImplicits[D] {
-  val dataTyper: AtomDataTyper[D]
-  implicit class AtomWithData(atom: Atom) {
-    def tdata = dataTyper.getData(atom)
-    def withData(data: D): Atom =
-      dataTyper.setData(atom, data).updateDefaultHtml
-    def updateData(f: D => D): Atom = withData(f(atom.tdata))
-    def withRevision(f: Long => Long): Atom = atom.copy(
-      contentChangeDetails = atom.contentChangeDetails.copy(
-        revision = f(atom.contentChangeDetails.revision)
-      )
-    )
-    def withRevision(newRevision: Long): Atom = withRevision(_ => newRevision)
-    def updateDefaultHtml = atom.copy(defaultHtml = dataTyper.makeDefaultHtml(atom))
-  }
-}
 
 trait MediaAtomImplicits extends AtomImplicits[MediaAtom] {
   val dataTyper = new AtomDataTyper[MediaAtom] {

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
@@ -1,7 +1,7 @@
 package com.gu.atom.play.test
 
 import cats.data.Xor
-import com.gu.atom.publish.test.TestData
+import com.gu.atom.TestData
 
 import scala.collection.mutable.{ Map => MMap }
 

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -14,6 +14,12 @@ scalaVersion := "2.11.8"
 scmInfo := Some(ScmInfo(url("https://github.com/guardian/media-atom-maker"),
   "scm:git:git@github.com:guardian/media-atom-maker.git"))
 
+// for testing dynamodb access
+dynamoDBLocalDownloadDir := file(".dynamodb-local")
+startDynamoDBLocal <<= startDynamoDBLocal.dependsOn(compile in Test)
+test in Test <<= (test in Test).dependsOn(startDynamoDBLocal)
+testOptions in Test <+= dynamoDBLocalTestCleanup
+
 pomExtra := (
   <url>https://github.com/guardian/media-atom-maker</url>
     <developers>

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
@@ -1,8 +1,6 @@
 package com.gu.atom.data
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
-
-import com.amazonaws.services.dynamodbv2.model.PutItemResult
+import com.amazonaws.services.dynamodbv2.model.{ AttributeValue, PutItemResult }
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
 import com.gu.contentatom.thrift.{ Atom, AtomData, Flags }
 import com.gu.scanamo.{ Scanamo, DynamoFormat, Table }
@@ -47,7 +45,9 @@ abstract class DynamoDataStore[D : ClassTag : DynamoFormat]
       succeed(put(atom))
 
   def updateAtom(newAtom: Atom) = {
-    val validationCheck = KeyIs('version, LT, newAtom.contentChangeDetails.revision)
+    val validationCheck = NestedKeyIs(
+      List('contentChangeDetails, 'revision), LT, newAtom.contentChangeDetails.revision
+    )
     val res = (Scanamo.exec(dynamo)(Table[Atom](tableName).given(validationCheck).put(newAtom)))
     res.map(_ => ())
       .leftMap(_ => VersionConflictError(newAtom.contentChangeDetails.revision))

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/util/AtomUtils.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/util/AtomUtils.scala
@@ -1,0 +1,41 @@
+package com.gu.atom.util
+
+import com.gu.contentatom.thrift._
+
+trait AtomDataTyper[D] {
+  def getData(a: Atom): D
+  def setData(a: Atom, newData: D): Atom
+  def makeDefaultHtml(a: Atom): String
+}
+
+object AtomDataTyper {
+  val general = new AtomDataTyper[AtomData] {
+    def getData(a: Atom) = a.data
+    def setData(a: Atom, newData: AtomData) =
+      a.copy(data = newData)
+    def makeDefaultHtml(a: Atom) = a.defaultHtml
+  }
+}
+
+trait AtomImplicits[D] {
+  val dataTyper: AtomDataTyper[D]
+  implicit class AtomWithData(atom: Atom) {
+    def tdata = dataTyper.getData(atom)
+    def withData(data: D): Atom =
+      dataTyper.setData(atom, data).updateDefaultHtml
+    def updateData(f: D => D): Atom = withData(f(atom.tdata))
+    def withRevision(f: Long => Long): Atom = atom.copy(
+      contentChangeDetails = atom.contentChangeDetails.copy(
+        revision = f(atom.contentChangeDetails.revision)
+      )
+    )
+    def withRevision(newRevision: Long): Atom = withRevision(_ => newRevision)
+    def bumpRevision = withRevision(_ + 1)
+    def updateDefaultHtml = atom.copy(defaultHtml = dataTyper.makeDefaultHtml(atom))
+  }
+}
+
+// default implementation that doesn't really do anything with the atom data
+trait AtomImplicitsGeneral extends AtomImplicits[AtomData] {
+  val dataTyper = AtomDataTyper.general
+}

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/TestData.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/TestData.scala
@@ -1,4 +1,4 @@
-package com.gu.atom.publish.test
+package com.gu.atom
 
 import java.util.Date
 

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
@@ -1,0 +1,51 @@
+package com.gu.atom.data
+
+import com.gu.contentatom.thrift.Atom
+import com.gu.contentatom.thrift.atom.media.MediaAtom
+import org.scalatest.{ fixture, Matchers, BeforeAndAfterAll, OptionValues }
+
+import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import com.amazonaws.services.dynamodbv2.model._
+import com.gu.scanamo.DynamoFormat._
+import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
+import ScanamoUtil._
+
+import cats.data.Xor
+
+import com.gu.atom.TestData._
+
+class DynamoDataStoreSpec
+    extends fixture.FunSpec
+    with Matchers
+    with OptionValues
+    with BeforeAndAfterAll {
+  val tableName = "atom-test-table"
+
+  type FixtureParam = DynamoDataStore[MediaAtom]
+
+  def withFixture(test: OneArgTest) = {
+    val db = new DynamoDataStore[MediaAtom](LocalDynamoDB.client, tableName) with MediaAtomDynamoFormats
+    super.withFixture(test.toNoArgTest(db))
+  }
+
+  describe("DynamoDataStore") {
+    it("should create a new atom") { dataStore =>
+      dataStore.createAtom(testAtom) should equal(Xor.Right())
+    }
+
+    it("should return the atom") { dataStore =>
+      dataStore.getAtom(testAtom.id).value should equal(testAtom)
+    }
+
+    it("should update the atom") { dataStore =>
+      val updated = testAtom.copy(defaultHtml = "<div>updated</div>")
+      dataStore.updateAtom(updated) should equal(Xor.Right())
+      dataStore.getAtom(testAtom.id).value should equal(updated)
+    }
+  }
+
+  override def beforeAll() = {
+    val client = LocalDynamoDB.client
+    LocalDynamoDB.createTable(client)(tableName)('id -> S)
+  }
+}

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
@@ -10,6 +10,8 @@ import com.gu.scanamo.DynamoFormat._
 import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
 import ScanamoUtil._
 
+import com.gu.atom.util.AtomImplicitsGeneral
+
 import cats.data.Xor
 
 import com.gu.atom.TestData._
@@ -18,7 +20,8 @@ class DynamoDataStoreSpec
     extends fixture.FunSpec
     with Matchers
     with OptionValues
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with AtomImplicitsGeneral {
   val tableName = "atom-test-table"
 
   type FixtureParam = DynamoDataStore[MediaAtom]
@@ -38,7 +41,10 @@ class DynamoDataStoreSpec
     }
 
     it("should update the atom") { dataStore =>
-      val updated = testAtom.copy(defaultHtml = "<div>updated</div>")
+      val updated = testAtom
+        .copy(defaultHtml = "<div>updated</div>")
+        .bumpRevision
+
       dataStore.updateAtom(updated) should equal(Xor.Right())
       dataStore.getAtom(testAtom.id).value should equal(updated)
     }

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/LocalDynamoDB.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/LocalDynamoDB.scala
@@ -1,0 +1,40 @@
+package com.gu.atom.data
+
+import scala.collection.convert.decorateAsJava._
+
+import com.amazonaws.services.dynamodbv2._
+import com.amazonaws.services.dynamodbv2.model._
+
+/*
+ * copied from:
+ *    https://github.com/guardian/scanamo/blob/master/src/test/scala/com/gu/scanamo/LocalDynamoDB.scala
+ */
+
+object LocalDynamoDB {
+  def client() = {
+    val c = new AmazonDynamoDBAsyncClient(new com.amazonaws.auth.BasicAWSCredentials("key", "secret"))
+    c.setEndpoint("http://localhost:8000")
+    c
+  }
+
+  def createTable(client: AmazonDynamoDB)(tableName: String)(attributes: (Symbol, ScalarAttributeType)*) = {
+    client.createTable(
+      attributeDefinitions(attributes),
+      tableName,
+      keySchema(attributes),
+      arbitraryThroughputThatIsIgnoredByDynamoDBLocal
+    )
+  }
+
+  private def keySchema(attributes: Seq[(Symbol, ScalarAttributeType)]) = {
+    val hashKeyWithType :: rangeKeyWithType = attributes.toList
+    val keySchemas = hashKeyWithType._1 -> KeyType.HASH :: rangeKeyWithType.map(_._1 -> KeyType.RANGE)
+    keySchemas.map{ case (symbol, keyType) => new KeySchemaElement(symbol.name, keyType)}.asJava
+  }
+
+  private def attributeDefinitions(attributes: Seq[(Symbol, ScalarAttributeType)]) = {
+    attributes.map{ case (symbol, attributeType) => new AttributeDefinition(symbol.name, attributeType)}.asJava
+  }
+
+  private val arbitraryThroughputThatIsIgnoredByDynamoDBLocal = new ProvisionedThroughput(1L, 1L)
+}

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomPublisherSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomPublisherSpec.scala
@@ -8,7 +8,7 @@ import com.amazonaws.services.kinesis.AmazonKinesisClient
 import org.mockito.Matchers.{eq => argEq, _}
 import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.mock.MockitoSugar
-import TestData._
+import com.gu.atom.TestData._
 import org.mockito.Mockito._
 
 

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito._
 import org.mockito.Matchers.{ eq => meq, _ }
 
-// import akka.testkit.TestKit
+import com.gu.atom.TestData
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ dependencies:
     - "project/project/target/streams"
     - "project/target/resolution-cache"
     - "project/target/streams"
+    - ".dynamodb-local"
 
 test:
   override:

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object BuildVars {
-  lazy val awsVersion         = "1.11.8"
+  lazy val awsVersion         = "1.10.69"
   lazy val contentAtomVersion = "2.4.0"
   lazy val scroogeVersion     = "4.2.0"
   lazy val akkaVersion        = "2.4.8"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,7 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+
+// for creating test cases that use a local dynamodb
+
+addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.4.0")


### PR DESCRIPTION
Now that we are storing a proper nested structure for the atom in the database, the version check no longer works because the revision is nested in the `contentChangeDetails`.

In addition to fixing this, this PR creates some tests that use a local DynamoDB for testing, which actually reproduces this issue and generally exercises code that wasn't being tested until now.