### PR TITLE
Bug Fix: Add more appropriate default data for creating a video.

### DIFF
--- a/public/video-ui/src/actions/VideoActions/createVideo.js
+++ b/public/video-ui/src/actions/VideoActions/createVideo.js
@@ -1,12 +1,6 @@
 import { browserHistory } from 'react-router';
 import VideosApi from '../../services/VideosApi';
-
-const BLANK_VIDEO = {
-  data: {
-    title: '',
-    category: ''
-  }
-};
+import {blankVideoData} from '../../constants/blankVideoData';
 
 function requestVideoCreate() {
   return {
@@ -46,7 +40,7 @@ export function createVideo(video) {
 export function populateEmptyVideo() {
   return {
     type:        'VIDEO_POPULATE_BLANK',
-    video:       Object.assign({}, BLANK_VIDEO, {
+    video:       Object.assign({}, blankVideoData, {
       type: 'media'
     }),
     receivedAt:  Date.now()

--- a/public/video-ui/src/components/Video/Create.js
+++ b/public/video-ui/src/components/Video/Create.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import VideoEdit from '../VideoEdit/VideoEdit';
 import SaveButton from '../utils/SaveButton';
+import {blankVideoData} from '../../constants/blankVideoData';
 
 class VideoCreate extends React.Component {
 
@@ -21,17 +22,10 @@ class VideoCreate extends React.Component {
   };
 
   render () {
-    const defaultVideoData = {
-      data: {
-        title: '',
-        category: ''
-      }
-    }
-
     return (
       <div className="container">
         <form className="form">
-          <VideoEdit video={this.props.video || defaultVideoData} updateVideo={this.updateVideo} />
+          <VideoEdit video={this.props.video || blankVideoData} updateVideo={this.updateVideo} />
           <SaveButton onSaveClick={this.createVideo} />
         </form>
       </div>

--- a/public/video-ui/src/components/Video/Create.js
+++ b/public/video-ui/src/components/Video/Create.js
@@ -21,10 +21,17 @@ class VideoCreate extends React.Component {
   };
 
   render () {
+    const defaultVideoData = {
+      data: {
+        title: '',
+        category: ''
+      }
+    }
+
     return (
       <div className="container">
         <form className="form">
-          <VideoEdit video={this.props.video || {}} updateVideo={this.updateVideo} />
+          <VideoEdit video={this.props.video || defaultVideoData} updateVideo={this.updateVideo} />
           <SaveButton onSaveClick={this.createVideo} />
         </form>
       </div>

--- a/public/video-ui/src/constants/blankVideoData.js
+++ b/public/video-ui/src/constants/blankVideoData.js
@@ -1,0 +1,6 @@
+export const blankVideoData = {
+  data: {
+    title: '',
+    category: ''
+  }
+};


### PR DESCRIPTION
Problem: The create video page was not rendering

Cause: The page would first try to render with `this.props.video = {}` as the blank video default data was only assigned to this.props.video after the component mounts. This caused issues as there were references to `this.props.video.data.title` in sub components of the create component.

Fix: The default is now 
``` 
this.props.video = {      
    data: {
           title: '',
           category: ''
    }
}
```