### PR TITLE
Add Youtube Channels endpoint

### DIFF
--- a/app/controllers/Youtube.scala
+++ b/app/controllers/Youtube.scala
@@ -4,14 +4,19 @@ import javax.inject._
 
 import com.gu.pandahmac.HMACAuthActions
 import play.api.libs.json.Json
-import util.{YouTubeConfig, YouTubeVideoCategoryApi}
+import util.{YouTubeChannelsApi, YouTubeConfig, YouTubeVideoCategoryApi}
 
-class YoutubeCategory @Inject() (val authActions: HMACAuthActions,
+class Youtube @Inject() (val authActions: HMACAuthActions,
                                  val youtubeConfig: YouTubeConfig) extends AtomController {
   import authActions.AuthAction
 
-  def list() = AuthAction {
+  def listCategories() = AuthAction {
     val categories = YouTubeVideoCategoryApi(youtubeConfig).list
     Ok(Json.toJson(categories))
+  }
+
+  def listChannels() = AuthAction {
+    val channels = YouTubeChannelsApi(youtubeConfig).fetchMyChannels()
+    Ok(Json.toJson(channels))
   }
 }

--- a/app/model/YouTubeChannel.scala
+++ b/app/model/YouTubeChannel.scala
@@ -1,0 +1,24 @@
+package model
+
+import com.google.api.services.youtube.model.Channel
+import play.api.libs.json._
+
+case class YouTubeChannel(
+                           name: String,
+                           logo: String,
+                           id: String
+                          )
+
+object YouTubeChannel {
+  implicit val reads: Reads[YouTubeChannel] = Json.reads[YouTubeChannel]
+  implicit val writes: Writes[YouTubeChannel] = Json.writes[YouTubeChannel]
+
+  def build(channel: Channel): YouTubeChannel = {
+
+    YouTubeChannel(
+      name = channel.getSnippet().getTitle(),
+      logo = channel.getSnippet().getThumbnails().getDefault().getUrl(),
+      id = channel.getId
+    )
+  }
+}

--- a/app/model/YouTubeChannel.scala
+++ b/app/model/YouTubeChannel.scala
@@ -3,11 +3,7 @@ package model
 import com.google.api.services.youtube.model.Channel
 import play.api.libs.json._
 
-case class YouTubeChannel(
-                           name: String,
-                           logo: String,
-                           id: String
-                          )
+case class YouTubeChannel(name: String, logo: String, id: String)
 
 object YouTubeChannel {
   implicit val reads: Reads[YouTubeChannel] = Json.reads[YouTubeChannel]

--- a/app/model/YouTubeChannel.scala
+++ b/app/model/YouTubeChannel.scala
@@ -2,18 +2,29 @@ package model
 
 import com.google.api.services.youtube.model.Channel
 import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import java.net.URI
 
-case class YouTubeChannel(name: String, logo: String, id: String)
+case class YouTubeChannel(name: String, logo: URI, id: String)
 
 object YouTubeChannel {
-  implicit val reads: Reads[YouTubeChannel] = Json.reads[YouTubeChannel]
-  implicit val writes: Writes[YouTubeChannel] = Json.writes[YouTubeChannel]
+  implicit val reads: Reads[YouTubeChannel] = (
+    (__ \ "name").read[String] ~
+    (__ \ "logo").read[String].map(URI.create) ~
+    (__ \ "id").read[String]
+    )(YouTubeChannel.apply _)
+
+  implicit val writes: Writes[YouTubeChannel] = (
+    (__ \ "name").write[String] ~
+    (__ \ "logo").write[String].contramap((_: URI).toString) ~
+    (__ \ "id").write[String]
+    )(unlift(YouTubeChannel.unapply))
 
   def build(channel: Channel): YouTubeChannel = {
 
     YouTubeChannel(
       name = channel.getSnippet().getTitle(),
-      logo = channel.getSnippet().getThumbnails().getDefault().getUrl(),
+      logo = URI.create(channel.getSnippet().getThumbnails().getDefault().getUrl()),
       id = channel.getId
     )
   }

--- a/app/util/Youtube.scala
+++ b/app/util/Youtube.scala
@@ -7,7 +7,7 @@ import com.google.api.client.http.javanet.NetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.youtube.YouTube
 import com.google.api.services.youtube.model.Video
-import model.{UpdatedMetadata, YouTubeVideoCategory}
+import model.{UpdatedMetadata, YouTubeVideoCategory, YouTubeChannel}
 import play.api.Configuration
 
 import scala.collection.JavaConverters._
@@ -78,4 +78,16 @@ case class YouTubeVideoUpdateApi(config: YouTubeConfig) extends YouTubeBuilder {
         Some(youtube.videos().update("snippet, status", video).setOnBehalfOfContentOwner(onBehalfOfContentOwner).execute())
       case _ => None
     }
+}
+
+case class YouTubeChannelsApi(config: YouTubeConfig) extends YouTubeBuilder {
+  def fetchMyChannels(): List[YouTubeChannel] = {
+    val request = youtube.channels()
+      .list("snippet")
+      .setMaxResults(50L)
+      .setManagedByMe(true)
+      .setOnBehalfOfContentOwner(config.contentOwner)
+
+    request.execute().getItems.asScala.toList.map(YouTubeChannel.build).sortBy(_.name)
+  }
 }

--- a/app/util/Youtube.scala
+++ b/app/util/Youtube.scala
@@ -20,6 +20,7 @@ class YouTubeConfig @Inject()(config: Configuration) {
   lazy val clientSecret = config.getString("youtube.clientSecret").getOrElse("")
   lazy val refreshToken = config.getString("youtube.refreshToken").getOrElse("")
   lazy val contentOwner = config.getString("youtube.contentOwner").getOrElse("")
+  lazy val allowedChannels = config.getStringList("youtube.allowedChannels")
 }
 
 trait YouTubeBuilder {
@@ -88,6 +89,12 @@ case class YouTubeChannelsApi(config: YouTubeConfig) extends YouTubeBuilder {
       .setManagedByMe(true)
       .setOnBehalfOfContentOwner(config.contentOwner)
 
-    request.execute().getItems.asScala.toList.map(YouTubeChannel.build).sortBy(_.name)
+    val allChannels = request.execute().getItems.asScala.toList.map(YouTubeChannel.build).sortBy(_.name)
+
+    config.allowedChannels match {
+      case None => allChannels
+      case Some(allowedList) => allChannels.filter(c => allowedList.contains(c.id))
+    }
+
   }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -17,7 +17,9 @@ GET     /api2/atom/:id                  controllers.Api2.getAtom(id)
 PUT     /api2/atom/:id/asset            controllers.Api2.addAsset(id)
 PUT     /api/atom/:id/updateMetadata    controllers.Api2.updateMetadata(id)
 
-GET     /api/youtube/categories         controllers.YoutubeCategory.list()
+GET     /api/youtube/categories         controllers.Youtube.listCategories()
+GET     /api/youtube/channels           controllers.Youtube.listChannels()
+
 
 # reindex
 


### PR DESCRIPTION
Adds a `/api/youtube/channels` list endpoint, also generalises the YoutubeCategories controller to be a general YouTube controller.