### PR TITLE
remove version from play lib build.sbt

### DIFF
--- a/atom-manager-play-lib/build.sbt
+++ b/atom-manager-play-lib/build.sbt
@@ -6,8 +6,6 @@ lazy val AwsSdkVersion = "1.11.8"
 
 name := "atom-manager-play"
 
-version := "1.0.0-SNAPSHOT"
-
 libraryDependencies ++= Seq(
   "com.typesafe.play"      %% "play"                  % playVersion,
   "com.gu"                 %% "content-atom-model"    % contentAtomVersion,


### PR DESCRIPTION
Removes the version from play library build.sbt so that the version stays in sync with publisher.