### PR TITLE
Restrict youtube assets to ones in the Guardian's ownership.

### DIFF
--- a/app/controllers/Youtube.scala
+++ b/app/controllers/Youtube.scala
@@ -4,7 +4,7 @@ import javax.inject._
 
 import com.gu.pandahmac.HMACAuthActions
 import play.api.libs.json.Json
-import util.{YouTubeChannelsApi, YouTubeConfig, YouTubeVideoCategoryApi}
+import util._
 
 class Youtube @Inject() (val authActions: HMACAuthActions,
                                  val youtubeConfig: YouTubeConfig) extends AtomController {

--- a/app/model/commands/AddAssetCommand.scala
+++ b/app/model/commands/AddAssetCommand.scala
@@ -5,6 +5,7 @@ import java.util.Date
 import com.gu.atom.data.PreviewDataStore
 import CommandExceptions._
 import com.gu.atom.publish.PreviewAtomPublisher
+import com.gu.contentatom.thrift.atom.media.Category.Hosted
 import com.gu.contentatom.thrift.{ContentAtomEvent, EventType}
 import com.gu.contentatom.thrift.atom.media.{Asset, Platform}
 import model.MediaAtom
@@ -60,7 +61,9 @@ case class AddAssetCommand(atomId: String,
         val newAsset = ThriftUtil.parseAsset(videoUri, mimeType, resolvedVersion)
           .fold(err => AssetParseFailed, identity)
 
-        validateYoutubeOwnership(newAsset)
+        if (mediaAtom.category != Hosted) {
+          validateYoutubeOwnership(newAsset)
+        }
 
         val assetDuration = getAssetDuration(newAsset)
 

--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -18,6 +18,8 @@ object CommandExceptions extends Results {
   def AtomUpdateFailed(err: String) = throw new CommandException(s"Failed to update atom: $err", 500)
   def AtomPublishFailed(err: String) = throw new CommandException(s"Failed to publish atom: $err", 500)
 
+  def NotGuardianYoutubeVideo = throw new CommandException("YouTube video is not in the Guardian's account", 400)
+
   // Add exceptions here as required
   def commandExceptionAsResult: PartialFunction[Throwable, Result] = {
     case CommandException(msg, 400) => BadRequest(msg)

--- a/public/video-ui/src/actions/VideoActions/createAsset.js
+++ b/public/video-ui/src/actions/VideoActions/createAsset.js
@@ -27,7 +27,7 @@ function receiveAssetCreate(video) {
 function errorAssetCreate(error) {
   return {
     type:       'SHOW_ERROR',
-    message:    'Could not create asset',
+    message:    `Could not create asset. ${error}`,
     error:      error,
     receivedAt: Date.now()
   };
@@ -38,7 +38,7 @@ export function createAsset(asset, videoId) {
     dispatch(requestAssetCreate());
     return VideosApi.createAsset(asset, videoId)
         .then(res => dispatch(receiveAssetCreate(res)))
-        .catch(error => dispatch(errorAssetCreate(error)));
+        .catch(error => dispatch(errorAssetCreate(error.response)));
   };
 }
 


### PR DESCRIPTION
Adds a restriction allowing only youtube videos that we own to be added as an asset as only our content should be atoms.

![not-gu](https://cloud.githubusercontent.com/assets/836140/21142000/014b13fa-c138-11e6-91a1-d0a5e100db27.gif)
