### PR TITLE
rename `name` field to `title` in channel list api

### DIFF
--- a/app/model/YouTubeChannel.scala
+++ b/app/model/YouTubeChannel.scala
@@ -5,17 +5,17 @@ import play.api.libs.json._
 import play.api.libs.functional.syntax._
 import java.net.URI
 
-case class YouTubeChannel(name: String, logo: URI, id: String)
+case class YouTubeChannel(title: String, logo: URI, id: String)
 
 object YouTubeChannel {
   implicit val reads: Reads[YouTubeChannel] = (
-    (__ \ "name").read[String] ~
+    (__ \ "title").read[String] ~
     (__ \ "logo").read[String].map(URI.create) ~
     (__ \ "id").read[String]
     )(YouTubeChannel.apply _)
 
   implicit val writes: Writes[YouTubeChannel] = (
-    (__ \ "name").write[String] ~
+    (__ \ "title").write[String] ~
     (__ \ "logo").write[String].contramap((_: URI).toString) ~
     (__ \ "id").write[String]
     )(unlift(YouTubeChannel.unapply))
@@ -23,7 +23,7 @@ object YouTubeChannel {
   def build(channel: Channel): YouTubeChannel = {
 
     YouTubeChannel(
-      name = channel.getSnippet().getTitle(),
+      title = channel.getSnippet().getTitle(),
       logo = URI.create(channel.getSnippet().getThumbnails().getDefault().getUrl()),
       id = channel.getId
     )

--- a/app/util/Youtube.scala
+++ b/app/util/Youtube.scala
@@ -87,7 +87,7 @@ case class YouTubeChannelsApi(config: YouTubeConfig) extends YouTubeBuilder {
       .setManagedByMe(true)
       .setOnBehalfOfContentOwner(config.contentOwner)
 
-    val allChannels = request.execute().getItems.asScala.toList.map(YouTubeChannel.build).sortBy(_.name)
+    val allChannels = request.execute().getItems.asScala.toList.map(YouTubeChannel.build).sortBy(_.title)
 
     config.allowedChannels match {
       case None => allChannels


### PR DESCRIPTION
as that's what the [`SelectBox` component expects](https://github.com/guardian/media-atom-maker/blob/aa-name-to-title/public/video-ui/src/components/FormFields/SelectBox.js#L30).

Changing the field name in the API is simpler and cheaper than trying to make the component super generic.

Before
![screen shot 2016-11-28 at 16 41 07](https://cloud.githubusercontent.com/assets/836140/20676967/81ed0992-b589-11e6-9bfc-f2d055e98c2f.jpeg)

After
![screen shot 2016-11-28 at 16 41 45](https://cloud.githubusercontent.com/assets/836140/20676995/9723323c-b589-11e6-9a6b-ea9457648b6d.jpeg)
