### PR TITLE
Active sset endpoint

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -11,12 +11,11 @@ import com.gu.pandahmac.HMACAuthActions
 import data.JsonConversions._
 import model.commands.CommandExceptions._
 import model.commands._
-import model.UpdatedMetadata
 import play.api.Configuration
 import util.{YouTubeConfig, AWSConfig}
 import util.atom.MediaAtomImplicits
 import play.api.libs.json._
-import model.MediaAtom
+import model.{UpdatedMetadata, MediaAtom}
 
 import scala.util.{Failure, Success}
 
@@ -112,5 +111,21 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
       BadRequest("Could not read json")
     }
     Ok
+  }
+
+  def setActiveAsset(atomId: String) = APIHMACAuthAction { implicit req =>
+    req.body.asJson.map { json =>
+      try {
+        val videoId = (json \ "youtubeId").as[String]
+
+        val status: Unit = ActiveAssetCommand(atomId, videoId).process()
+
+        Ok("asset added")
+      } catch {
+        commandExceptionAsResult
+      }
+    }.getOrElse {
+      BadRequest("Could not read json")
+    }
   }
 }

--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -120,7 +120,7 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
 
         val status: Unit = ActiveAssetCommand(atomId, videoId).process()
 
-        Ok("asset added")
+        Ok("made asset " + videoId + " active in atom " + atomId)
       } catch {
         commandExceptionAsResult
       }

--- a/app/model/commands/ActiveAssetCommand.scala
+++ b/app/model/commands/ActiveAssetCommand.scala
@@ -33,7 +33,7 @@ case class ActiveAssetCommand(atomId: String, youtubeId: String)
             val mediaAtom = atom.tdata
             val atomAssets: Seq[Asset] = mediaAtom.assets
 
-            val newActiveAsset = atomAssets.find(asset => asset.id.split("v=")(1) == youtubeId).get
+            val newActiveAsset = atomAssets.find(asset => asset.id == youtubeId).get
 
             val newAtom = atom
               .withData(mediaAtom.copy(

--- a/app/model/commands/ActiveAssetCommand.scala
+++ b/app/model/commands/ActiveAssetCommand.scala
@@ -1,0 +1,62 @@
+package model.commands
+
+import java.util.Date
+import scala.util.{Failure, Success}
+import CommandExceptions._
+
+import com.gu.atom.data.PreviewDataStore
+import com.gu.atom.publish.PreviewAtomPublisher
+import com.gu.contentatom.thrift.{EventType, ContentAtomEvent}
+import com.gu.contentatom.thrift.atom.media.Asset
+import util.atom.MediaAtomImplicits
+import util.{YouTubeConfig, YouTubeVideoStatusApi}
+
+
+case class ActiveAssetCommand(atomId: String, youtubeId: String)
+                             (implicit previewDataStore: PreviewDataStore,
+                              previewPublisher: PreviewAtomPublisher,
+                              val youtubeConfig: YouTubeConfig)
+  extends Command
+  with MediaAtomImplicits {
+
+  type T = Unit
+
+  def process(): Unit = {
+
+    val videoStatus = YouTubeVideoStatusApi(youtubeConfig).get(youtubeId)
+
+    videoStatus match {
+      case Some("succeeded") => {
+
+        previewDataStore.getAtom(atomId) match {
+          case Some(atom) =>
+            val mediaAtom = atom.tdata
+            val atomAssets: Seq[Asset] = mediaAtom.assets
+
+            val newActiveAsset = atomAssets.find(asset => asset.id.split("v=")(1) == youtubeId).get
+
+            val newAtom = atom
+              .withData(mediaAtom.copy(
+                activeVersion = Some(newActiveAsset.version)
+              ))
+              .withRevision(_ + 1)
+
+            previewDataStore.updateAtom(newAtom).fold(
+              err => InternalServerError(err.msg),
+              _ => {
+                val event = ContentAtomEvent(newAtom, EventType.Update, new Date().getTime)
+
+                previewPublisher.publishAtomEvent(event) match {
+                  case Success(_) => ()
+                  case Failure(err) => InternalServerError(s"could not publish: ${err.toString}")
+                }
+              }
+            )
+          case None => AtomNotFound
+        }
+      }
+      case Some(_) => AssetEncodingInProcess
+      case None => NotYoutubeAsset
+    }
+  }
+}

--- a/app/model/commands/ActiveAssetCommand.scala
+++ b/app/model/commands/ActiveAssetCommand.scala
@@ -44,7 +44,7 @@ case class ActiveAssetCommand(atomId: String, youtubeId: String)
           case Some("succeeded") => {
 
             previewDataStore.getAtom(atomId) match {
-              case Some(atom) =>
+              case Some(atom) => {
                 val mediaAtom = atom.tdata
                 val atomAssets: Seq[Asset] = mediaAtom.assets
 
@@ -71,6 +71,7 @@ case class ActiveAssetCommand(atomId: String, youtubeId: String)
                   }
                   case None => BadRequest(s"could not find asset with id: ${youtubeId}")
                 }
+              }
               case None => AtomNotFound
             }
           }

--- a/app/model/commands/ActiveAssetCommand.scala
+++ b/app/model/commands/ActiveAssetCommand.scala
@@ -51,16 +51,16 @@ case class ActiveAssetCommand(atomId: String, youtubeId: String)
                 atomAssets.find(asset => asset.id == youtubeId) match {
                   case Some(newActiveAsset) => {
 
-                    val newAtom = atom
+                    val nextAtomRevision = atom
                       .withData(mediaAtom.copy(
                         activeVersion = Some(newActiveAsset.version)
                       ))
                       .withRevision(_ + 1)
 
-                    previewDataStore.updateAtom(newAtom).fold(
+                    previewDataStore.updateAtom(nextAtomRevision).fold(
                       err => InternalServerError(err.msg),
                       _ => {
-                        val event = ContentAtomEvent(newAtom, EventType.Update, new Date().getTime)
+                        val event = ContentAtomEvent(nextAtomRevision, EventType.Update, new Date().getTime)
 
                         previewPublisher.publishAtomEvent(event) match {
                           case Success(_) => ()

--- a/app/model/commands/AddAssetCommand.scala
+++ b/app/model/commands/AddAssetCommand.scala
@@ -41,7 +41,6 @@ case class AddAssetCommand(atomId: String,
 
         val newAtom = atom
           .withData(mediaAtom.copy(
-            activeVersion = Some(newAsset.version),
             assets = newAsset +: currentAssets
           ))
           .withRevision(_ + 1)

--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -12,7 +12,7 @@ object CommandExceptions extends Results {
   def NotYoutubeAsset = throw new CommandException("Asset is not a youtube video", 400)
   def AssetVersionConflict = throw new CommandException("Asset version conflict", 400)
   def AssetParseFailed = throw new CommandException("Failed to parse asset", 400)
-  def AssetEncodingInProcess = throw new CommandException("Asset encoding in process", 400)
+  def AssetEncodingInProcess = throw new CommandException("Asset encoding in progress", 400)
 
   def AtomUpdateFailed(err: String) = throw new CommandException(s"Failed to update atom: $err", 500)
   def AtomPublishFailed(err: String) = throw new CommandException(s"Failed to publish atom: $err", 500)

--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -12,7 +12,7 @@ object CommandExceptions extends Results {
   def NotYoutubeAsset = throw new CommandException("Asset is not a youtube video", 400)
   def AssetVersionConflict = throw new CommandException("Asset version conflict", 400)
   def AssetParseFailed = throw new CommandException("Failed to parse asset", 400)
-  def AssetEncodingInProcess = throw new CommandException("Asset enconding in process", 400)
+  def AssetEncodingInProcess = throw new CommandException("Asset encoding in process", 400)
 
   def AtomUpdateFailed(err: String) = throw new CommandException(s"Failed to update atom: $err", 500)
   def AtomPublishFailed(err: String) = throw new CommandException(s"Failed to publish atom: $err", 500)

--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -12,6 +12,7 @@ object CommandExceptions extends Results {
   def NotYoutubeAsset = throw new CommandException("Asset is not a youtube video", 400)
   def AssetVersionConflict = throw new CommandException("Asset version conflict", 400)
   def AssetParseFailed = throw new CommandException("Failed to parse asset", 400)
+  def AssetEncodingInProcess = throw new CommandException("Asset enconding in process", 400)
 
   def AtomUpdateFailed(err: String) = throw new CommandException(s"Failed to update atom: $err", 500)
   def AtomPublishFailed(err: String) = throw new CommandException(s"Failed to publish atom: $err", 500)

--- a/app/util/Youtube.scala
+++ b/app/util/Youtube.scala
@@ -6,7 +6,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.http.javanet.NetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.youtube.YouTube
-import com.google.api.services.youtube.model.Video
+import com.google.api.services.youtube.model.{VideoProcessingDetails, Video}
 import model.{UpdatedMetadata, YouTubeVideoCategory, YouTubeChannel}
 import play.api.Configuration
 
@@ -95,4 +95,18 @@ case class YouTubeChannelsApi(config: YouTubeConfig) extends YouTubeBuilder {
     }
 
   }
+}
+
+case class YouTubeVideoStatusApi(config: YouTubeConfig) extends YouTubeBuilder {
+  def get(youtubeId: String): Option[String] =
+    youtube.videos()
+      .list("processingDetails")
+      .setId(youtubeId)
+      .setOnBehalfOfContentOwner(onBehalfOfContentOwner)
+      .execute()
+      .getItems.asScala.toList.headOption match {
+      case Some(video) =>
+        Some(video.getProcessingDetails().getProcessingStatus)
+      case None => None
+    }
 }

--- a/app/util/Youtube.scala
+++ b/app/util/Youtube.scala
@@ -102,11 +102,11 @@ case class YouTubeVideoStatusApi(config: YouTubeConfig) extends YouTubeBuilder {
     youtube.videos()
       .list("processingDetails")
       .setId(youtubeId)
-      .setOnBehalfOfContentOwner(onBehalfOfContentOwner)
+      .setOnBehalfOfContentOwner(config.contentOwner)
       .execute()
       .getItems.asScala.toList.headOption match {
       case Some(video) =>
-        Some(video.getProcessingDetails().getProcessingStatus)
+        Some(video.getProcessingDetails().getProcessingStatus())
       case None => None
     }
 }

--- a/app/util/YoutubeResponse.scala
+++ b/app/util/YoutubeResponse.scala
@@ -1,0 +1,6 @@
+package util
+
+trait YoutubeResponse
+
+class SuccesfulYoutubeResponse (val status: Option[String]) extends YoutubeResponse
+class YoutubeException (val exception: Throwable) extends YoutubeResponse

--- a/conf/routes
+++ b/conf/routes
@@ -19,6 +19,7 @@ GET     /api2/atoms/:id                 controllers.Api2.getMediaAtom(id)
 PUT     /api2/atoms/:id                 controllers.Api2.putMediaAtom(id)
 POST    /api2/atoms/:id/assets          controllers.Api2.addAsset(id)
 PUT     /api/atom/:id/update-metadata    controllers.Api2.updateMetadata(id)
+POST    /api2/atom/:id/asset-active     controllers.Api2.setActiveAsset(id)
 
 GET     /api/youtube/categories         controllers.Youtube.listCategories()
 GET     /api/youtube/channels           controllers.Youtube.listChannels()


### PR DESCRIPTION
Add an endpoint to media atom maker that makes an asset active if youtube has finished encoding it. The endpoint is polled by CDS.

@clloyd @akash1810 