### PR TITLE
increase revision number of new atom when creating it instead of active version

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -76,7 +76,7 @@ class Api @Inject() (val dataStore: DataStore,
           maxVersion + 1
         }
         val newAtom = atom
-                      .withRevision(newVersion)
+                      .withRevision(_ + 1)
                       .updateData { media =>
                         media.copy(
                           activeVersion = Some(newVersion),


### PR DESCRIPTION
Fixes the following bug: 

- atoms that have already been published cannot be updated

This is because the active version was being used as the revision for the new atom, causing the revision validation check to fail later. 