### PR TITLE
update privacy status

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -55,7 +55,9 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
   def createMediaAtom = APIHMACAuthAction { implicit req =>
     req.body.asJson.map { json =>
       try {
-        val atom = CreateAtomCommand(json.as[CreateAtomCommandData]).process()
+        val request = json.as[CreateAtomCommandData]
+
+        val atom = CreateAtomCommand(request).process()
         Created(Json.toJson(atom)).withHeaders("Location" -> atomUrl(atom.id))
 
       } catch {

--- a/app/model/Metadata.scala
+++ b/app/model/Metadata.scala
@@ -1,11 +1,24 @@
 package model
 
+import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-case class UpdatedMetadata(description: Option[String], tags: Option[List[String]], categoryId: Option[String], license: Option[String])
+case class UpdatedMetadata (
+  description: Option[String],
+  tags: Option[List[String]],
+  categoryId: Option[String],
+  license: Option[String],
+  privacyStatus: Option[PrivacyStatus]
+)
 
 object UpdatedMetadata {
-  implicit val metadataRead = Json.reads[UpdatedMetadata]
+  implicit val metadataRead: Reads[UpdatedMetadata] = (
+    (__ \ "description").readNullable[String] ~
+    (__ \ "tags").readNullable[List[String]] ~
+    (__ \ "categoryId").readNullable[String] ~
+    (__ \ "license").readNullable[String] ~
+    (__ \ "privacyStatus").readNullable[PrivacyStatus]
+  )(UpdatedMetadata.apply _)
 }
 
 // The license has only this 2 valid values. Update the thrift model?

--- a/app/model/PrivacyStatus.scala
+++ b/app/model/PrivacyStatus.scala
@@ -10,15 +10,15 @@ sealed trait PrivacyStatus {
 
 
 object PrivacyStatus {
-  case object Private extends PrivacyStatus { val name = "private"}
-  case object Unlisted extends PrivacyStatus { val name = "unlisted"}
-  case object Public extends PrivacyStatus { val name = "public"}
+  case object Private extends PrivacyStatus { val name = "Private"}
+  case object Unlisted extends PrivacyStatus { val name = "Unlisted"}
+  case object Public extends PrivacyStatus { val name = "Public"}
 
   val reads: Reads[PrivacyStatus] = Reads[PrivacyStatus](json => {
     json.as[String] match {
-      case "private" => JsSuccess(Private)
-      case "unlisted" => JsSuccess(Unlisted)
-      case "public" => JsSuccess(Public)
+      case "Private" => JsSuccess(Private)
+      case "Unlisted" => JsSuccess(Unlisted)
+      case "Public" => JsSuccess(Public)
     }
   })
 

--- a/app/model/commands/CreateAtomCommand.scala
+++ b/app/model/commands/CreateAtomCommand.scala
@@ -6,23 +6,24 @@ import java.util.UUID._
 import com.gu.atom.data.{IDConflictError, PreviewDataStore}
 import com.gu.atom.publish.PreviewAtomPublisher
 import com.gu.contentatom.thrift._
-import model.{Image, MediaAtom}
+import model.{Image, MediaAtom, PrivacyStatus}
 import model.commands.CommandExceptions._
 import org.cvogt.play.json.Jsonx
 
 import scala.util.{Failure, Success}
 import com.gu.contentatom.thrift.{Atom => ThriftAtom}
-import com.gu.contentatom.thrift.atom.media.{Metadata => ThriftMetadata, Category => ThriftCategory, MediaAtom => ThriftMediaAtom}
+import com.gu.contentatom.thrift.atom.media.{Category => ThriftCategory, MediaAtom => ThriftMediaAtom, Metadata => ThriftMetadata, PrivacyStatus => ThriftPrivacyStatus}
 
 // Since the data store and publisher are injected rather than being objects we cannot serialize JSON directly into a
 // command so we'll use a small POD for easy JSONification
 case class CreateAtomCommandData(
   title: String,
-  category: String,
+  category: String, //TODO use Category model for stronger typing
   posterImage: Image,
   duration: Long,
   youtubeCategoryId: String,
-  channelId: String
+  channelId: String,
+  privacyStatus: PrivacyStatus
 )
 
 object CreateAtomCommandData {
@@ -53,7 +54,8 @@ case class CreateAtomCommand(data: CreateAtomCommandData)
         description = None,
         metadata = Some(ThriftMetadata(
           categoryId = Some(data.youtubeCategoryId),
-          channelId = Some(data.channelId)
+          channelId = Some(data.channelId),
+          privacyStatus = data.privacyStatus.asThrift
         ))
       )),
       contentChangeDetails = ContentChangeDetails(None, None, None, 1L)

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -45,7 +45,7 @@ case class PublishAtomCommand(id: String)(implicit val previewDataStore: Preview
           case None => Logger.info(s"No active YouTube asset found for atom: ${id}")
         }
 
-        api.updateMetadata(id, UpdatedMetadata(atom.description, Some(atom.tags), atom.youtubeCategoryId, atom.license))
+        api.updateMetadata(id, UpdatedMetadata(atom.description, Some(atom.tags), atom.youtubeCategoryId, atom.license, atom.privacyStatus))
 
         val changeRecord = ChangeRecord((new Date()).getTime(), None) // Todo: User...
         val updatedAtom = thriftAtom.copy(

--- a/app/model/commands/UpdateMetadataCommand.scala
+++ b/app/model/commands/UpdateMetadataCommand.scala
@@ -35,7 +35,8 @@ case class UpdateMetadataCommand(atomId: String,
             val newMetadata = thriftMediaAtom.metadata.map(_.copy(
               tags = metadata.tags,
               categoryId = metadata.categoryId,
-              license = metadata.license))
+              license = metadata.license,
+              privacyStatus = metadata.privacyStatus.flatMap(_.asThrift)))
 
             val activeYTAssetDuration = YouTubeVideoInfoApi(youtubeConfig).getDuration(youtubeAsset.id)
 

--- a/app/util/Youtube.scala
+++ b/app/util/Youtube.scala
@@ -108,7 +108,7 @@ case class YouTubeVideoUpdateApi(config: YouTubeConfig) extends YouTubeBuilder {
         }
 
         metadata.privacyStatus match {
-          case Some(ps) => status.setPrivacyStatus(ps.name)
+          case Some(ps) => status.setPrivacyStatus(ps.name.toLowerCase)
           case _ => None
         }
 

--- a/public/video-ui/src/components/VideoEdit/VideoEdit.js
+++ b/public/video-ui/src/components/VideoEdit/VideoEdit.js
@@ -7,6 +7,7 @@ import VideoPosterEdit from './formComponents/VideoPoster';
 import YoutubeCategorySelect from './formComponents/YoutubeCategory';
 import YoutubeKeywordsSelect from './formComponents/YoutubeKeywords';
 import YoutubeChannelSelect from './formComponents/YoutubeChannel';
+import PrivacyStatusSelect from './formComponents/PrivacyStatus';
 import ContentFlags from './formComponents/ContentFlags';
 import SaveButton from '../utils/SaveButton';
 import validate from '../../constants/videoEditValidation';
@@ -43,6 +44,11 @@ const VideoEdit = (props) => {
             type="select"
             component={YoutubeChannelSelect}
             {...props} />
+
+          <Field name="privacy-status"
+                 type="text"
+                 component={PrivacyStatusSelect}
+                 {...props} />
 
           <SaveButton saveState={props.saveState.saving} onSaveClick={props.saveVideo} onResetClick={props.resetVideo} />
         </div>
@@ -100,6 +106,13 @@ const VideoEdit = (props) => {
                 type="select"
                 component={YoutubeCategorySelect}
                 {...props} />
+            </FormFieldSaveWrapper>
+
+            <FormFieldSaveWrapper {...props}>
+              <Field name="privacy-status"
+                     type="text"
+                     component={PrivacyStatusSelect}
+                     {...props} />
             </FormFieldSaveWrapper>
 
             <Field name="youtube-keywords" component={YoutubeKeywordsSelect} {...props} />

--- a/public/video-ui/src/components/VideoEdit/formComponents/PrivacyStatus.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/PrivacyStatus.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import SelectBox from '../../FormFields/SelectBox';
+import { privacyStates } from '../../../constants/privacyStates';
+
+export default class PrivacyStatusSelect extends React.Component {
+
+  updatePrivacyStatus = (e) => {
+    const newData = Object.assign({}, this.props.video, {
+      privacyStatus: e.target.value
+    });
+
+    this.props.updateVideo(newData);
+  };
+
+  render () {
+    return (
+      <SelectBox
+        fieldName="Privacy Status"
+        fieldValue={this.props.video.privacyStatus}
+        selectValues={privacyStates || []}
+        onUpdateField={this.updatePrivacyStatus}
+        {...this.props} />
+    );
+  }
+}

--- a/public/video-ui/src/constants/blankVideoData.js
+++ b/public/video-ui/src/constants/blankVideoData.js
@@ -1,5 +1,6 @@
 export const blankVideoData = {
     title: '',
     category: '',
-    duration: 0
+    duration: 0,
+    privacyStatus: 'Unlisted'
 };

--- a/public/video-ui/src/constants/privacyStates.js
+++ b/public/video-ui/src/constants/privacyStates.js
@@ -1,0 +1,5 @@
+export const privacyStates = [
+  'Private',
+  'Public',
+  'Unlisted'
+].map(state => {return {id: state, title: state}});


### PR DESCRIPTION
also updates the logic, setting a metadata field to the value passed in if it has been passed in.

I had originally made the privacy status a separate end-point however it feels neater for it to be wrapped in the `updateMetadata` one.

TODO
- [x] set `privacyStatus` on the atom model once https://github.com/guardian/content-atom/pull/63 has been merged