### PR TITLE
Embed URL

### DIFF
--- a/public/javascript/atom/atom.html
+++ b/public/javascript/atom/atom.html
@@ -23,7 +23,7 @@
         </div>
             <label ng-if="publishedAtom" for="embedUrl">Embed URL:</label>
             <div id="embed-url" ng-if="publishedAtom && !publishedNotPreview">
-                <textarea class="form-control embed-url" rows="1" readonly id="embedUrl">{{embedUrl}}</textarea>
+                <textarea class="form-control embed-url" rows="2" readonly id="embedUrl">{{embedUrl}}</textarea>
             </div>
             <div ng-if="!publishedAtom" class=small>Because this atom has not yet been published, the capi link cannot be embedded to composer</div>
 

--- a/public/javascript/atom/atom.html
+++ b/public/javascript/atom/atom.html
@@ -13,11 +13,7 @@
 
             <label for="embedLink">Link to capi:</label>
             <div id="embed-link">
-            <a
-                    href="{{linkToCapi}}"
-                    type="text"
-                    id="embedLink"
-            >
+            <a ng-href="{{linkToCapi}}" type="text" id="embedLink">
                 {{embedLink}}
             </a>
         </div>

--- a/public/javascript/atom/atom.html
+++ b/public/javascript/atom/atom.html
@@ -11,7 +11,7 @@
         <div class="col-md-6 asset-data">
             <h1 class="atom-section" id="section">Atom Data</h1>
 
-            <label ng-if="!publishedAtom" for="embedUrl">Link to capi:</label>
+            <label for="embedUrl">Link to capi:</label>
             <div id="embed-link">
             <a
                     href="{{linkToCapi}}"

--- a/public/javascript/atom/atom.html
+++ b/public/javascript/atom/atom.html
@@ -11,7 +11,7 @@
         <div class="col-md-6 asset-data">
             <h1 class="atom-section" id="section">Atom Data</h1>
 
-            <label for="embedUrl">Link to capi:</label>
+            <label for="embedLink">Link to capi:</label>
             <div id="embed-link">
             <a
                     href="{{linkToCapi}}"

--- a/public/javascript/atom/atom.html
+++ b/public/javascript/atom/atom.html
@@ -11,16 +11,19 @@
         <div class="col-md-6 asset-data">
             <h1 class="atom-section" id="section">Atom Data</h1>
 
-            <label ng-if="!publishedAtom" for="embedLink">Link to capi:</label>
-            <label ng-if="publishedAtom" for="embedLink">Embed link:</label>
+            <label ng-if="!publishedAtom" for="embedUrl">Link to capi:</label>
             <div id="embed-link">
-                <a
+            <a
                     href="{{linkToCapi}}"
                     type="text"
                     id="embedLink"
-                >
-                    {{embedLink}}
-                </a>
+            >
+                {{embedLink}}
+            </a>
+        </div>
+            <label ng-if="publishedAtom" for="embedUrl">Embed URL:</label>
+            <div id="embed-url" ng-if="publishedAtom && !publishedNotPreview">
+                <textarea class="form-control embed-url" rows="1" readonly id="embedUrl">{{embedUrl}}</textarea>
             </div>
             <div ng-if="!publishedAtom" class=small>Because this atom has not yet been published, the capi link cannot be embedded to composer</div>
 

--- a/public/javascript/atom/atomController.js
+++ b/public/javascript/atom/atomController.js
@@ -124,15 +124,18 @@ mediaAtomApp.controller('AtomCtrl', ['$scope', '$http', '$routeParams', '$httpPa
         if ($scope.config && $scope.config.stage === 'PROD') {
             if ($scope.publishedAtom) {
                 $scope.linkToCapi = appConfig.prodLiveUrl + $scope.embedLink + appConfig.capiApiKey;
+                $scope.embedUrl = appConfig.prodLiveUrl + $scope.embedLink;
             } else {
                 $scope.linkToCapi = appConfig.prodPreviewUrl + $scope.embedLink + appConfig.capiApiKey;
+                $scope.embedUrl = appConfig.prodPreviewUrl + $scope.embedLink;
             }
         } else {
             if ($scope.publishedAtom) {
                 $scope.linkToCapi = appConfig.codeLiveUrl + $scope.embedLink + appConfig.capiApiKey;
+                $scope.embedUrl = appConfig.codeLiveUrl + $scope.embedLink;
             } else {
                 $scope.linkToCapi = appConfig.codePreviewUrl + $scope.embedLink + appConfig.capiApiKey;
-
+                $scope.embedUrl = appConfig.codePreviewUrl + $scope.embedLink;
             }
         }
     }

--- a/public/javascript/atom/published-atom-detail.html
+++ b/public/javascript/atom/published-atom-detail.html
@@ -2,6 +2,12 @@
     <label for="atomTitle">Title:</label>
     <input type="text" class="form-control" id="atomTitle" ng-model="publishedAtom.title" required readonly>
 </div>
+
+<div class="form-group">
+<label for="embedUrl">Embed URL:</label>
+    <textarea class="form-control embed-url" rows="1" readonly id="embedUrl">{{embedUrl}}</textarea>
+</div>
+
 <div class="form-group">
     <label for="atomCategory">Category:</label>
     <input type="text" class="form-control" id="atomCategory" ng-model="publishedAtom.category" required readonly>

--- a/public/stylesheets/atom-data.css
+++ b/public/stylesheets/atom-data.css
@@ -7,6 +7,9 @@ td {
     border: 1px solid black;
 }
 
+textarea.embed-url {
+    resize: none;
+}
 
 button.paddedButton {
     margin-bottom: 3px;


### PR DESCRIPTION
Add Embed URL `<textarea>` to published atoms. This is useful as the link URL fails in Composer because it includes an API key.

CC @Reettaphant @akash1810 
<img width="622" alt="screen shot 2016-09-26 at 10 27 26" src="https://cloud.githubusercontent.com/assets/1764158/18829414/093b639a-83d4-11e6-9b19-cc6fa920ddde.png">
