### PR TITLE
Temporary error message change

### DIFF
--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -13,7 +13,7 @@ object CommandExceptions extends Results {
   def NotYoutubeAsset = throw new CommandException("Asset is not a youtube video", 400)
   def AssetVersionConflict = throw new CommandException("Asset version conflict", 400)
   def AssetParseFailed = throw new CommandException("Failed to parse asset", 400)
-  def AssetEncodingInProcess = throw new CommandException("Asset encoding in progress", 400)
+  def AssetEncodingInProcess = throw new CommandException("Asset encoding in process", 400) //This is a temporary fix to match the CDS message
   def AssetNotFound = throw new CommandException("Asset not found", 404)
 
   def AssetNotFound(assetId: String) = throw new CommandException(s"Asset with id $assetId not found", 404)


### PR DESCRIPTION
After discussing this with @akash1810 we decided to submit this temporary fix to match the CDS error message: https://github.com/guardian/content_delivery_system/blob/master/CDS/scripts/js_utils/media-atom-lib.js#L132

This should be reverted after the message will be updated in CDS.