### PR TITLE
fix displaying errors

### DIFF
--- a/public/javascript/atom.js
+++ b/public/javascript/atom.js
@@ -2,7 +2,7 @@ window.AtomUtil = (function() {
   var ret = {};
 
   function handleError(xhr, err) {
-    alert(err + ":" + xhr.responseJSON.error);
+    alert(err + ": " + xhr.responseText);
   }
 
   ret.addAsset = function(atomId) {


### PR DESCRIPTION
Display errors correctly on the client. ResponseJSON does not exist in the error response and the client was never displaying the error alerts.