### PR TITLE
wait for async call() to complete in AtomAPIActions test

### DIFF
--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
@@ -35,7 +35,8 @@ class AtomAPIActionsSpec extends AtomSuite with Inside {
     "update publish time for atom" in AtomTestConf() { implicit conf =>
       val startTime = (new Date()).getTime()
       val atomCaptor = ArgumentCaptor.forClass(classOf[Atom])
-      call(apiActions.publishAtom("1"), FakeRequest())
+      val result = call(apiActions.publishAtom("1"), FakeRequest())
+      status(result) mustEqual NO_CONTENT
       verify(conf.dataStore).updateAtom(atomCaptor.capture())
       inside(atomCaptor.getValue()) {
         case Atom("1", _, _, _, _, changeDetails, _) =>


### PR DESCRIPTION
without this fix there is a race condition, that if you check for interactions before waiting for the api call to complete, you have random test failures if the check happens before the completion.