### PR TITLE
only attempt to update a yt thumbnail if the active asset is a youtube type

### DIFF
--- a/app/model/MediaAtom.scala
+++ b/app/model/MediaAtom.scala
@@ -105,4 +105,14 @@ object MediaAtom extends MediaAtomImplicits {
       privacyStatus = data.metadata.flatMap(_.privacyStatus).flatMap(PrivacyStatus.fromThrift)
     )
   }
+
+  def getActiveYouTubeAsset(mediaAtom: MediaAtom): Option[Asset] = {
+    val assets = mediaAtom.assets
+    val activeAsset = mediaAtom.activeVersion.flatMap(activeVersion => assets.find(_.version == activeVersion))
+
+    activeAsset match {
+      case Some(asset) if asset.platform == Platform.Youtube => Some(asset)
+      case _ => None
+    }
+  }
 }

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -23,11 +23,17 @@ case class PublishAtomCommand(id: String)(implicit val previewDataStore: Preview
         val atom = MediaAtom.fromThrift(a)
         val api = YouTubeVideoUpdateApi(youtubeConfig)
 
-        try {
-          updateThumbnail(atom, api)
-        } catch {
-          case NonFatal(e) => PosterImageUploadFailed(e.getMessage)
+        MediaAtom.getActiveYouTubeAsset(atom) match {
+          case Some(_) => {
+            try {
+              updateThumbnail(atom, api)
+            } catch {
+              case NonFatal(e) => PosterImageUploadFailed(e.getMessage)
+            }
+          }
+          case None =>
         }
+
         api.updateMetadata(id, UpdatedMetadata(atom.description, Some(atom.tags), atom.youtubeCategoryId, atom.license))
         publishAtom(id)
 


### PR DESCRIPTION
Currently, the `publish` endpoint will always attempt to update the thumbnail on youtube. This breaks when there are no assets.

We now check that the active asset is a youtube one before talking to youtube.