### PR TITLE
Add tests to atom manager play artifact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,7 @@ lazy val appDistSettings = Seq(
 lazy val atomPublisher = project in file("./atom-publisher-lib")
 
 lazy val atomManagerPlay = (project in file("./atom-manager-play-lib"))
+  .settings(publishArtifact in Test := true)
   .dependsOn(atomPublisher % "test->test;compile->compile")
 
 lazy val root = (project in file("."))


### PR DESCRIPTION
Add tests to the atom manager play artifact so that the resources it provides for writing tests can be used by apps that use the library.