### PR TITLE
filter yt categories to only those that are assignable

### DIFF
--- a/app/util/Youtube.scala
+++ b/app/util/Youtube.scala
@@ -55,7 +55,10 @@ case class YouTubeVideoCategoryApi(config: YouTubeConfig) extends YouTubeBuilder
       .list("snippet")
       .setRegionCode("GB")
 
-    request.execute.getItems.asScala.toList.map(YouTubeVideoCategory.build).sortBy(_.title)
+    request.execute.getItems.asScala.toList
+      .filter(_.getSnippet.getAssignable)
+      .map(YouTubeVideoCategory.build)
+      .sortBy(_.title)
   }
 }
 


### PR DESCRIPTION
the category list api returns all categories on yt, however only some only some can be assigned to a video - filter these out.

see https://developers.google.com/youtube/v3/docs/videoCategories#resource