### PR TITLE
Send correct change details to client side

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -45,8 +45,8 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
 
   def publishMediaAtom(id: String) = APIHMACAuthAction { implicit req =>
     try {
-      PublishAtomCommand(id).process()
-      Ok
+      val updatedAtom = PublishAtomCommand(id).process()
+      Ok(Json.toJson(updatedAtom))
     } catch {
       commandExceptionAsResult
     }
@@ -71,9 +71,8 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
     req.body.asJson.map { json =>
       try {
         val atom = json.as[MediaAtom]
-        UpdateAtomCommand(id, atom).process()
-
-        Ok
+        val updatedAtom = UpdateAtomCommand(id, atom).process()
+        Ok(Json.toJson(updatedAtom))
       } catch {
         commandExceptionAsResult
       }

--- a/app/model/commands/UpdateAtomCommand.scala
+++ b/app/model/commands/UpdateAtomCommand.scala
@@ -7,20 +7,20 @@ import com.gu.atom.publish.PreviewAtomPublisher
 import com.gu.contentatom.thrift.{Atom, ContentAtomEvent, EventType}
 import model.commands.CommandExceptions._
 import util.atom.MediaAtomImplicits
-import model.MediaAtom
+import model.{ChangeRecord, MediaAtom}
 
 import scala.util.{Failure, Success}
-
 import model.commands.CommandExceptions._
+import org.joda.time.DateTime
 case class UpdateAtomCommand(id: String, atom: MediaAtom)
                             (implicit previewDataStore: PreviewDataStore,
                              previewPublisher: PreviewAtomPublisher)
     extends Command
     with MediaAtomImplicits {
 
-  type T = Unit
+  type T = MediaAtom
 
-  def process(): Unit = {
+  def process() = {
     if (id != atom.id) {
       AtomIdConflict
     }
@@ -31,7 +31,12 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom)
       AtomNotFound
     }
 
-    val details = atom.contentChangeDetails.copy(revision = existingAtom.get.contentChangeDetails.revision + 1)
+    val changeRecord = ChangeRecord(DateTime.now(), None)
+
+    val details = atom.contentChangeDetails.copy(
+      revision = existingAtom.get.contentChangeDetails.revision + 1,
+      lastModified = Some(changeRecord)
+    )
     val thrift = atom.copy(contentChangeDetails = details).asThrift
 
     previewDataStore.updateAtom(thrift).fold(
@@ -40,7 +45,7 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom)
         val event = ContentAtomEvent(thrift, EventType.Update, new Date().getTime)
 
         previewPublisher.publishAtomEvent(event) match {
-          case Success(_) => ()
+          case Success(_) => MediaAtom.fromThrift(thrift)
           case Failure(err) => AtomPublishFailed(s"could not publish: ${err.toString}")
         }
       }

--- a/public/video-ui/src/actions/VideoActions/publishVideo.js
+++ b/public/video-ui/src/actions/VideoActions/publishVideo.js
@@ -1,16 +1,17 @@
-import { browserHistory } from 'react-router';
 import VideosApi from '../../services/VideosApi';
 
 function requestVideoPublish() {
   return {
     type:       'VIDEO_PUBLISH_REQUEST',
+    video: video,
     receivedAt: Date.now()
   };
 }
 
-function receiveVideoPublish() {
+function receiveVideoPublish(video) {
   return {
     type: 'VIDEO_PUBLISH_RECEIVE',
+    video: video,
     receivedAt: Date.now()
   };
 }
@@ -26,7 +27,7 @@ function errorVideoPublish(error) {
 
 export function publishVideo(video) {
   return dispatch => {
-    dispatch(requestVideoPublish());
+    dispatch(requestVideoPublish(video));
     return VideosApi.publishVideo(video)
         .then(res => dispatch(receiveVideoPublish(res)))
         .catch(error => dispatch(errorVideoPublish(error)));

--- a/public/video-ui/src/components/VideoPreview/VideoPreview.js
+++ b/public/video-ui/src/components/VideoPreview/VideoPreview.js
@@ -36,7 +36,7 @@ export default class VideoPreview extends React.Component {
     }
 
     return  (
-      <iframe className="video-preview__video" src={this.youtubeEmbedUrl() + activeAsset.id} allowfullscreen></iframe>
+      <iframe className="video-preview__video" src={this.youtubeEmbedUrl() + activeAsset.id} allowFullScreen></iframe>
     )
   }
 

--- a/public/video-ui/src/reducers/videoReducer.js
+++ b/public/video-ui/src/reducers/videoReducer.js
@@ -16,6 +16,16 @@ export default function video(state = null, action) {
     case 'VIDEO_POPULATE_BLANK':
       return action.video;
 
+    case 'VIDEO_PUBLISH_RECEIVE':
+      return Object.assign({}, state, {
+        contentChangeDetails: action.video.contentChangeDetails
+      });
+
+    case 'VIDEO_SAVE_RECEIVE':
+      return Object.assign({}, state, {
+        contentChangeDetails: action.video.contentChangeDetails
+      });
+
     case 'ASSET_REVERT_REQUEST':
       return Object.assign({}, state, {
         activeVersion: action.assetVersion


### PR DESCRIPTION
This PR does the following
 - Updates PublishCommand to set the correct change records and update preview before updating live
 - Modifies UpdateCommand and PublishCommand to return the updated MediaAtom after completing
 - Listens client side for the response from save and publish requests and pulls the appropriate contentChangeRecord out of the response for use client side @ShaunYearStrong 