### PR TITLE
make yt channel readonly in edit mode

### DIFF
--- a/public/video-ui/src/components/VideoEdit/VideoEdit.js
+++ b/public/video-ui/src/components/VideoEdit/VideoEdit.js
@@ -94,13 +94,11 @@ const VideoEdit = (props) => {
           <div className="form__group">
             <div className="form__group__header">Youtube Metadata</div>
 
-            <FormFieldSaveWrapper {...props}>
-              <Field
-                name="youtube-channel"
-                type="select"
-                component={YoutubeChannelSelect}
-                {...props} />
-            </FormFieldSaveWrapper>
+            <Field
+              name="youtube-channel"
+              type="select"
+              component={YoutubeChannelSelect}
+              {...props} />
 
             <FormFieldSaveWrapper {...props}>
               <Field


### PR DESCRIPTION
As we cannot move a video between yt channels, it doesn't make sense to be able to edit it.
If we want this feature, we would need to re-upload the video to the new channel and set the old video private.