### PR TITLE
Rv published to separate dynamo table

### DIFF
--- a/app/controllers/MainApp.scala
+++ b/app/controllers/MainApp.scala
@@ -32,9 +32,9 @@ class MainApp @Inject() (dataStore: DataStore,
   }
 
   def getAtom(id: String) = AuthAction { implicit req =>
-    dataStore.getAtom(id) match {
-      case Some(atom) => Ok(displayAtom(atom))
-      case None => NotFound(s"no atom with id $id found")
+    (dataStore.getAtom(id), dataStore.getPublishedAtom(id)) match {
+      case (Some(atom), publishedAtom) => Ok(displayAtom(atom, publishedAtom))
+      case (None, _) => NotFound(s"no atom with id $id found")
     }
   }
 

--- a/app/controllers/MainApp.scala
+++ b/app/controllers/MainApp.scala
@@ -15,7 +15,8 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.ws.WSClient
 import play.api.Logger
 
-class MainApp @Inject() (dataStore: DataStore,
+class MainApp @Inject() (previewDataStore: PreviewDataStore,
+                         publishedDataStore: PublishedDataStore,
                          val wsClient: WSClient,
                          val conf: Configuration,
                          val authActions: AuthActions)
@@ -32,14 +33,14 @@ class MainApp @Inject() (dataStore: DataStore,
   }
 
   def getAtom(id: String) = AuthAction { implicit req =>
-    (dataStore.getAtom(id), dataStore.getPublishedAtom(id)) match {
+    (previewDataStore.getAtom(id), publishedDataStore.getAtom(id)) match {
       case (Some(atom), publishedAtom) => Ok(displayAtom(atom, publishedAtom))
       case (None, _) => NotFound(s"no atom with id $id found")
     }
   }
 
   def listAtoms = AuthAction { implicit req =>
-    dataStore.listAtoms.fold(
+    previewDataStore.listAtoms.fold(
       err => InternalServerError(err.msg),
       atoms => Ok(displayAtomList(atoms.toList))
     )

--- a/app/data/AtomReindexerProvider.scala
+++ b/app/data/AtomReindexerProvider.scala
@@ -8,13 +8,13 @@ import util.AWSConfig
 class PreviewAtomReindexerProvider @Inject() (awsConfig: AWSConfig)
     extends Provider[PreviewAtomReindexer] {
   def get() = new PreviewKinesisAtomReindexer(
-    awsConfig.kinesisReindexStreamName, awsConfig.kinesisClient
+    awsConfig.previewKinesisReindexStreamName, awsConfig.kinesisClient
   )
 }
 
 class PublishedAtomReindexerProvider @Inject() (awsConfig: AWSConfig)
   extends Provider[PublishedAtomReindexer] {
   def get() = new PublishedKinesisAtomReindexer(
-    awsConfig.kinesisReindexStreamName, awsConfig.kinesisClient
+    awsConfig.publishedKinesisReindexStreamName, awsConfig.kinesisClient
   )
 }

--- a/app/data/AtomReindexerProvider.scala
+++ b/app/data/AtomReindexerProvider.scala
@@ -2,12 +2,19 @@ package data
 
 import javax.inject.{Inject, Provider}
 
-import com.gu.atom.publish.{ KinesisAtomReindexer, AtomReindexer }
+import com.gu.atom.publish.{PublishedKinesisAtomReindexer, PublishedAtomReindexer, PreviewKinesisAtomReindexer, PreviewAtomReindexer}
 import util.AWSConfig
 
-class AtomReindexerProvider @Inject() (awsConfig: AWSConfig)
-    extends Provider[AtomReindexer] {
-  def get() = new KinesisAtomReindexer(
+class PreviewAtomReindexerProvider @Inject() (awsConfig: AWSConfig)
+    extends Provider[PreviewAtomReindexer] {
+  def get() = new PreviewKinesisAtomReindexer(
+    awsConfig.kinesisReindexStreamName, awsConfig.kinesisClient
+  )
+}
+
+class PublishedAtomReindexerProvider @Inject() (awsConfig: AWSConfig)
+  extends Provider[PublishedAtomReindexer] {
+  def get() = new PublishedKinesisAtomReindexer(
     awsConfig.kinesisReindexStreamName, awsConfig.kinesisClient
   )
 }

--- a/app/data/MediaAtomDataStore.scala
+++ b/app/data/MediaAtomDataStore.scala
@@ -16,7 +16,8 @@ import ScanamoUtil._
 
 class MediaAtomDataStoreProvider @Inject() (awsConfig: AWSConfig)
     extends Provider[DataStore] {
-  def get = new DynamoDataStore[MediaAtom](awsConfig.dynamoDB, awsConfig.dynamoTableName) {
+  def get = new DynamoDataStore[MediaAtom](awsConfig.dynamoDB, awsConfig.dynamoTableName,
+    awsConfig.publishedDynamoTableName) {
     def fromAtomData = { case AtomData.Media(data) => data }
     def toAtomData(data: MediaAtom) = AtomData.Media(data)
   }

--- a/app/data/MediaAtomDataStore.scala
+++ b/app/data/MediaAtomDataStore.scala
@@ -14,11 +14,19 @@ import DynamoFormat._
 
 import ScanamoUtil._
 
-class MediaAtomDataStoreProvider @Inject() (awsConfig: AWSConfig)
-    extends Provider[DataStore] {
-  def get = new DynamoDataStore[MediaAtom](awsConfig.dynamoDB, awsConfig.dynamoTableName,
-    awsConfig.publishedDynamoTableName) {
+class PublishedMediaAtomDataStoreProvider @Inject() (awsConfig: AWSConfig)
+    extends Provider[PublishedDataStore] {
+  def get = new PublishedDynamoDataStore[MediaAtom](awsConfig.dynamoDB, awsConfig.publishedDynamoTableName) {
     def fromAtomData = { case AtomData.Media(data) => data }
     def toAtomData(data: MediaAtom) = AtomData.Media(data)
   }
 }
+
+class PreviewMediaAtomDataStoreProvider @Inject() (awsConfig: AWSConfig)
+  extends Provider[PreviewDataStore] {
+  def get = new PreviewDynamoDataStore[MediaAtom](awsConfig.dynamoDB, awsConfig.dynamoTableName) {
+    def fromAtomData = { case AtomData.Media(data) => data }
+    def toAtomData(data: MediaAtom) = AtomData.Media(data)
+  }
+}
+

--- a/app/di.scala
+++ b/app/di.scala
@@ -18,7 +18,10 @@ class Module extends AbstractModule {
     bind(classOf[PreviewAtomPublisher])
       .toProvider(classOf[PreviewAtomPublisherProvider])
 
-    bind(classOf[AtomReindexer])
-      .toProvider(classOf[AtomReindexerProvider])
+    bind(classOf[PreviewAtomReindexer])
+      .toProvider(classOf[PreviewAtomReindexerProvider])
+
+    bind(classOf[PublishedAtomReindexer])
+      .toProvider(classOf[PublishedAtomReindexerProvider])
   }
 }

--- a/app/di.scala
+++ b/app/di.scala
@@ -1,5 +1,5 @@
 import com.google.inject.AbstractModule
-import com.gu.atom.data.{ MediaAtomDataStoreProvider, DataStore }
+import com.gu.atom.data._
 import com.gu.atom.publish._
 import com.gu.pandomainauth.action.AuthActions
 import data._
@@ -9,8 +9,11 @@ class Module extends AbstractModule {
     bind(classOf[AuthActions])
       .to(classOf[controllers.PanDomainAuthActions])
 
-    bind(classOf[DataStore])
-    .toProvider(classOf[MediaAtomDataStoreProvider])
+    bind(classOf[PublishedDataStore])
+    .toProvider(classOf[PublishedMediaAtomDataStoreProvider])
+
+    bind(classOf[PreviewDataStore])
+      .toProvider(classOf[PreviewMediaAtomDataStoreProvider])
 
     bind(classOf[LiveAtomPublisher])
     .toProvider(classOf[LiveAtomPublisherProvider])

--- a/app/util/AWS.scala
+++ b/app/util/AWS.scala
@@ -45,7 +45,8 @@ class AWSConfig @Inject() (config: Configuration) {
   lazy val liveKinesisStreamName = config.getString("aws.kinesis.liveStreamName").get
   lazy val previewKinesisStreamName = config.getString("aws.kinesis.previewStreamName").get
 
-  lazy val kinesisReindexStreamName = config.getString("aws.kinesis.reindexStreamName").get
+  lazy val previewKinesisReindexStreamName = config.getString("aws.kinesis.previewReindexStreamName").get
+  lazy val publishedKinesisReindexStreamName = config.getString("aws.kinesis.publishedReindexStreamName").get
 
   lazy val stage = config.getString("stage").getOrElse("DEV")
   lazy val readFromComposerAccount = config.getBoolean("readFromComposer").getOrElse(false)

--- a/app/util/AWS.scala
+++ b/app/util/AWS.scala
@@ -40,6 +40,7 @@ class AWSConfig @Inject() (config: Configuration) {
   )
 
   lazy val dynamoTableName = config.getString("aws.dynamo.tableName").get
+  lazy val publishedDynamoTableName = config.getString("aws.dynamo.publishedTableName").get
 
   lazy val liveKinesisStreamName = config.getString("aws.kinesis.liveStreamName").get
   lazy val previewKinesisStreamName = config.getString("aws.kinesis.previewStreamName").get

--- a/app/views/MediaAtom/displayAtom.scala.html
+++ b/app/views/MediaAtom/displayAtom.scala.html
@@ -16,11 +16,11 @@
             <a href="/atoms">Back</a>
         </p>
         @atomTable(atom)
-        @showPublished(atom, publishedAtom)
         @updateAtomUI(atom.id)
         @publishUI(atom.id)
         @addAssetForm(atom.id, atom.tdata.activeVersion.map(_ + (if(atom.tdata.assets.isEmpty) 0 else 1)) getOrElse 1)
         @showDefaultHtml(atom)
+        @showPublished(atom, publishedAtom)
 
     </body>
 </html>

--- a/app/views/MediaAtom/displayAtom.scala.html
+++ b/app/views/MediaAtom/displayAtom.scala.html
@@ -1,6 +1,6 @@
 @import com.gu.contentatom.thrift._
 @import util.atom.MediaAtomImplicits._
-@(atom: Atom)
+@(atom: Atom, publishedAtom: Option[Atom])
 <html>
     <head>
         <script
@@ -16,9 +16,11 @@
             <a href="/atoms">Back</a>
         </p>
         @atomTable(atom)
+        @showPublished(atom, publishedAtom)
         @updateAtomUI(atom.id)
         @publishUI(atom.id)
         @addAssetForm(atom.id, atom.tdata.activeVersion.map(_ + (if(atom.tdata.assets.isEmpty) 0 else 1)) getOrElse 1)
         @showDefaultHtml(atom)
+
     </body>
 </html>

--- a/app/views/MediaAtom/showPublished.scala.html
+++ b/app/views/MediaAtom/showPublished.scala.html
@@ -1,0 +1,32 @@
+@import com.gu.contentatom.thrift.Atom
+
+@(atom: Atom, publishedAtom: Option[Atom])
+
+@atom.contentChangeDetails.lastModified
+<div>
+    @publishedAtom match {
+      case Some(atom) => {
+
+        <div>
+            <input type="button"
+               onClick="AtomUtil.displayPublishInformation()"
+               id="displayPublish"
+               value="Display published atom information">
+            </input>
+            <input type="button"
+               onClick="AtomUtil.hidePublishInformation()"
+               id="hidePublish"
+               value="Hide published atom information">
+            </input>
+        </div>
+
+        <div id="publishInfo">
+
+            <h1>Published Atom</h1>
+            <div>@atomTable(atom)</div>
+        </div>
+    }
+    case None => {
+        <div>This atom has not yet been published</div>
+    }}
+</div>

--- a/atom-manager-play-lib/src/main/scala/com.gu.atom/play/AtomAPIActions.scala
+++ b/atom-manager-play-lib/src/main/scala/com.gu.atom/play/AtomAPIActions.scala
@@ -22,11 +22,16 @@ trait AtomAPIActions extends Controller {
 
   def publishAtom(atomId: String) = Action { implicit req =>
 
+    val revisionNumber = publishedDataStore.getAtom(atomId) match {
+      case Some(atom) => atom.contentChangeDetails.revision + 1
+      case None => 1
+    }
+
     previewDataStore.getAtom(atomId) match {
       case Some(atom) => {
         val updatedAtom = atom.copy(
           contentChangeDetails = atom.contentChangeDetails.copy(published = Some(ChangeRecord((new Date()).getTime(), None)))
-        ).withRevision(1)
+        ).withRevision(revisionNumber)
 
         saveAtom(updatedAtom)
       }

--- a/atom-manager-play-lib/src/main/scala/com.gu.atom/play/AtomAPIActions.scala
+++ b/atom-manager-play-lib/src/main/scala/com.gu.atom/play/AtomAPIActions.scala
@@ -33,13 +33,13 @@ trait AtomAPIActions extends Controller {
           contentChangeDetails = atom.contentChangeDetails.copy(published = Some(ChangeRecord((new Date()).getTime(), None)))
         ).withRevision(revisionNumber)
 
-        saveAtom(updatedAtom)
+        savePublishedAtom(updatedAtom)
       }
       case None => NotFound(jsonError(s"No such atom $atomId"))
     }
   }
 
-  private def saveAtom(updatedAtom: Atom) = {
+  private def savePublishedAtom(updatedAtom: Atom) = {
     val event = ContentAtomEvent(updatedAtom, EventType.Update, (new Date()).getTime())
     livePublisher.publishAtomEvent(event) match {
       case Success(_) =>

--- a/atom-manager-play-lib/src/main/scala/com.gu.atom/play/AtomAPIActions.scala
+++ b/atom-manager-play-lib/src/main/scala/com.gu.atom/play/AtomAPIActions.scala
@@ -20,25 +20,43 @@ trait AtomAPIActions extends Controller {
   private def jsonError(msg: String): JsObject = JsObject(Seq("error" -> JsString(msg)))
 
   def publishAtom(atomId: String) = Action { implicit req =>
-    dataStore.getAtom(atomId) match {
-      case Some(atom) =>
+    dataStore.getPublishedAtom(atomId) match {
+      case Some(atom) => {
         val updatedAtom = atom.copy(
           contentChangeDetails = atom.contentChangeDetails.copy(
             published = Some(ChangeRecord((new Date()).getTime(), None))
           )
         ).bumpRevision
-        val event = ContentAtomEvent(updatedAtom, EventType.Update, (new Date()).getTime())
-        livePublisher.publishAtomEvent(event) match {
-          case Success(_)  =>
-            dataStore.updateAtom(updatedAtom) match {
-              case Xor.Right(_)  => NoContent
-              case Xor.Left(err) => InternalServerError(
-                jsonError(s"could not update after publish: ${err.toString}")
-              )
-            }
-          case Failure(err) => InternalServerError(jsonError(s"could not publish: ${err.toString}"))
+        saveAtom(updatedAtom)
+      }
+      case None =>
+
+        // The atom has not yet published and needs to be saved in the published
+        // table for the first time
+        dataStore.getAtom(atomId) match {
+          case Some(atom) => {
+            val updatedAtom = atom.copy(
+              contentChangeDetails = atom.contentChangeDetails.copy(published = Some(ChangeRecord((new Date()).getTime(), None)))
+            ).withRevision(1)
+
+            saveAtom(updatedAtom)
+          }
+          case None => NotFound(jsonError(s"No such atom $atomId"))
         }
-      case None => NotFound(jsonError(s"No such atom $atomId"))
+    }
+  }
+
+  private def saveAtom(updatedAtom: Atom) = {
+    val event = ContentAtomEvent(updatedAtom, EventType.Update, (new Date()).getTime())
+    livePublisher.publishAtomEvent(event) match {
+      case Success(_) =>
+        dataStore.updatePublishedAtom(updatedAtom) match {
+          case Xor.Right(_) => NoContent
+          case Xor.Left(err) => InternalServerError(
+            jsonError(s"could not update after publish: ${err.toString}")
+          )
+        }
+      case Failure(err) => InternalServerError(jsonError(s"could not publish: ${err.toString}"))
     }
   }
 }

--- a/atom-manager-play-lib/src/main/scala/com.gu.atom/play/reindex.scala
+++ b/atom-manager-play-lib/src/main/scala/com.gu.atom/play/reindex.scala
@@ -90,7 +90,9 @@ object ReindexActor {
 }
 
 @Singleton
-class ReindexController @Inject() (dataStore: DataStore,
+class ReindexController @Inject() (
+                                   previewDataStore: PreviewDataStore,
+                                   publishedDataStore: PublishedDataStore,
                                    previewReindexer: PreviewAtomReindexer,
                                    publishedReindexer: PublishedAtomReindexer,
                                    config: Configuration,
@@ -118,8 +120,8 @@ class ReindexController @Inject() (dataStore: DataStore,
     }
   }
 
-  def newPreviewReindexJob = getNewReindexJob(dataStore.listAtoms, previewReindexActor)
-  def newPublishedReindexJob = getNewReindexJob(dataStore.listPublishedAtoms, publishedReindexActor)
+  def newPreviewReindexJob = getNewReindexJob(previewDataStore.listAtoms, previewReindexActor)
+  def newPublishedReindexJob = getNewReindexJob(publishedDataStore.listAtoms, publishedReindexActor)
 
   def previewReindexJobStatus = getReindexJobStatus(previewReindexActor)
   def publishedReindexJobStatus = getReindexJobStatus(publishedReindexActor)
@@ -132,7 +134,7 @@ class ReindexController @Inject() (dataStore: DataStore,
     }
   }
 
-  private def getNewReindexJob(getAtoms: dataStore.DataStoreResult[Iterator[Atom]], actor: ActorRef) =
+  private def getNewReindexJob(getAtoms: previewDataStore.DataStoreResult[Iterator[Atom]], actor: ActorRef) =
     ApiKeyAction.async { implicit req =>
       getAtoms.fold(
 

--- a/atom-manager-play-lib/src/main/scala/com.gu.atom/play/reindex.scala
+++ b/atom-manager-play-lib/src/main/scala/com.gu.atom/play/reindex.scala
@@ -91,7 +91,8 @@ object ReindexActor {
 
 @Singleton
 class ReindexController @Inject() (dataStore: DataStore,
-                                   reindexer: AtomReindexer,
+                                   previewReindexer: PreviewAtomReindexer,
+                                   publishedReindexer: PublishedAtomReindexer,
                                    config: Configuration,
                                    system: ActorSystem) extends Controller {
 
@@ -99,8 +100,8 @@ class ReindexController @Inject() (dataStore: DataStore,
 
   implicit val ec = system.dispatcher
 
-  val previewReindexActor = system.actorOf(Props(classOf[ReindexActor], reindexer))
-  val publishedReindexActor = system.actorOf(Props(classOf[ReindexActor], reindexer))
+  val previewReindexActor = system.actorOf(Props(classOf[ReindexActor], previewReindexer))
+  val publishedReindexActor = system.actorOf(Props(classOf[ReindexActor], publishedReindexer))
 
   implicit val timeout = Timeout(5.seconds)
 

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
@@ -46,7 +46,7 @@ class AtomAPIActionsSpec extends AtomSuite with Inside {
       inside(atomCaptor.getValue()) {
         case Atom("1", _, _, _, _, changeDetails, _) => {
           changeDetails.published.value.date must be >= startTime
-          changeDetails.revision mustEqual 1
+          changeDetails.revision mustEqual 2
         }
       }
     }

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
@@ -1,5 +1,6 @@
 package com.gu.atom.play.test
 
+import com.gu.atom.TestData
 import com.gu.contentatom.thrift._
 import org.mockito.Mockito._
 import org.mockito.ArgumentCaptor
@@ -18,6 +19,8 @@ class AtomAPIActionsSpec extends AtomSuite with Inside {
   override def initialDataStore = {
     val m = dataStoreMockWithTestData
     when(m.updateAtom(any())).thenReturn(Xor.Right(()))
+    when(m.getPublishedAtom(any())).thenReturn(Some(TestData.testAtoms.head))
+    when(m.updatePublishedAtom(any())).thenReturn(Xor.Right(()))
     m
   }
 
@@ -32,15 +35,18 @@ class AtomAPIActionsSpec extends AtomSuite with Inside {
       val result = call(apiActions.publishAtom("1"), FakeRequest())
       status(result) mustEqual NO_CONTENT
     }
+
     "update publish time for atom" in AtomTestConf() { implicit conf =>
       val startTime = (new Date()).getTime()
       val atomCaptor = ArgumentCaptor.forClass(classOf[Atom])
       val result = call(apiActions.publishAtom("1"), FakeRequest())
       status(result) mustEqual NO_CONTENT
-      verify(conf.dataStore).updateAtom(atomCaptor.capture())
+      verify(conf.dataStore).updatePublishedAtom(atomCaptor.capture())
+
       inside(atomCaptor.getValue()) {
         case Atom("1", _, _, _, _, changeDetails, _) =>
           changeDetails.published.value.date must be >= startTime
+
       }
     }
   }

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
@@ -41,7 +41,7 @@ class AtomAPIActionsSpec extends AtomSuite with Inside {
       val atomCaptor = ArgumentCaptor.forClass(classOf[Atom])
       val result = call(apiActions.publishAtom("1"), FakeRequest())
       status(result) mustEqual NO_CONTENT
-      verify(conf.dataStore).updateAtom(atomCaptor.capture())
+      verify(conf.publishedDataStore).updateAtom(atomCaptor.capture())
       
       inside(atomCaptor.getValue()) {
         case Atom("1", _, _, _, _, changeDetails, _) => {

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
@@ -30,8 +30,17 @@ import org.scalatest.mock.MockitoSugar.mock
 
 trait AtomSuite extends PlaySpec with GuiceableModuleConversions {
 
-  def dataStoreMockWithTestData = {
-    val m = mock[DataStore]
+  def dataStore = mock[DataStore]
+
+  def previewDataStoreMockWithTestData = {
+    val m = mock[PreviewDataStore]
+    when(m.getAtom(any())).thenReturn(Some(TestData.testAtoms.head))
+    when(m.listAtoms).thenReturn(DataStoreResult.succeed(TestData.testAtoms.iterator))
+    m
+  }
+
+  def publishedDataStoreMockWithTestData = {
+    val m = mock[PublishedDataStore]
     when(m.getAtom(any())).thenReturn(Some(TestData.testAtoms.head))
     when(m.listAtoms).thenReturn(DataStoreResult.succeed(TestData.testAtoms.iterator))
     m
@@ -55,7 +64,8 @@ trait AtomSuite extends PlaySpec with GuiceableModuleConversions {
     p
   }
 
-  def initialDataStore = dataStoreMockWithTestData
+  def initialPreviewDataStore = previewDataStoreMockWithTestData
+  def initialPublishedDataStore = publishedDataStoreMockWithTestData
   def initialLivePublisher = mock[LiveAtomPublisher]
   def initialPreviewPublisher = mock[PreviewAtomPublisher]
 
@@ -74,13 +84,16 @@ trait AtomSuite extends PlaySpec with GuiceableModuleConversions {
     mbind[A]((a: A) => ())
 
   case class AtomTestConf(
-    dataStore: DataStore = initialDataStore,
+    previewDataStore: PreviewDataStore = initialPreviewDataStore,
+    publishedDataStore: PublishedDataStore = initialPublishedDataStore,
     livePublisher: LiveAtomPublisher = initialLivePublisher,
     previewPublisher: PreviewAtomPublisher = initialPreviewPublisher,
     shutDownHook: AtomTestConf => Unit = _.app.stop) {
 
     private def makeOverrides: GuiceableModule = Seq(
       ibind(dataStore),
+      ibind(previewDataStore),
+      ibind(publishedDataStore),
       ibind(livePublisher),
       ibind(previewPublisher)
     ) ++ customOverrides

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/reindex-spec.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/reindex-spec.scala
@@ -16,23 +16,34 @@ class ReindexSpec extends AtomSuite {
   val reindexApiKey = "xyzzy"
 
   override def customOverrides = {
-    val mockReindexer = mock[AtomReindexer]
-    super.customOverrides :+ mbind[AtomReindexer] { (r: AtomReindexer) =>
+
+    super.customOverrides :+ mbind[PublishedAtomReindexer] { (r: AtomReindexer) =>
+      when(r.startReindexJob(any(), any())).thenReturn(AtomReindexJob.empty)
+    } :+ mbind[PreviewAtomReindexer] { (r: AtomReindexer) =>
       when(r.startReindexJob(any(), any())).thenReturn(AtomReindexJob.empty)
     }
+
   }
   override def customConfig = super.customConfig + ("reindexApiKey" -> reindexApiKey)
 
-  "reindex api" should {
+  "preview reindex api" should {
     "deny access without api key or with incorrect key" in AtomTestConf() { implicit conf =>
-      (status(reindexCtrl.newReindexJob().apply(FakeRequest()))
+      (status(reindexCtrl.newPreviewReindexJob().apply(FakeRequest()))
          mustEqual UNAUTHORIZED)
 
-      (status(reindexCtrl.newReindexJob().apply(FakeRequest("GET", s"/?api=jafklsj")))
+      (status(reindexCtrl.newPreviewReindexJob().apply(FakeRequest("GET", s"/?api=jafklsj")))
          mustEqual UNAUTHORIZED)
     }
+  }
 
-//    "deny access
+  "publish reindex api" should {
+    "deny access without api key or with incorrect key" in AtomTestConf() { implicit conf =>
+      (status(reindexCtrl.newPublishedReindexJob().apply(FakeRequest()))
+        mustEqual UNAUTHORIZED)
+
+      (status(reindexCtrl.newPublishedReindexJob().apply(FakeRequest("GET", s"/?api=jafklsj")))
+        mustEqual UNAUTHORIZED)
+    }
   }
 
 }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
@@ -26,6 +26,8 @@ trait DataStore extends DataStoreResult {
    * it as a version conflict error */
 
   def listAtoms: DataStoreResult[Iterator[Atom]]
+
+  def updateAtom(newAtom: Atom): DataStoreResult[Unit]
 }
 
 trait DataStoreResult {
@@ -37,10 +39,6 @@ trait DataStoreResult {
 
 object DataStoreResult extends DataStoreResult
 
-trait PreviewDataStore extends DataStore {
-  def updateAtom(newAtom: Atom): DataStoreResult[Unit]
-}
+trait PreviewDataStore extends DataStore
 
-trait PublishedDataStore extends DataStore {
-  def updateAtom(newAtom: Atom): DataStoreResult[Unit]
-}
+trait PublishedDataStore extends DataStore

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
@@ -19,20 +19,13 @@ trait DataStore extends DataStoreResult {
 
   def getAtom(id: String): Option[Atom]
 
-  def getPublishedAtom(id: String): Option[Atom]
-
   def createAtom(atom: Atom): DataStoreResult[Unit]
 
   /* this will only allow the update if the version in atom is later
    * than the version stored in the database, otherwise it will report
    * it as a version conflict error */
-  def updateAtom(newAtom: Atom): DataStoreResult[Unit]
-
-  def updatePublishedAtom(newAtom: Atom): DataStoreResult[Unit]
 
   def listAtoms: DataStoreResult[Iterator[Atom]]
-
-  def listPublishedAtoms: DataStoreResult[Iterator[Atom]]
 }
 
 trait DataStoreResult {
@@ -43,3 +36,11 @@ trait DataStoreResult {
 }
 
 object DataStoreResult extends DataStoreResult
+
+trait PreviewDataStore extends DataStore {
+  def updateAtom(newAtom: Atom): DataStoreResult[Unit]
+}
+
+trait PublishedDataStore extends DataStore {
+  def updateAtom(newAtom: Atom): DataStoreResult[Unit]
+}

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
@@ -31,6 +31,8 @@ trait DataStore extends DataStoreResult {
   def updatePublishedAtom(newAtom: Atom): DataStoreResult[Unit]
 
   def listAtoms: DataStoreResult[Iterator[Atom]]
+
+  def listPublishedAtoms: DataStoreResult[Iterator[Atom]]
 }
 
 trait DataStoreResult {

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
@@ -19,12 +19,16 @@ trait DataStore extends DataStoreResult {
 
   def getAtom(id: String): Option[Atom]
 
+  def getPublishedAtom(id: String): Option[Atom]
+
   def createAtom(atom: Atom): DataStoreResult[Unit]
 
   /* this will only allow the update if the version in atom is later
    * than the version stored in the database, otherwise it will report
    * it as a version conflict error */
   def updateAtom(newAtom: Atom): DataStoreResult[Unit]
+
+  def updatePublishedAtom(newAtom: Atom): DataStoreResult[Unit]
 
   def listAtoms: DataStoreResult[Iterator[Atom]]
 }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
@@ -20,7 +20,7 @@ import com.gu.atom.data._
 import ScanamoUtil._
 
 abstract class DynamoDataStore[D : ClassTag : DynamoFormat]
-  (dynamo: AmazonDynamoDBClient, tableName: String, publishedTableName: String)
+  (dynamo: AmazonDynamoDBClient, tableName: String)
     extends DataStore
     with AtomDynamoFormats[D] {
 
@@ -29,17 +29,11 @@ abstract class DynamoDataStore[D : ClassTag : DynamoFormat]
 
   // useful shortcuts
   private val get  = Scanamo.get[Atom](dynamo)(tableName) _
-  private val getPublished  = Scanamo.get[Atom](dynamo)(publishedTableName) _
   private val put  = Scanamo.put[Atom](dynamo)(tableName) _
 
   // this should probably return an Either so we can report an error,
   // e.g. if the atom exists, but it can't be deseralised
   def getAtom(id: String): Option[Atom] = get(UniqueKey(KeyEquals('id, id))) match {
-    case Some(Xor.Right(atom)) => Some(atom)
-    case _ => None
-  }
-
-  def getPublishedAtom(id: String): Option[Atom] = getPublished(UniqueKey(KeyEquals('id, id))) match {
     case Some(Xor.Right(atom)) => Some(atom)
     case _ => None
   }
@@ -50,6 +44,20 @@ abstract class DynamoDataStore[D : ClassTag : DynamoFormat]
     else
       succeed(put(atom))
 
+
+  private def findAtoms(tableName: String): DataStoreResult[List[Atom]] =
+    Scanamo.scan[Atom](dynamo)(tableName).sequenceU.leftMap {
+      _ => ReadError
+    }
+
+  def listAtoms: DataStoreResult[Iterator[Atom]] = findAtoms(tableName).rightMap(_.iterator)
+}
+
+abstract class PreviewDynamoDataStore[D : ClassTag : DynamoFormat]
+(dynamo: AmazonDynamoDBClient, tableName: String)
+  extends DynamoDataStore[D](dynamo, tableName)
+  with PreviewDataStore {
+
   def updateAtom(newAtom: Atom) = {
     val validationCheck = NestedKeyIs(
       List('contentChangeDetails, 'revision), LT, newAtom.contentChangeDetails.revision
@@ -59,15 +67,13 @@ abstract class DynamoDataStore[D : ClassTag : DynamoFormat]
       .leftMap(_ => VersionConflictError(newAtom.contentChangeDetails.revision))
   }
 
-  def updatePublishedAtom(newAtom: Atom) =
-    succeed((Scanamo.exec(dynamo)(Table[Atom](publishedTableName).put(newAtom))))
+}
 
-  private def findAtoms(tableName: String): DataStoreResult[List[Atom]] =
-    Scanamo.scan[Atom](dynamo)(tableName).sequenceU.leftMap {
-      _ => ReadError
-    }
+abstract class PublishedDynamoDataStore[D : ClassTag : DynamoFormat]
+(dynamo: AmazonDynamoDBClient, tableName: String)
+  extends DynamoDataStore[D](dynamo, tableName)
+  with PublishedDataStore {
 
-  def listAtoms: DataStoreResult[Iterator[Atom]] = findAtoms(tableName).rightMap(_.iterator)
-
-  def listPublishedAtoms: DataStoreResult[Iterator[Atom]] = findAtoms(publishedTableName).rightMap(_.iterator)
+  def updateAtom(newAtom: Atom) =
+    succeed((Scanamo.exec(dynamo)(Table[Atom](tableName).put(newAtom))))
 }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
@@ -62,10 +62,12 @@ abstract class DynamoDataStore[D : ClassTag : DynamoFormat]
   def updatePublishedAtom(newAtom: Atom) =
     succeed((Scanamo.exec(dynamo)(Table[Atom](publishedTableName).put(newAtom))))
 
-  private def findAtoms: DataStoreResult[List[Atom]] =
+  private def findAtoms(tableName: String): DataStoreResult[List[Atom]] =
     Scanamo.scan[Atom](dynamo)(tableName).sequenceU.leftMap {
       _ => ReadError
     }
 
-  def listAtoms: DataStoreResult[Iterator[Atom]] = findAtoms.rightMap(_.iterator)
+  def listAtoms: DataStoreResult[Iterator[Atom]] = findAtoms(tableName).rightMap(_.iterator)
+
+  def listPublishedAtoms: DataStoreResult[Iterator[Atom]] = findAtoms(publishedTableName).rightMap(_.iterator)
 }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
@@ -16,8 +16,6 @@ class MemoryStore extends DataStore {
 
   def getAtom(id: String) = dataStore.get(id)
 
-  def getPublishedAtom(id: String) = dataStore.get(id)
-
   def createAtom(atom: Atom) = dataStore.synchronized {
     if(dataStore.get(atom.id).isDefined) {
       fail(IDConflictError)
@@ -39,20 +37,8 @@ class MemoryStore extends DataStore {
     }
   }
 
-  def updatePublishedAtom(newAtom: Atom) = dataStore.synchronized {
-    getPublishedAtom(newAtom.id) match {
-      case Some(oldAtom) =>
-        if(oldAtom.contentChangeDetails.revision >=
-          newAtom.contentChangeDetails.revision) {
-          fail(VersionConflictError(newAtom.contentChangeDetails.revision))
-        } else {
-          succeed(dataStore(newAtom.id) = newAtom)
-        }
-      case None => fail(IDNotFound)
-    }
-  }
-
   def listAtoms = Xor.right(dataStore.values.iterator)
-
-  def listPublishedAtoms = Xor.right(dataStore.values.iterator)
 }
+
+class PreviewMemoryStore(initial: Map[String, Atom]) extends MemoryStore(initial) with PreviewDataStore
+class PublishedMemoryStore(initial: Map[String, Atom]) extends MemoryStore(initial) with PublishedDataStore

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
@@ -54,4 +54,5 @@ class MemoryStore extends DataStore {
 
   def listAtoms = Xor.right(dataStore.values.iterator)
 
+  def listPublishedAtoms = Xor.right(dataStore.values.iterator)
 }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
@@ -16,6 +16,8 @@ class MemoryStore extends DataStore {
 
   def getAtom(id: String) = dataStore.get(id)
 
+  def getPublishedAtom(id: String) = dataStore.get(id)
+
   def createAtom(atom: Atom) = dataStore.synchronized {
     if(dataStore.get(atom.id).isDefined) {
       fail(IDConflictError)
@@ -29,6 +31,19 @@ class MemoryStore extends DataStore {
       case Some(oldAtom) =>
         if(oldAtom.contentChangeDetails.revision >=
              newAtom.contentChangeDetails.revision) {
+          fail(VersionConflictError(newAtom.contentChangeDetails.revision))
+        } else {
+          succeed(dataStore(newAtom.id) = newAtom)
+        }
+      case None => fail(IDNotFound)
+    }
+  }
+
+  def updatePublishedAtom(newAtom: Atom) = dataStore.synchronized {
+    getPublishedAtom(newAtom.id) match {
+      case Some(oldAtom) =>
+        if(oldAtom.contentChangeDetails.revision >=
+          newAtom.contentChangeDetails.revision) {
           fail(VersionConflictError(newAtom.contentChangeDetails.revision))
         } else {
           succeed(dataStore(newAtom.id) = newAtom)

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/AtomReindexer.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/AtomReindexer.scala
@@ -25,3 +25,6 @@ trait AtomReindexer {
   def startReindexJob(atomsToReindex: Iterator[ContentAtomEvent], expectedSize: Int): AtomReindexJob
 
 }
+
+trait PreviewAtomReindexer extends AtomReindexer
+trait PublishedAtomReindexer extends AtomReindexer

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
@@ -24,4 +24,13 @@ class KinesisAtomReindexer(
       }
     }
 }
+
+class PreviewKinesisAtomReindexer( val streamName: String,
+                                   val kinesis: AmazonKinesisClient)
+  extends KinesisAtomReindexer(streamName, kinesis) with PreviewAtomReindexer
+
+class PublishedKinesisAtomReindexer( val streamName: String,
+                                     val kinesis: AmazonKinesisClient)
+  extends KinesisAtomReindexer(streamName, kinesis) with PublishedAtomReindexer
+
  

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
@@ -23,11 +23,12 @@ class DynamoDataStoreSpec
     with BeforeAndAfterAll
     with AtomImplicitsGeneral {
   val tableName = "atom-test-table"
+  val publishedTableName = "published-atom-test-table"
 
   type FixtureParam = DynamoDataStore[MediaAtom]
 
   def withFixture(test: OneArgTest) = {
-    val db = new DynamoDataStore[MediaAtom](LocalDynamoDB.client, tableName) with MediaAtomDynamoFormats
+    val db = new DynamoDataStore[MediaAtom](LocalDynamoDB.client, tableName, publishedTableName) with MediaAtomDynamoFormats
     super.withFixture(test.toNoArgTest(db))
   }
 
@@ -48,10 +49,16 @@ class DynamoDataStoreSpec
       dataStore.updateAtom(updated) should equal(Xor.Right())
       dataStore.getAtom(testAtom.id).value should equal(updated)
     }
+
+    it("should save a published atom") { dataStore =>
+      dataStore.updatePublishedAtom(testAtom) should equal(Xor.Right())
+      dataStore.getPublishedAtom(testAtom.id).value should equal(testAtom)
+    }
   }
 
   override def beforeAll() = {
     val client = LocalDynamoDB.client
     LocalDynamoDB.createTable(client)(tableName)('id -> S)
+    LocalDynamoDB.createTable(client)(publishedTableName)('id -> S)
   }
 }

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
@@ -25,34 +25,39 @@ class DynamoDataStoreSpec
   val tableName = "atom-test-table"
   val publishedTableName = "published-atom-test-table"
 
-  type FixtureParam = DynamoDataStore[MediaAtom]
+  type FixtureParam = (PreviewDynamoDataStore[MediaAtom], PublishedDynamoDataStore[MediaAtom])
 
   def withFixture(test: OneArgTest) = {
-    val db = new DynamoDataStore[MediaAtom](LocalDynamoDB.client, tableName, publishedTableName) with MediaAtomDynamoFormats
-    super.withFixture(test.toNoArgTest(db))
+    val previewDb = new PreviewDynamoDataStore[MediaAtom](LocalDynamoDB.client, tableName) with MediaAtomDynamoFormats
+    val publishedDb = new PublishedDynamoDataStore[MediaAtom](LocalDynamoDB.client, tableName) with MediaAtomDynamoFormats
+    super.withFixture(test.toNoArgTest((previewDb, publishedDb)))
   }
 
   describe("DynamoDataStore") {
-    it("should create a new atom") { dataStore =>
-      dataStore.createAtom(testAtom) should equal(Xor.Right())
+    it("should create a new atom") { dataStores =>
+      dataStores._1.createAtom(testAtom) should equal(Xor.Right())
     }
 
-    it("should return the atom") { dataStore =>
-      dataStore.getAtom(testAtom.id).value should equal(testAtom)
+    it("should return the atom") { dataStores =>
+      dataStores._1.getAtom(testAtom.id).value should equal(testAtom)
     }
 
-    it("should update the atom") { dataStore =>
+    it("should update the atom") { dataStores =>
       val updated = testAtom
         .copy(defaultHtml = "<div>updated</div>")
         .bumpRevision
 
-      dataStore.updateAtom(updated) should equal(Xor.Right())
-      dataStore.getAtom(testAtom.id).value should equal(updated)
+      dataStores._1.updateAtom(updated) should equal(Xor.Right())
+      dataStores._1.getAtom(testAtom.id).value should equal(updated)
     }
 
-    it("should save a published atom") { dataStore =>
-      dataStore.updatePublishedAtom(testAtom) should equal(Xor.Right())
-      dataStore.getPublishedAtom(testAtom.id).value should equal(testAtom)
+    it("should update a published atom") { dataStores =>
+      val updated = testAtom
+        .copy()
+        .withRevision(1)
+
+      dataStores._2.updateAtom(updated) should equal(Xor.Right())
+      dataStores._2.getAtom(testAtom.id).value should equal(updated)
     }
   }
 

--- a/cloudformation/media-atom-maker-dev.yml
+++ b/cloudformation/media-atom-maker-dev.yml
@@ -1,18 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: "Media atom maker development"
-Parameters:
-  DynamoDBTablePrefix:
-    Description: "DynamoDB Table prefix"
-    Type: "String"
-    Default: "media-atom-maker"
-  KinesisPreviewPrefix:
-    Description: "Preview kinesis prefix"
-    Type: "String"
-    Default: "media-atom-maker-preview"
-  KinesisLivePrefix:
-    Description: "Live kinesis prefix"
-    Type: "String"
-    Default: "media-atom-maker-live"
 Resources:
   MediaAtomGroup:
     Type: "AWS::IAM::Group"
@@ -28,6 +15,12 @@ Resources:
                   - Fn::Join:
                     - ""
                     - ["arn:aws:dynamodb:", {Ref: "AWS::Region"}, ":", {Ref: "AWS::AccountId"}, ":table/", {Ref: "MediaAtomsDynamoTable"}]
+              - Effect: "Allow"
+                Action: ["dynamodb:*"]
+                Resource:
+                  - Fn::Join:
+                    - ""
+                    - ["arn:aws:dynamodb:", {Ref: "AWS::Region"}, ":", {Ref: "AWS::AccountId"}, ":table/", {Ref: "PublishedMediaAtomsDynamoTable"}]
   MediaAtomUser:
     Type: "AWS::IAM::User"
     Properties:
@@ -57,10 +50,25 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: "10"
         WriteCapacityUnits: "5"
+  PublishedMediaAtomsDynamoTable:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: "id"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "id"
+          KeyType: "HASH"
+      ProvisionedThroughput:
+        ReadCapacityUnits: "10"
+        WriteCapacityUnits: "5"
 Outputs:
   EditsDynamoTable:
     Value:
       Ref: "MediaAtomsDynamoTable"
+  PublishedDynamoTable:
+    Value:
+      Ref: "PublishedMediaAtomsDynamoTable"
   AwsId:
     Value:
       Ref: "HostKeys"

--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -47,6 +47,10 @@
         "AtomMakerTable": {
             "Description": "Name of the media atom dynamo table",
             "Type": "String"
+        },
+        "PublishedAtomMakerTable": {
+            "Description": "Name of the published media atom dynamo table",
+            "Type": "String"
         }
     },
     "Resources": {
@@ -307,6 +311,7 @@
                                 "/home/media-service/media-atom-maker/conf/application.conf\n",
                                 "cat >> /home/media-service/media-atom-maker/conf/application.conf<<'EOF'\n",
                                 "aws.dynamo.tableName=", { "Ref": "AtomMakerTable" }, "\n",
+                                "aws.dynamo.publishedTableName=", { "Ref": "PublishedAtomMakerTable" }, "\n",
                                 "EOF\n",
 
                                 "systemctl start media-atom-maker\n"
@@ -374,6 +379,13 @@
                             "Effect": "Allow",
                             "Resource": {
                                 "Fn::Join": ["", ["arn:aws:dynamodb:", {"Ref": "AWS::Region"}, ":", {"Ref": "AWS::AccountId"}, ":table/", {"Ref": "AtomMakerTable"} ] ]
+                            }
+                        },
+                        {
+                            "Action": [ "dynamodb:*" ],
+                            "Effect": "Allow",
+                            "Resource": {
+                                "Fn::Join": ["", ["arn:aws:dynamodb:", {"Ref": "AWS::Region"}, ":", {"Ref": "AWS::AccountId"}, ":table/", {"Ref": "PublishedAtomMakerTable"} ] ]
                             }
                         }
                     ]

--- a/cloudformation/media-atoms-dynamo-code.json
+++ b/cloudformation/media-atoms-dynamo-code.json
@@ -5,6 +5,11 @@
             "Description": "Code dynamo table",
             "Type": "String",
             "Default": "media-atom-maker-CODE"
+        },
+        "PublishedAtomMakerCodeTable": {
+            "Description": "Published code dynamo table",
+            "Type": "String",
+            "Default": "published-media-atom-maker-CODE"
         }
     },
     "Resources": {
@@ -12,6 +17,28 @@
             "Type": "AWS::DynamoDB::Table",
             "Properties": {
                 "TableName": { "Ref": "AtomMakerCodeTable" },
+                "AttributeDefinitions": [
+                    {
+                        "AttributeName": "id",
+                        "AttributeType": "S"
+                    }
+                ],
+                "KeySchema": [
+                    {
+                        "AttributeName": "id",
+                        "KeyType": "HASH"
+                    }
+                ],
+                "ProvisionedThroughput": {
+                    "ReadCapacityUnits": "5",
+                    "WriteCapacityUnits": "5"
+                }
+            }
+        },
+        "PublishedMediaAtomMakerCode": {
+            "Type": "AWS::DynamoDB::Table",
+            "Properties": {
+                "TableName": { "Ref": "PublishedAtomMakerCodeTable" },
                 "AttributeDefinitions": [
                     {
                         "AttributeName": "id",

--- a/cloudformation/media-atoms-dynamo-prod.json
+++ b/cloudformation/media-atoms-dynamo-prod.json
@@ -5,6 +5,11 @@
             "Description": "Prod dynamo table",
             "Type": "String",
             "Default": "media-atom-maker-PROD"
+        },
+        "PublishedAtomMakerProdTable": {
+            "Description": "Published prod dynamo table",
+            "Type": "String",
+            "Default": "published-media-atom-maker-PROD"
         }
     },
     "Resources": {
@@ -12,6 +17,28 @@
             "Type": "AWS::DynamoDB::Table",
             "Properties": {
                 "TableName": { "Ref": "AtomMakerProdTable" },
+                "AttributeDefinitions": [
+                    {
+                        "AttributeName": "id",
+                        "AttributeType": "S"
+                    }
+                ],
+                "KeySchema": [
+                    {
+                        "AttributeName": "id",
+                        "KeyType": "HASH"
+                    }
+                ],
+                "ProvisionedThroughput": {
+                    "ReadCapacityUnits": "5",
+                    "WriteCapacityUnits": "5"
+                }
+            }
+        },
+        "PublishedMediaAtomMakerProd": {
+            "Type": "AWS::DynamoDB::Table",
+            "Properties": {
+                "TableName": { "Ref": "PublishedAtomMakerProdTable" },
                 "AttributeDefinitions": [
                     {
                         "AttributeName": "id",

--- a/conf/reference.conf
+++ b/conf/reference.conf
@@ -9,7 +9,8 @@ aws {
    kinesis {
         liveStreamName = "won't you fill me in"
         previewStreamName = "won't you fill me in"
-        reindexStreamName = "???"   # in mostcase this should be the same as liveStreamName
+        previewReindexStreamName = "???"   # in mostcase this should be the same as previewStreamName
+        publishedReindexStreamName = "???"   # in mostcase this should be the same as liveStreamName
    }
 
    dynamo {

--- a/conf/reference.conf
+++ b/conf/reference.conf
@@ -14,6 +14,7 @@ aws {
 
    dynamo {
         tableName = "???"
+        publishedTableName = "???"
    }
 }
 

--- a/conf/routes
+++ b/conf/routes
@@ -14,8 +14,10 @@ POST    /api/atom/:id/publish           controllers.Api.publishAtom(id)
 
 # reindex
 
-POST    /reindex                        com.gu.atom.play.ReindexController.newReindexJob()
-GET     /reindex                        com.gu.atom.play.ReindexController.reindexJobStatus()
+POST    /reindex-preview                com.gu.atom.play.ReindexController.newPreviewReindexJob()
+POST    /reindex-publish                com.gu.atom.play.ReindexController.newPublishedReindexJob()
+GET     /reindex-preview                com.gu.atom.play.ReindexController.previewReindexJobStatus()
+GET     /reindex-publish                com.gu.atom.play.ReindexController.publishedReindexJobStatus()
 
 #static assets
 GET  /assets/*file                      controllers.Assets.at(path="/public", file)

--- a/public/javascript/atom.js
+++ b/public/javascript/atom.js
@@ -5,6 +5,18 @@ window.AtomUtil = (function() {
     alert(err + ": " + xhr.responseText);
   }
 
+  ret.hidePublishInformation = function() {
+    $("#publishInfo").hide();
+    $("#hidePublish").hide();
+    $("#displayPublish").show()
+  };
+
+  ret.displayPublishInformation = function() {
+    $("#publishInfo").show();
+    $("#hidePublish").show();
+    $("#displayPublish").hide();
+  };
+
   ret.addAsset = function(atomId) {
     var uri = $("#urlInput").val();
     var mimeType = $("#mimeTypeInput").val();
@@ -78,4 +90,6 @@ window.AtomUtil = (function() {
 
 // INIT bits
 $(function () {
+    $("#hidePublish").hide();
+    $("#publishInfo").hide();
 });

--- a/public/stylesheets/atom-data.css
+++ b/public/stylesheets/atom-data.css
@@ -56,3 +56,7 @@ div.defaultHtmlSource {
     margin: 10px 0;
     max-width: 70%;
 }
+
+div#publishInfo {
+  background: lightgrey;
+  }


### PR DESCRIPTION
Saves published atoms to a separate dynamo table

This allows for reindexing to push atoms in the correct kinesis streams (preview/live)

It also allows for displaying published atom information on the client