### PR TITLE
[wip] use poster image as default html for new atom

### DIFF
--- a/app/model/commands/CreateAtomCommand.scala
+++ b/app/model/commands/CreateAtomCommand.scala
@@ -37,11 +37,16 @@ case class CreateAtomCommand(data: CreateAtomCommandData)
 
   def process() = {
 
+    val defaultHtml = data.posterImage.master match {
+      case Some(image) => s"""<img src="${image.file}">"""
+      case None => "<div></div>"
+    }
+
     val atom = ThriftAtom(
       id = randomUUID().toString,
       atomType = AtomType.Media,
       labels = Nil,
-      defaultHtml = "<div></div>", // No content set so empty div
+      defaultHtml = defaultHtml,
       data = AtomData.Media(ThriftMediaAtom(
         title = data.title,
         assets = Nil,


### PR DESCRIPTION
Composer renders the default html read from CAPI. If there is no asset on the atom, this is just `<div></div>` which looks a little odd.

This changes the default html to be an image tag.