### PR TITLE
add modestbranding param to youtube embeds

### DIFF
--- a/app/views/MediaAtom/embedYoutubeAsset.scala.html
+++ b/app/views/MediaAtom/embedYoutubeAsset.scala.html
@@ -1,6 +1,6 @@
 @import com.gu.contentatom.thrift.atom.media.Asset
 @(asset: Asset)
 <iframe width="420" height="315"
-        src="https://www.youtube.com/embed/@asset.id" frameborder="0"
+        src="https://www.youtube.com/embed/@asset.id?modestbranding=1" frameborder="0"
         allowfullscreen="">
 </iframe>


### PR DESCRIPTION
Add [modest branding](https://developers.google.com/youtube/player_parameters#modestbranding) param to youtube embed. This is a requirement of YouTube PFP.
CC @akash1810 @Reettaphant 