### PR TITLE
Base revision number on previous revision from dynamo

### DIFF
--- a/app/model/commands/UpdateAtomCommand.scala
+++ b/app/model/commands/UpdateAtomCommand.scala
@@ -24,7 +24,14 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom)
     if (id != atom.id) {
       AtomIdConflict
     }
-    val details = atom.contentChangeDetails.copy(revision = atom.contentChangeDetails.revision + 1)
+
+    val existingAtom = previewDataStore.getAtom(atom.id)
+
+    if (existingAtom.isEmpty) {
+      AtomNotFound
+    }
+
+    val details = atom.contentChangeDetails.copy(revision = existingAtom.get.contentChangeDetails.revision + 1)
     val thrift = atom.copy(contentChangeDetails = details).asThrift
 
     previewDataStore.updateAtom(thrift).fold(


### PR DESCRIPTION
If you made more than 1 update from the client side the subsequent changes would fair due to the revision being passed being out of date. This updates the command to use the dynamo stored update.