### PR TITLE
Remove server side activeAsset Incrementing

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -75,21 +75,14 @@ class Api @Inject() (val previewDataStore: PreviewDataStore,
     val updatedData = req.body.tdata
     previewDataStore.getAtom(atomId) match {
       case Some(atom) =>
-        val newVersion = {
-          val maxVersion = {
-            val activeVersion = atom.tdata.activeVersion
-            val assetVersions = atom.tdata.assets.map(_.version)
-            val versions = activeVersion.map(assetVersions.+:(_)) getOrElse assetVersions
-            if (versions.isEmpty) 0
-            else versions.max
-          }
-          maxVersion + 1
-        }
+
+        val activeVersion = atom.tdata.activeVersion.getOrElse(atom.tdata.assets.map(_.version).max)
+
         val newAtom = atom
                       .withRevision(_ + 1)
                       .updateData { media =>
                         media.copy(
-                          activeVersion = Some(newVersion),
+                          activeVersion = Some(activeVersion),
                           title = updatedData.title,
                           category = updatedData.category,
                           duration = updatedData.duration,

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -76,7 +76,10 @@ class Api @Inject() (val previewDataStore: PreviewDataStore,
     previewDataStore.getAtom(atomId) match {
       case Some(atom) =>
 
-        val activeVersion = atom.tdata.activeVersion.getOrElse(atom.tdata.assets.map(_.version).max)
+        val activeVersion = atom.tdata.activeVersion getOrElse {
+          val versions = atom.tdata.assets.map(_.version)
+          if (versions.isEmpty) 1 else versions.max
+        }
 
         val newAtom = atom
                       .withRevision(_ + 1)


### PR DESCRIPTION
This fixes the unpredictable activeAsset version when clicking save. It will either use the value supplied from the client, or default to the highest version in the improbable case it doesn't have an active asset.

@kelvin-chappell @steppenwells 