### PR TITLE
Instance type change

### DIFF
--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -350,7 +350,7 @@
                     "Ref": "MediaAtomLaunchConfig"
                 },
                 "MinSize": { "Fn::FindInMap": [ "StageMap", {"Ref": "Stage"}, "MinSize"]},
-                "MaxSize": { "Fn::FindInMap": [ "StageMap", {"Ref": "Stage"}, "MaxSize"]},,
+                "MaxSize": { "Fn::FindInMap": [ "StageMap", {"Ref": "Stage"}, "MaxSize"]},
                 "DesiredCapacity": { "Fn::FindInMap": [ "StageMap", {"Ref": "Stage"}, "DesiredCapacity"]},
                 "Cooldown": "180",
                 "HealthCheckType": "ELB",

--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -53,6 +53,23 @@
             "Type": "String"
         }
     },
+    "Mappings": {
+        "StageMap": {
+            "PROD": {
+                "MinSize": 1,
+                "MaxSize": 2,
+                "DesiredCapacity": 1,
+                "InstanceType": "t2.medium"
+            },
+            "CODE": {
+                "MinSize": 1,
+                "MaxSize": 2,
+                "DesiredCapacity": 1,
+                "InstanceType": "t2.small"
+            }
+        }
+    },
+    
     "Resources": {
         "MediaMakerInstanceProfile": {
             "Type": "AWS::IAM::InstanceProfile",
@@ -278,7 +295,7 @@
                         ]
                     }
                 ],
-                "InstanceType": "m3.medium",
+                "InstanceType": { "Fn::FindInMap": [ "StageMap", {"Ref": "Stage"}, "InstanceType"]},
                 "IamInstanceProfile": {
                     "Ref": "MediaMakerInstanceProfile"
                 },
@@ -332,9 +349,9 @@
                 "LaunchConfigurationName": {
                     "Ref": "MediaAtomLaunchConfig"
                 },
-                "MinSize": 1,
-                "MaxSize": 2,
-                "DesiredCapacity": 1,
+                "MinSize": { "Fn::FindInMap": [ "StageMap", {"Ref": "Stage"}, "MinSize"]},
+                "MaxSize": { "Fn::FindInMap": [ "StageMap", {"Ref": "Stage"}, "MaxSize"]},,
+                "DesiredCapacity": { "Fn::FindInMap": [ "StageMap", {"Ref": "Stage"}, "DesiredCapacity"]},
                 "Cooldown": "180",
                 "HealthCheckType": "ELB",
                 "HealthCheckGracePeriod": 300,


### PR DESCRIPTION
As discussed moved instance type from m3.medium to t2.medium for Prod and  t2.small for Code.

While I was here I though it would be good to separate the min, max and desired capacity so that we can tweak them when we're ready for youtube etc.

cc @paulmr @clloyd 