### PR TITLE
remove the `Hosted` category from React frontend

### DIFF
--- a/public/video-ui/src/constants/videoCategories.js
+++ b/public/video-ui/src/constants/videoCategories.js
@@ -1,7 +1,12 @@
+// TODO add `Hosted` category.
+// Although `Hosted` is a valid category, the APIs driving the React frontend perform authenticated calls to YT.
+// These only work with content that we own. `Hosted` can have third-party assets so the API calls will fail.
+// Add `Hosted` once the UI is smarter and removes features when category is `Hosted`.
+
 export const videoCategories = [
   'News',
   'Documentary',
   'Explainer',
   'Feature',
-  'Hosted'
+  // 'Hosted'
 ].map(cat => { return { id: cat, title: cat } });


### PR DESCRIPTION
The APIs perform authenticated calls to YT. This won't always work with Hosted as third-party assets can be added.

Remove the category until the UI adds/removes features depending on the category.

The `/atom` Angular UI is still available.