### PR TITLE
Store published time in atom when it is published

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -14,6 +14,8 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import util.atom.MediaAtomImplicits
 import play.api.libs.json._
 
+import com.gu.atom.play._
+
 import scala.util.{Failure, Success}
 
 class Api @Inject() (val dataStore: DataStore,
@@ -22,7 +24,8 @@ class Api @Inject() (val dataStore: DataStore,
                      val conf: Configuration,
                      val authActions: AuthActions)
     extends AtomController
-    with MediaAtomImplicits {
+    with MediaAtomImplicits
+    with AtomAPIActions {
 
   import authActions.APIAuthAction
 
@@ -133,18 +136,6 @@ class Api @Inject() (val dataStore: DataStore,
   }
 
   def now() = (new Date()).getTime()
-
-  def publishAtom(atomId: String) = APIAuthAction { implicit req =>
-    dataStore.getAtom(atomId) match {
-      case Some(atom) =>
-        val event = ContentAtomEvent(atom, EventType.Update, now())
-        livePublisher.publishAtomEvent(event) match {
-          case Success(_)  => NoContent
-          case Failure(err) => InternalServerError(jsonError(s"could not publish: ${err.toString}"))
-        }
-      case None => NotFound(jsonError(s"No such atom $atomId"))
-    }
-  }
 
   def revertAtom(atomId: String, version: Long) = APIAuthAction { implicit req =>
     dataStore.getAtom(atomId) match {

--- a/atom-manager-play-lib/build.sbt
+++ b/atom-manager-play-lib/build.sbt
@@ -14,6 +14,6 @@ libraryDependencies ++= Seq(
   "org.typelevel"          %% "cats-core"             % "0.6.0",
   "org.scalatestplus.play" %% "scalatestplus-play"    % "1.5.0"   % "test",
   "com.amazonaws"          %  "aws-java-sdk-dynamodb" % awsVersion,
-  "org.mockito"            %  "mockito-core"          % "1.10.19" % "test"
+  "org.mockito"            %  "mockito-core"          % mockitoVersion % "test"
     //"com.typesafe.play" %% "play-ws" % playVersion
 )

--- a/atom-manager-play-lib/src/main/scala/com.gu.atom/play/AtomAPIActions.scala
+++ b/atom-manager-play-lib/src/main/scala/com.gu.atom/play/AtomAPIActions.scala
@@ -1,0 +1,30 @@
+package com.gu.atom.play
+
+import com.gu.atom.data._
+import com.gu.atom.publish._
+import com.gu.contentatom.thrift._
+import java.util.Date
+import play.api.mvc._
+import scala.util.{ Failure, Success }
+import play.api.libs.json.{ JsObject, JsString }
+
+trait AtomAPIActions extends Controller {
+
+  val livePublisher: LiveAtomPublisher
+  val previewPublisher: PreviewAtomPublisher
+  val dataStore: DataStore
+
+  private def jsonError(msg: String): JsObject = JsObject(Seq("error" -> JsString(msg)))
+
+  def publishAtom(atomId: String) = Action { implicit req =>
+    dataStore.getAtom(atomId) match {
+      case Some(atom) =>
+        val event = ContentAtomEvent(atom, EventType.Update, (new Date()).getTime())
+        livePublisher.publishAtomEvent(event) match {
+          case Success(_)  => NoContent
+          case Failure(err) => InternalServerError(jsonError(s"could not publish: ${err.toString}"))
+        }
+      case None => NotFound(jsonError(s"No such atom $atomId"))
+    }
+  }
+}

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
@@ -1,0 +1,26 @@
+package com.gu.atom.play.test
+
+import com.gu.atom.play._
+import play.api.mvc.Controller
+import play.api.test.Helpers._
+import play.api.test.FakeRequest
+
+class AtomAPIActionsSpec extends AtomSuite {
+
+  override def initialLivePublisher = defaultMockPublisher
+
+  def apiActions(implicit conf: AtomTestConf) = new Controller with AtomAPIActions {
+    val livePublisher = conf.livePublisher
+    val previewPublisher = conf.previewPublisher
+    val  dataStore = conf.dataStore
+  }
+
+  "api publish action" should {
+    "call out to live publisher to publish an atom" in AtomTestConf() { implicit conf =>
+      val result = call(apiActions.publishAtom("1"), FakeRequest())
+      status(result) mustEqual NO_CONTENT
+    }
+
+  }
+
+}

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
@@ -1,26 +1,47 @@
 package com.gu.atom.play.test
 
+import com.gu.contentatom.thrift._
+import org.mockito.Mockito._
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import cats.data.Xor
 import com.gu.atom.play._
 import play.api.mvc.Controller
 import play.api.test.Helpers._
 import play.api.test.FakeRequest
+import org.scalatest.Inside
+import java.util.Date
 
-class AtomAPIActionsSpec extends AtomSuite {
+class AtomAPIActionsSpec extends AtomSuite with Inside {
 
   override def initialLivePublisher = defaultMockPublisher
+  override def initialDataStore = {
+    val m = dataStoreMockWithTestData
+    when(m.updateAtom(any())).thenReturn(Xor.Right(()))
+    m
+  }
 
   def apiActions(implicit conf: AtomTestConf) = new Controller with AtomAPIActions {
     val livePublisher = conf.livePublisher
     val previewPublisher = conf.previewPublisher
-    val  dataStore = conf.dataStore
+    val dataStore = conf.dataStore
   }
 
   "api publish action" should {
-    "call out to live publisher to publish an atom" in AtomTestConf() { implicit conf =>
+    "succeed with NO_CONTENT" in AtomTestConf() { implicit conf =>
       val result = call(apiActions.publishAtom("1"), FakeRequest())
       status(result) mustEqual NO_CONTENT
     }
-
+    "update publish time for atom" in AtomTestConf() { implicit conf =>
+      val startTime = (new Date()).getTime()
+      val atomCaptor = ArgumentCaptor.forClass(classOf[Atom])
+      call(apiActions.publishAtom("1"), FakeRequest())
+      verify(conf.dataStore).updateAtom(atomCaptor.capture())
+      inside(atomCaptor.getValue()) {
+        case Atom("1", _, _, _, _, changeDetails, _) =>
+          changeDetails.published.value.date must be >= startTime
+      }
+    }
   }
 
 }

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
@@ -23,7 +23,7 @@ import play.api.inject.{ bind, Binding }
 import scala.reflect.ClassTag
 
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 
 import org.scalatest.mock.MockitoSugar.mock
 

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
@@ -1,5 +1,6 @@
 package com.gu.atom.play.test
 
+import scala.util.{Failure, Success}
 import cats.data.Xor
 import com.gu.atom.publish.test.TestData
 
@@ -34,6 +35,24 @@ trait AtomSuite extends PlaySpec with GuiceableModuleConversions {
     when(m.getAtom(any())).thenReturn(Some(TestData.testAtoms.head))
     when(m.listAtoms).thenReturn(DataStoreResult.succeed(TestData.testAtoms.iterator))
     m
+  }
+
+  def defaultMockPublisher: LiveAtomPublisher = {
+    val p = mock[LiveAtomPublisher]
+    when(p.publishAtomEvent(any())).thenReturn(Success(()))
+    p
+  }
+
+  def defaultPreviewMockPublisher: PreviewAtomPublisher = {
+    val p = mock[PreviewAtomPublisher]
+    when(p.publishAtomEvent(any())).thenReturn(Success(()))
+    p
+  }
+
+  def failingMockPublisher: LiveAtomPublisher = {
+    val p = mock[LiveAtomPublisher]
+    when(p.publishAtomEvent(any())).thenReturn(Failure(new Exception("failure")))
+    p
   }
 
   def initialDataStore = dataStoreMockWithTestData

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/reindex-spec.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/reindex-spec.scala
@@ -1,10 +1,11 @@
 package com.gu.atom.play.test
 
+import org.mockito.ArgumentMatchers._
+
 import com.gu.atom.play.ReindexController
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import org.mockito.Mockito._
-import org.mockito.Matchers._
 import org.scalatest.mock.MockitoSugar.mock
 import com.gu.atom.publish._
 

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -50,7 +50,7 @@ libraryDependencies ++= Seq(
   "com.twitter"                %% "scrooge-serializer"   % scroogeVersion,
   "com.twitter"                %% "scrooge-core"         % scroogeVersion,
   "com.typesafe.akka"          %% "akka-actor"           % akkaVersion,
-  "org.mockito"                %  "mockito-core"         % "1.10.19"   % "test",
+  "org.mockito"                %  "mockito-core"         % mockitoVersion % "test",
   "org.scalatest"              %% "scalatest"            % "2.2.6"     % "test",
   "com.typesafe.akka"          %% "akka-testkit"         % akkaVersion % "test"
 ) ++  scanamoDeps

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
@@ -27,7 +27,6 @@ trait DataStore extends DataStoreResult {
   def updateAtom(newAtom: Atom): DataStoreResult[Unit]
 
   def listAtoms: DataStoreResult[Iterator[Atom]]
-
 }
 
 trait DataStoreResult {

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomPublisherSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomPublisherSpec.scala
@@ -5,7 +5,9 @@ import java.nio.ByteBuffer
 import com.gu.atom.publish.KinesisAtomPublisher
 
 import com.amazonaws.services.kinesis.AmazonKinesisClient
-import org.mockito.Matchers.{eq => argEq, _}
+
+import org.mockito.ArgumentMatchers.{eq => argEq, _}
+
 import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.mock.MockitoSugar
 import TestData._

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
@@ -11,7 +11,8 @@ import org.scalatest.{ FunSpecLike, Matchers }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito._
-import org.mockito.Matchers.{ eq => meq, _ }
+
+import org.mockito.ArgumentMatchers.{ eq => meq, _ }
 
 // import akka.testkit.TestKit
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ libraryDependencies ++= Seq(
   "com.gu"                     %% "pan-domain-auth-verification" % pandaVer,
   "com.gu"                     %% "pan-domain-auth-core"         % pandaVer,
   "org.scalatestplus.play"     %% "scalatestplus-play"           % "1.5.0"   % "test",
-  "org.mockito"                %  "mockito-core"                 % "1.10.19" % "test",
+  "org.mockito"                %  "mockito-core"                 % mockitoVersion % "test",
   "org.scala-lang.modules"     %% "scala-xml"                    % "1.0.5"   % "test"
 ) ++ scanamoDeps
 

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -7,6 +7,7 @@ object BuildVars {
   lazy val akkaVersion        = "2.4.8"
   lazy val pandaVer           = "0.3.0"
   lazy val playVersion        = "2.5.3"
+  lazy val mockitoVersion     = "2.0.97-beta"
 
   lazy val scanamoDeps = Seq(
     "com.gu"                     %% "scanamo"              % "0.6.0",

--- a/test/ApiSpec.scala
+++ b/test/ApiSpec.scala
@@ -19,8 +19,6 @@ import play.api.libs.json._
 import play.api.test.Helpers._
 import test.TestData._
 
-import scala.util.{Failure, Success}
-
 class ApiSpec
     extends AtomSuite
     with AuthTests
@@ -37,24 +35,6 @@ class ApiSpec
 
   val youtubeId  =  "7H9Z4sn8csA"
   val youtubeUrl = s"https://www.youtube.com/watch?v=${youtubeId}"
-
-  def defaultMockPublisher: LiveAtomPublisher = {
-    val p = mock[LiveAtomPublisher]
-    when(p.publishAtomEvent(any())).thenReturn(Success(()))
-    p
-  }
-
-  def defaultPreviewMockPublisher: PreviewAtomPublisher = {
-    val p = mock[PreviewAtomPublisher]
-    when(p.publishAtomEvent(any())).thenReturn(Success(()))
-    p
-  }
-
-  def failingMockPublisher: LiveAtomPublisher = {
-    val p = mock[LiveAtomPublisher]
-    when(p.publishAtomEvent(any())).thenReturn(Failure(new Exception("failure")))
-    p
-  }
 
   "api" should {
 
@@ -149,11 +129,6 @@ class ApiSpec
       mediaAtom.category mustEqual Hosted
       mediaAtom.duration mustEqual Some(34)
       mediaAtom.posterUrl mustEqual Some("https://abc/def.jpg")
-    }
-
-    "call out to live publisher to publish an atom" in AtomTestConf() { implicit conf =>
-      val result = call(api.publishAtom("1"), requestWithCookies)
-      status(result) mustEqual NO_CONTENT
     }
 
     "call out to preview publisher when adding an asset" in

--- a/test/ApiSpec.scala
+++ b/test/ApiSpec.scala
@@ -9,7 +9,7 @@ import com.gu.contentatom.thrift.atom.media.Category.{Hosted, News}
 import controllers.Api
 import data.MemoryStore
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.AppendedClues
 import org.scalatest.mock.MockitoSugar


### PR DESCRIPTION
* Move the publish endpoint into the `atom-manager-play` library for re-use
* Bump the version of mockito because it was causing a memory leak problem that meant you couldn't run the tests more than a couple of times
* When publishing store the time in the `contentChangeDetails` field of the atom
* Test the same