### PR TITLE
Add video search

### DIFF
--- a/public/video-ui/src/actions/SearchActions/updateSearchTerm.js
+++ b/public/video-ui/src/actions/SearchActions/updateSearchTerm.js
@@ -1,0 +1,7 @@
+export function updateSearchTerm(searchTerm) {
+  return {
+    type: 'UPDATE_SEARCH_TERM',
+    searchTerm: searchTerm,
+    receivedAt: Date.now()
+  };
+}

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Link, IndexLink} from 'react-router';
+import VideoSearch from './VideoSearch/VideoSearch';
 
 export default class Header extends React.Component {
   constructor(props) {
@@ -16,8 +17,9 @@ export default class Header extends React.Component {
             </Link>
           </div>
 
-          <div className="topbar__container">
+          <VideoSearch {...this.props}/>
 
+          <div className="topbar__container">
             <nav className="topbar__nav">
               <Link activeClassName="topbar__nav-link--active" className="topbar__nav-link" to="/video/videos/create">Create new video</Link>
             </nav>

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -3,9 +3,6 @@ import {Link, IndexLink} from 'react-router';
 import VideoSearch from './VideoSearch/VideoSearch';
 
 export default class Header extends React.Component {
-  constructor(props) {
-    super(props);
-  }
 
   render () {
     return (

--- a/public/video-ui/src/components/ReactApp.js
+++ b/public/video-ui/src/components/ReactApp.js
@@ -2,15 +2,19 @@ import React from 'react';
 
 import Header from './Header';
 
-export default class ReactApp extends React.Component {
+class ReactApp extends React.Component {
   constructor(props) {
     super(props);
+  }
+
+  updateSearchTerm = (searchTerm) => {
+    this.props.updateSearchTermActions.updateSearchTerm(searchTerm);
   }
 
   render() {
     return (
         <div className="wrap">
-          <Header/>
+          <Header updateSearchTerm={this.updateSearchTerm} searchTerm={this.props.searchTerm} />
           <div>
             {this.props.children}
           </div>
@@ -18,3 +22,22 @@ export default class ReactApp extends React.Component {
     );
   }
 }
+
+//REDUX CONNECTIONS
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import * as updateSearchTerm from '../actions/SearchActions/updateSearchTerm';
+
+function mapStateToProps(state) {
+  return {
+    searchTerm: state.searchTerm
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    updateSearchTermActions: bindActionCreators(Object.assign({}, updateSearchTerm), dispatch)
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ReactApp)

--- a/public/video-ui/src/components/VideoSearch/VideoSearch.js
+++ b/public/video-ui/src/components/VideoSearch/VideoSearch.js
@@ -2,10 +2,6 @@ import React from 'react'
 
 export default class VideoSearch extends React.Component {
 
-  constructor(props) {
-    super(props)
-  }
-
   onSearch = (e) => {
     this.props.updateSearchTerm(e.target.value);
   };

--- a/public/video-ui/src/components/VideoSearch/VideoSearch.js
+++ b/public/video-ui/src/components/VideoSearch/VideoSearch.js
@@ -14,7 +14,7 @@ export default class VideoSearch extends React.Component {
     return (
       <form className="form">
         <div className="form__row">
-          <input className="form__field" type="text" value={this.props.searchTerm || ''} onChange={this.onSearch} />
+          <input className="form__field" type="text" value={this.props.searchTerm || ''} onChange={this.onSearch} placeholder={"Search for videos..."} />
         </div>
       </form>
     )

--- a/public/video-ui/src/components/VideoSearch/VideoSearch.js
+++ b/public/video-ui/src/components/VideoSearch/VideoSearch.js
@@ -1,0 +1,23 @@
+import React from 'react'
+
+export default class VideoSearch extends React.Component {
+
+  constructor(props) {
+    super(props)
+  }
+
+  onSearch = (e) => {
+    console.log("Here");
+    this.props.updateSearchTerm(e.target.value);
+  };
+
+  render () {
+    return (
+      <form className="form">
+        <div className="form__row">
+          <input className="form__field" type="text" value={this.props.searchTerm || ''} onChange={this.onSearch} />
+        </div>
+      </form>
+    )
+  }
+}

--- a/public/video-ui/src/components/VideoSearch/VideoSearch.js
+++ b/public/video-ui/src/components/VideoSearch/VideoSearch.js
@@ -7,7 +7,6 @@ export default class VideoSearch extends React.Component {
   }
 
   onSearch = (e) => {
-    console.log("Here");
     this.props.updateSearchTerm(e.target.value);
   };
 

--- a/public/video-ui/src/components/Videos/Videos.js
+++ b/public/video-ui/src/components/Videos/Videos.js
@@ -23,9 +23,15 @@ class Videos extends React.Component {
     }
   }
 
+  searchFilter = (value) => {
+    const title = value.data.title.toLowerCase();
+    const searchTerm = this.props.searchTerm.toLowerCase();
+    return title.includes(searchTerm);
+  }
+
   renderListItems() {
     return (
-        this.props.videos.map((video) => <VideoItem key={video.id} video={video} />)
+        this.props.videos.filter(this.searchFilter).map((video) => <VideoItem key={video.id} video={video} />)
     );
   }
 
@@ -49,7 +55,8 @@ import * as getVideos from '../../actions/VideoActions/getVideos';
 
 function mapStateToProps(state) {
   return {
-    videos: state.videos
+    videos: state.videos,
+    searchTerm: state.searchTerm
   };
 }
 

--- a/public/video-ui/src/reducers/rootReducer.js
+++ b/public/video-ui/src/reducers/rootReducer.js
@@ -2,10 +2,12 @@ import { combineReducers } from 'redux';
 import error from './errorReducer';
 import video from './videoReducer';
 import videos from './videosReducer';
+import searchTerm from './searchTermReducer';
 
 
 export default combineReducers({
   error,
   video,
-  videos
+  videos,
+  searchTerm
 });

--- a/public/video-ui/src/reducers/searchTermReducer.js
+++ b/public/video-ui/src/reducers/searchTermReducer.js
@@ -1,0 +1,8 @@
+export default function searchTerm(state = "", action) {
+  switch (action.type) {
+    case 'UPDATE_SEARCH_TERM':
+      return action.searchTerm || "";
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
![videofilter](https://cloud.githubusercontent.com/assets/6666113/19857230/de6e959e-9f74-11e6-8b80-79e90b235344.gif)

Adds a search bar to allow filtering by title. Currently it looks ugly as all the beautiful style is in @ShaunYearStrong's pr https://github.com/guardian/media-atom-maker/pull/71 but the correct classes are being used for the style to be consistent after the merge.