### PR TITLE
Add CAPI usages check

### DIFF
--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -1,0 +1,47 @@
+package controllers
+
+import javax.inject._
+
+import com.gu.pandahmac.HMACAuthActions
+import com.squareup.okhttp.{OkHttpClient, Credentials, Request}
+import java.util.concurrent.TimeUnit
+import play.api.Configuration
+
+
+class Support @Inject() (val authActions: HMACAuthActions,
+                                  val conf: Configuration) extends AtomController {
+
+  import authActions.APIAuthAction
+
+  def previewCapiProxy(path: String) = APIAuthAction { request =>
+    val httpClient = new OkHttpClient()
+    httpClient.setConnectTimeout(5, TimeUnit.SECONDS)
+
+    val resp = for {
+      capiPreviewUser <- conf.getString("capi.previewUser")
+      capiPreviewPassword <- conf.getString("capi.previewPassword")
+      capiUrl <- conf.getString("capi.previewUrl")
+    } yield {
+      val url = s"$capiUrl/$path?${request.rawQueryString}"
+
+      val req = new Request.Builder()
+        .url(url)
+        .header("Authorization", Credentials.basic(capiPreviewUser, capiPreviewPassword))
+        .build
+
+      httpClient.newCall(req).execute
+    }
+
+    resp match {
+      case None => {
+        InternalServerError("Could not construct CAPI request")
+      }
+      case Some(r) if r.code() == 200 => {
+        Ok(r.body.string).as(JSON)
+      }
+      case Some(r) => {
+        BadRequest(s"CAPI returned status: ${r.code()}")
+      }
+    }
+  }
+}

--- a/app/controllers/VideoUIApp.scala
+++ b/app/controllers/VideoUIApp.scala
@@ -23,7 +23,8 @@ class VideoUIApp @Inject() (val authActions: HMACAuthActions)
       youtubeEmbedUrl = "https://www.youtube.com/embed/",
       youtubeThumbnailUrl = "https://img.youtube.com/vi/",
       reauthUrl = "/reauth",
-      gridUrl = "https://media.gutools.co.uk"
+      gridUrl = "https://media.gutools.co.uk",
+      capiProxyUrl = "/support/previewCapi"
     )
 
     Ok(views.html.VideoUIApp.app("Media Atom Maker", jsLocation, Json.toJson(clientConfig).toString()))

--- a/app/model/ClientConfig.scala
+++ b/app/model/ClientConfig.scala
@@ -9,7 +9,8 @@ case class ClientConfig(username: String,
                         youtubeEmbedUrl: String,
                         youtubeThumbnailUrl: String,
                         reauthUrl: String,
-                        gridUrl: String
+                        gridUrl: String,
+                        capiProxyUrl: String
                        )
 
 object ClientConfig {

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,9 @@ libraryDependencies ++= Seq(
   "org.mockito"                %  "mockito-core"                 % mockitoVersion % "test",
   "org.scala-lang.modules"     %% "scala-xml"                    % "1.0.5"   % "test",
   "com.google.api-client"      %  "google-api-client"            % "1.22.0",
-  "com.google.apis"            % "google-api-services-youtube"   % "v3-rev178-1.22.0"
+  "com.google.apis"            % "google-api-services-youtube"   % "v3-rev178-1.22.0",
+  "com.squareup.okhttp"        % "okhttp"                        % "2.4.0"
+
 ) ++ scanamoDeps
 
 lazy val appDistSettings = Seq(

--- a/conf/routes
+++ b/conf/routes
@@ -35,3 +35,6 @@ GET  /reauth                            controllers.VideoUIApp.reauth
 GET /video                              controllers.VideoUIApp.index(id = "")
 GET /video/videos                       controllers.VideoUIApp.index(id = "")
 GET /video/videos/:id                   controllers.VideoUIApp.index(id)
+
+#Support
+GET /support/previewCapi/*path          controllers.Support.previewCapiProxy(path: String)

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -3,7 +3,9 @@ import VideoEdit from '../VideoEdit/VideoEdit';
 import VideoAssets from '../VideoAssets/VideoAssets';
 import VideoDetails from '../VideoDetails/VideoDetails';
 import VideoPreview from '../VideoPreview/VideoPreview';
+import VideoUsages from '../VideoUsages/VideoUsages';
 import SaveButton from '../utils/SaveButton';
+
 
 class VideoDisplay extends React.Component {
 
@@ -64,10 +66,12 @@ class VideoDisplay extends React.Component {
         <div className="video">
           {this.renderDetails()}
           <div className="video__main">
-            <VideoPreview video={this.props.video || {}} />
-            <VideoAssets video={this.props.video || {}} />
+            <div className="video__main__header">
+              <VideoPreview video={this.props.video || {}} />
+              <VideoAssets video={this.props.video || {}} />
+            </div>
+            <VideoUsages video={this.props.video} />
           </div>
-
         </div>
     )
   }

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -50,12 +50,6 @@ class VideoUsages extends React.Component {
 
   renderUsages() {
 
-    const fakeUsages = [
-      'technology/2016/oct/21/unlaunched-test-article',
-      'technology/2016/oct/14/testing-witness-embed',
-      'technology/2013/sep/18/ios-7-review-can-apple-hold-off-the-attack-of-the-giant-screens',
-    ];
-
     if (!this.state.usages) {
       return (<div>Fetching Usages...</div>)
     }
@@ -66,7 +60,7 @@ class VideoUsages extends React.Component {
 
     return (
       <ul className="usages__list">
-        {fakeUsages.map(this.renderUsage)}
+        {this.state.usages.map(this.renderUsage)}
       </ul>
     )
   }

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import {fetchUsages} from '../../services/capi';
+
+class VideoUsages extends React.Component {
+
+  state = {
+    usages: undefined
+  }
+
+  updateUsages(videoId) {
+
+    if (!videoId) {
+      return this.setState({
+        usages: undefined
+      });
+    }
+
+    fetchUsages(videoId).then((resp) => {
+
+      const usages = resp.response.results;
+
+      this.setState({
+        usages: usages
+      });
+    });
+  }
+
+  componentDidMount() {
+    if (this.props.video) {
+      this.updateUsages(this.props.video.id);
+    }
+  }
+
+  componentWillReceiveProps(newProps) {
+    const oldVidId = this.props.video && this.props.video.id;
+    const newVidId = newProps.video && newProps.video.id;
+
+    if (oldVidId === newVidId) {
+      this.updateUsages(newVidId);
+    }
+  }
+
+  renderUsage(usage) {
+    return (
+      <li className="usages__list__item">
+        {usage}
+      </li>
+    )
+  }
+
+  renderUsages() {
+
+    const fakeUsages = [
+      'technology/2016/oct/21/unlaunched-test-article',
+      'technology/2016/oct/14/testing-witness-embed',
+      'technology/2013/sep/18/ios-7-review-can-apple-hold-off-the-attack-of-the-giant-screens',
+    ];
+
+    if (!this.state.usages) {
+      return (<div>Fetching Usages...</div>)
+    }
+
+    if (!this.state.usages.length) {
+      return (<div>No usages found</div>)
+    }
+
+    return (
+      <ul className="usages__list">
+        {fakeUsages.map(this.renderUsage)}
+      </ul>
+    )
+  }
+
+  render() {
+
+
+    if (!this.props.video) {
+      return false;
+    }
+
+    return (
+      <div className="usages">
+        <h1>Usages</h1>
+        {this.renderUsages()}
+      </div>
+    );
+  }
+
+}
+
+export default VideoUsages;

--- a/public/video-ui/src/services/capi.js
+++ b/public/video-ui/src/services/capi.js
@@ -1,0 +1,11 @@
+import {pandaReqwest} from './pandaReqwest';
+import {getStore} from '../util/storeAccessor';
+
+export function fetchUsages(videoId) {
+  
+  const capiProxyUrl = getStore().getState().config.capiProxyUrl;
+  return pandaReqwest({
+    url: capiProxyUrl + "/atom/media/" + videoId + "/usage",
+    method: 'get',
+  })
+}

--- a/public/video-ui/styles/components/_usages.scss
+++ b/public/video-ui/styles/components/_usages.scss
@@ -1,0 +1,3 @@
+.usages {
+  display: block;
+}

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -27,8 +27,10 @@
   color: $color700Grey;
   padding: 20px 30px;
 
-  display: flex;
-
+  &__header {
+    display: flex;
+    margin-bottom: 20px;
+  }
 }
 
 .video-preview {

--- a/public/video-ui/styles/main.scss
+++ b/public/video-ui/styles/main.scss
@@ -29,5 +29,5 @@
   'components/details-list',
   'components/asset-list',
   'components/modal',
-  'components/grid-embedder';
-
+  'components/grid-embedder',
+  'components/usages';


### PR DESCRIPTION
<img width="1505" alt="screen shot 2016-11-17 at 16 23 48" src="https://cloud.githubusercontent.com/assets/551573/20397770/e489e6e2-ace2-11e6-9587-1efc558b8821.png">

This adds an (unstyled) check for video usage in other content. There is a new `VideoUsages` component which makes use of a CAPI proxy to access preview CAPI (`/support/capiPreview/`). This requires a key and username for capi preview in configuration