### PR TITLE
Expiry dates

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -102,12 +102,11 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
       try {
         val atom = json.as[MediaAtom]
         val thriftAtom = atom.asThrift
-        val newAtom = YouTubeVideoUpdateApi(youtubeConfig).updateStatusIfExpired(thriftAtom) match {
+        val atomWithExpiryChecked = YouTubeVideoUpdateApi(youtubeConfig).updateStatusIfExpired(thriftAtom) match {
           case Some(expiredAtom) => expiredAtom
           case _ => atom
         }
-
-        val updatedAtom = UpdateAtomCommand(id, newAtom).process()
+        val updatedAtom = UpdateAtomCommand(id, atomWithExpiryChecked).process()
         Ok(Json.toJson(updatedAtom))
       } catch {
         commandExceptionAsResult

--- a/app/data/JsonConversions.scala
+++ b/app/data/JsonConversions.scala
@@ -39,7 +39,9 @@ object JsonConversions {
     (__ \ "license").writeNullable[String] and
     (__ \ "commentsEnabled").writeNullable[Boolean] and
     (__ \ "channelId").writeNullable[String] and
-    (__ \ "privacyStatus").writeNullable[PrivacyStatus]
+    (__ \ "privacyStatus").writeNullable[PrivacyStatus] and
+    (__ \ "expiryDate").writeNullable[Long]
+
   ) { metadata: Metadata =>
       (
         metadata.tags,
@@ -47,7 +49,8 @@ object JsonConversions {
         metadata.license,
         metadata.commentsEnabled,
         metadata.channelId,
-        metadata.privacyStatus
+        metadata.privacyStatus,
+        metadata.expiryDate
         )
   }
 
@@ -57,7 +60,8 @@ object JsonConversions {
     (__ \ "license").readNullable[String] and
     (__ \ "commentsEnabled").readNullable[Boolean] and
     (__ \ "channelId").readNullable[String] and
-    (__ \ "privacyStatus").readNullable[PrivacyStatus]
+    (__ \ "privacyStatus").readNullable[PrivacyStatus] and
+    (__ \ "expiryDate").readNullable[Long]
   )(Metadata.apply _)
 
   implicit val atomDataMedia = (

--- a/app/model/MediaAtom.scala
+++ b/app/model/MediaAtom.scala
@@ -28,7 +28,8 @@ case class MediaAtom(
   channelId: Option[String],
   commentsEnabled: Boolean = false,
   legallySensitive: Option[Boolean],
-  privacyStatus: Option[PrivacyStatus]) {
+  privacyStatus: Option[PrivacyStatus],
+  expiryDate: Option[Long] = None) {
 
   def asThrift = ThriftAtom(
       id = id,
@@ -52,7 +53,8 @@ case class MediaAtom(
           license = license,
           commentsEnabled = Some(commentsEnabled),
           channelId = channelId,
-          privacyStatus = privacyStatus.flatMap(_.asThrift)
+          privacyStatus = privacyStatus.flatMap(_.asThrift),
+          expiryDate = expiryDate
           ))
         )),
       contentChangeDetails = contentChangeDetails.asThrift,
@@ -98,6 +100,7 @@ object MediaAtom extends MediaAtomImplicits {
       description = data.description,
       tags = data.metadata.flatMap(_.tags.map(_.toList)).getOrElse(Nil),
       youtubeCategoryId = data.metadata.map(_.categoryId).getOrElse(None),
+      expiryDate = data.metadata.map(_.expiryDate).getOrElse(None),
       license = data.metadata.flatMap(_.license),
       commentsEnabled = data.metadata.flatMap(_.commentsEnabled).getOrElse(false),
       channelId = data.metadata.flatMap(_.channelId),

--- a/app/model/Metadata.scala
+++ b/app/model/Metadata.scala
@@ -8,7 +8,8 @@ case class UpdatedMetadata (
   tags: Option[List[String]],
   categoryId: Option[String],
   license: Option[String],
-  privacyStatus: Option[PrivacyStatus]
+  privacyStatus: Option[PrivacyStatus],
+  expiryDate: Option[Long]
 )
 
 object UpdatedMetadata {
@@ -17,7 +18,8 @@ object UpdatedMetadata {
     (__ \ "tags").readNullable[List[String]] ~
     (__ \ "categoryId").readNullable[String] ~
     (__ \ "license").readNullable[String] ~
-    (__ \ "privacyStatus").readNullable[PrivacyStatus]
+    (__ \ "privacyStatus").readNullable[PrivacyStatus] ~
+    (__ \ "expiryDate").readNullable[Long]
   )(UpdatedMetadata.apply _)
 }
 

--- a/app/model/commands/CreateAtomCommand.scala
+++ b/app/model/commands/CreateAtomCommand.scala
@@ -26,7 +26,8 @@ case class CreateAtomCommandData(
   duration: Long,
   youtubeCategoryId: String,
   channelId: String,
-  privacyStatus: PrivacyStatus
+  privacyStatus: PrivacyStatus,
+  expiryDate: Option[Long]
 )
 
 object CreateAtomCommandData {
@@ -60,7 +61,8 @@ case class CreateAtomCommand(data: CreateAtomCommandData)
         metadata = Some(ThriftMetadata(
           categoryId = Some(data.youtubeCategoryId),
           channelId = Some(data.channelId),
-          privacyStatus = data.privacyStatus.asThrift
+          privacyStatus = data.privacyStatus.asThrift,
+          expiryDate = data.expiryDate
         ))
       )),
       contentChangeDetails = ContentChangeDetails(None, None, None, 1L)

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -50,7 +50,8 @@ case class PublishAtomCommand(id: String)(implicit val previewDataStore: Preview
           case None => Logger.info(s"No active YouTube asset found for atom: ${id}")
         }
 
-        api.updateMetadata(id, UpdatedMetadata(atom.description, Some(atom.tags), atom.youtubeCategoryId, atom.license, atom.privacyStatus))
+        api.updateMetadata(id, UpdatedMetadata(atom.description, Some(atom.tags), atom.youtubeCategoryId, atom.license,
+          atom.privacyStatus, atom.expiryDate))
 
         val changeRecord = ChangeRecord((new Date()).getTime(), None) // Todo: User...
         val updatedAtom = thriftAtom.copy(

--- a/app/model/commands/UpdateMetadataCommand.scala
+++ b/app/model/commands/UpdateMetadataCommand.scala
@@ -41,7 +41,9 @@ case class UpdateMetadataCommand(atomId: String,
               tags = metadata.tags,
               categoryId = metadata.categoryId,
               license = metadata.license,
-              privacyStatus = metadata.privacyStatus.flatMap(_.asThrift)))
+              privacyStatus = metadata.privacyStatus.flatMap(_.asThrift),
+              expiryDate = metadata.expiryDate
+            ))
 
             val activeYTAssetDuration = YouTubeVideoInfoApi(youtubeConfig).getDuration(youtubeAsset.id)
 

--- a/app/util/AWS.scala
+++ b/app/util/AWS.scala
@@ -73,6 +73,9 @@ class AWSConfig @Inject() (config: Configuration) {
   else
     getKinesisClient(credProvider)
 
+  lazy val expiryPollerName = "Expiry"
+  lazy val expiryPollerLastName = "Poller"
+
   private def getKinesisClient(credentialsProvider: AWSCredentialsProviderChain) = region.createClient(
     classOf[AmazonKinesisClient],
     credentialsProvider,

--- a/app/util/ExpiryPoller.scala
+++ b/app/util/ExpiryPoller.scala
@@ -18,7 +18,8 @@ case class ExpiryPoller @Inject () (
                         previewPublisher: PreviewAtomPublisher,
                         livePublisher: LiveAtomPublisher,
                         youtubeConfig: YouTubeConfig,
-                        implicit val auditDataStore: AuditDataStore
+                        implicit val auditDataStore: AuditDataStore,
+                        val awsConfig: AWSConfig
                        ){
   def start(scheduler: Scheduler): Unit = {
 
@@ -29,7 +30,8 @@ case class ExpiryPoller @Inject () (
   def checkExpiryDates(): Unit = {
 
     val timeNow = new Date().getTime
-    implicit val username = PandaUser("Expiry", "Poller", "digitalcms.dev@guardian.co.uk", None)
+    implicit val username = PandaUser(awsConfig.expiryPollerName,
+      awsConfig.expiryPollerLastName, "expiryPoller", None)
 
     previewDataStore.listAtoms.map(atoms => {
       atoms.foreach(atom => {

--- a/app/util/ExpiryPoller.scala
+++ b/app/util/ExpiryPoller.scala
@@ -1,0 +1,78 @@
+package util
+
+import java.util.Date
+import javax.inject.Inject
+import akka.actor.Scheduler
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import com.gu.atom.publish.{LiveAtomPublisher, PreviewAtomPublisher}
+import model.commands.{PublishAtomCommand, UpdateAtomCommand}
+import play.api.Logger
+import com.gu.atom.data.{PublishedDataStore, PreviewDataStore}
+import model.{PrivacyStatus, MediaAtom}
+import model.Platform.Youtube
+
+
+case class ExpiryPoller @Inject () (
+                        implicit val previewDataStore: PreviewDataStore,
+                        implicit val publishedDataStore: PublishedDataStore,
+                        previewPublisher: PreviewAtomPublisher,
+                        livePublisher: LiveAtomPublisher,
+                        youtubeConfig: YouTubeConfig
+                       ){
+  def start(scheduler: Scheduler): Unit = {
+
+    scheduler.schedule(0.seconds, 6.hours)(checkExpiryDates())
+
+  }
+
+  def checkExpiryDates(): Unit = {
+
+    val timeNow = new Date().getTime
+
+    previewDataStore.listAtoms.map(atoms => {
+      atoms.foreach(thriftAtom => {
+
+        val atom: MediaAtom = MediaAtom.fromThrift(thriftAtom)
+        val atomId = atom.id
+
+        atom.expiryDate match {
+          case Some(date) => {
+
+            if (date <= timeNow && atom.privacyStatus.get != PrivacyStatus.Private) {
+
+              atom.assets.foreach(asset => {
+                if (asset.platform == Youtube) {
+                  try {
+                    YouTubeVideoUpdateApi(youtubeConfig).setStatusToPrivate(asset.id)
+                    val updatedAtom: MediaAtom = atom.copy(privacyStatus=Some(PrivacyStatus.Private))
+
+                    UpdateAtomCommand(atomId, updatedAtom).process()
+
+                    publishedDataStore.getAtom(atomId) match {
+
+                      case Some(atom) => PublishAtomCommand(atomId).process()
+                      case _ =>
+
+                    }
+
+                    Logger.info(s"marked video status for video $asset.id in atom $atomId as private")
+                  }
+                  catch {
+                    case e: Throwable => Logger.warn(s"could not mark video status in $asset.id in atom $atomId private $e")
+                  }
+                }
+              })
+            }
+          }
+          case _ =>
+
+        }
+      })
+
+
+    })
+  }
+}
+

--- a/app/util/ExpiryPoller.scala
+++ b/app/util/ExpiryPoller.scala
@@ -3,6 +3,7 @@ package util
 import java.util.Date
 import javax.inject.Inject
 import akka.actor.Scheduler
+import data.AuditDataStore
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -19,7 +20,8 @@ case class ExpiryPoller @Inject () (
                         implicit val publishedDataStore: PublishedDataStore,
                         previewPublisher: PreviewAtomPublisher,
                         livePublisher: LiveAtomPublisher,
-                        youtubeConfig: YouTubeConfig
+                        youtubeConfig: YouTubeConfig,
+                        implicit val auditDataStore: AuditDataStore
                        ){
   def start(scheduler: Scheduler): Unit = {
 
@@ -30,6 +32,7 @@ case class ExpiryPoller @Inject () (
   def checkExpiryDates(): Unit = {
 
     val timeNow = new Date().getTime
+    implicit val username = Some("ExpiryPoller")
 
     previewDataStore.listAtoms.map(atoms => {
       atoms.foreach(thriftAtom => {

--- a/app/util/ExpiryPoller.scala
+++ b/app/util/ExpiryPoller.scala
@@ -10,7 +10,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import com.gu.atom.publish.{LiveAtomPublisher, PreviewAtomPublisher}
 import model.commands.{PublishAtomCommand, UpdateAtomCommand}
 import com.gu.atom.data.{PublishedDataStore, PreviewDataStore}
-
+import com.gu.pandomainauth.model.{User => PandaUser}
 
 case class ExpiryPoller @Inject () (
                         implicit val previewDataStore: PreviewDataStore,
@@ -29,7 +29,7 @@ case class ExpiryPoller @Inject () (
   def checkExpiryDates(): Unit = {
 
     val timeNow = new Date().getTime
-    implicit val username = Some("ExpiryPoller")
+    implicit val username = PandaUser("Expiry", "Poller", "digitalcms.dev@guardian.co.uk", None)
 
     previewDataStore.listAtoms.map(atoms => {
       atoms.foreach(atom => {

--- a/app/util/Youtube.scala
+++ b/app/util/Youtube.scala
@@ -153,7 +153,7 @@ case class YouTubeVideoUpdateApi(config: YouTubeConfig) extends YouTubeBuilder {
 
   private def setStatusToPrivate(asset: Asset, atomId: String): Unit = {
     if (asset.platform == Youtube) {
-      YouTubeVideoInfoApi(config).getVideo(asset.id, "status") match {
+      YouTubeVideoInfoApi(config).getVideo(asset.id, "snippet,status") match {
         case Some(video) => {
           protectAgainstMistakesInDev(video)
 

--- a/app/util/Youtube.scala
+++ b/app/util/Youtube.scala
@@ -3,6 +3,7 @@ package util
 import java.io.BufferedInputStream
 import java.net.URL
 import java.time.Duration
+import java.util.Date
 import javax.inject.{Inject, Singleton}
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
@@ -12,8 +13,11 @@ import com.google.api.client.http.javanet.NetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.youtube.YouTube
 import com.google.api.services.youtube.model.Video
+import com.gu.contentatom.thrift.Atom
+import model.Platform.Youtube
 import model._
 import play.api.{Configuration, Logger}
+import util.YouTubeVideoInfoApi
 
 import scala.collection.JavaConverters._
 
@@ -122,21 +126,55 @@ case class YouTubeVideoUpdateApi(config: YouTubeConfig) extends YouTubeBuilder {
       case _ => None
     }
 
-  def setStatusToPrivate(id: String): Option[Video] =
-    YouTubeVideoInfoApi(config).getVideo(id, "status") match {
-      case Some(video) => {
-        protectAgainstMistakesInDev(video)
+  def updateStatusIfExpired(thriftAtom: Atom): Option[MediaAtom] = {
 
-        video.getStatus.setPrivacyStatus(PrivacyStatus.Private.name)
-        Some(youtube.videos()
-          .update("snippet, status", video)
-          .setOnBehalfOfContentOwner(config.contentOwner)
-          .execute())
+    val atom: MediaAtom = MediaAtom.fromThrift(thriftAtom)
+    val atomId = atom.id
+    val timeNow = new Date().getTime
+
+    atom.expiryDate match {
+      case Some(date) => {
+
+        if (date <= timeNow && atom.privacyStatus.get != PrivacyStatus.Private) {
+
+          atom.assets.foreach(asset => {
+            setStatusToPrivate(asset, atom.id)
+          })
+
+          val updatedAtom = atom.copy(privacyStatus = Some(PrivacyStatus.Private))
+          Some(updatedAtom)
+
+        } else None
 
       }
       case _ => None
-
     }
+  }
+
+  private def setStatusToPrivate(asset: Asset, atomId: String): Unit = {
+    if (asset.platform == Youtube) {
+      YouTubeVideoInfoApi(config).getVideo(asset.id, "status") match {
+        case Some(video) => {
+          protectAgainstMistakesInDev(video)
+
+          video.getStatus.setPrivacyStatus(PrivacyStatus.Private.name)
+
+          try {
+            Some(youtube.videos()
+              .update("snippet, status", video)
+              .setOnBehalfOfContentOwner(config.contentOwner)
+              .execute())
+
+              Logger.info(s"marked video status for video $asset.id in atom $atomId as private")
+          }
+          catch {
+            case e: Throwable => Logger.warn(s"could not mark video status in $asset.id in atom $atomId private $e")
+          }
+        }
+        case _ =>
+      }
+    }
+  }
 
   def updateThumbnail(id: String, thumbnailUrl: URL, mimeType: String): Option[Video] = {
     YouTubeVideoInfoApi(config).getVideo(id, "snippet") match {

--- a/app/util/Youtube.scala
+++ b/app/util/Youtube.scala
@@ -122,6 +122,22 @@ case class YouTubeVideoUpdateApi(config: YouTubeConfig) extends YouTubeBuilder {
       case _ => None
     }
 
+  def setStatusToPrivate(id: String): Option[Video] =
+    YouTubeVideoInfoApi(config).getVideo(id, "status") match {
+      case Some(video) => {
+        protectAgainstMistakesInDev(video)
+
+        video.getStatus.setPrivacyStatus(PrivacyStatus.Private.name)
+        Some(youtube.videos()
+          .update("snippet, status", video)
+          .setOnBehalfOfContentOwner(config.contentOwner)
+          .execute())
+
+      }
+      case _ => None
+
+    }
+
   def updateThumbnail(id: String, thumbnailUrl: URL, mimeType: String): Option[Video] = {
     YouTubeVideoInfoApi(config).getVideo(id, "snippet") match {
       case Some(video) => {

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,8 @@ libraryDependencies ++= Seq(
   "net.logstash.logback"       % "logstash-logback-encoder"      % "4.8",
   "com.gu"                     % "kinesis-logback-appender"      % "1.3.0",
   "org.slf4j"                  % "slf4j-api"                     % "1.7.21",
-  "org.slf4j"                  % "jcl-over-slf4j"                % "1.7.21"
+  "org.slf4j"                  % "jcl-over-slf4j"                % "1.7.21",
+  "com.gu"                     %% "content-atom-model"           %  "2.4.17"
 
 ) ++ scanamoDeps
 

--- a/package.json
+++ b/package.json
@@ -32,10 +32,12 @@
     "webpack-dev-server": "^1.16.2"
   },
   "dependencies": {
+    "moment": "^2.17.1",
     "panda-session": "^0.1.6",
     "q": "^1.4.1",
     "querystringify": "0.0.4",
     "react": "^15.3.2",
+    "react-datepicker": "^0.39.0",
     "react-dom": "^15.3.2",
     "react-redux": "^5.0.1",
     "react-router": "^2.8.1",

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -5,7 +5,7 @@ object BuildVars {
   lazy val scroogeVersion     = "4.2.0"
   lazy val pandaVer           = "0.4.0"
   lazy val mockitoVersion     = "2.0.97-beta"
-  lazy val atomMakerVersion   = "0.1.6"
+  lazy val atomMakerVersion   = "0.1.7-SNAPSHOT"
 
   lazy val scanamoDeps = Seq(
     "com.gu"                     %% "scanamo"              % "0.7.0",

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -5,7 +5,7 @@ object BuildVars {
   lazy val scroogeVersion     = "4.2.0"
   lazy val pandaVer           = "0.4.0"
   lazy val mockitoVersion     = "2.0.97-beta"
-  lazy val atomMakerVersion   = "0.1.7-SNAPSHOT"
+  lazy val atomMakerVersion   = "0.1.7"
 
   lazy val scanamoDeps = Seq(
     "com.gu"                     %% "scanamo"              % "0.7.0",

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.11.48"
-  lazy val scroogeVersion     = "4.2.0"
+  lazy val scroogeVersion     = "4.12.0"
   lazy val pandaVer           = "0.4.0"
   lazy val mockitoVersion     = "2.0.97-beta"
   lazy val atomMakerVersion   = "0.1.7"

--- a/public/video-ui/src/components/FormFields/DatePicker.js
+++ b/public/video-ui/src/components/FormFields/DatePicker.js
@@ -54,7 +54,8 @@ export default React.createClass({
           selected={this.state.startDate}
           onChange={this.handleChange}
           minDate={moment()}
-          />
+          className="form__field"
+        />
       </div>
     )
   },

--- a/public/video-ui/src/components/FormFields/DatePicker.js
+++ b/public/video-ui/src/components/FormFields/DatePicker.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import Picker from 'react-datepicker';
+import moment from 'moment';
+import 'react-datepicker/dist/react-datepicker.css';
+
+export default React.createClass({
+
+  handleChange(date) {
+    this.setState({
+      startDate: date
+    });
+
+    this.props.onUpdateField(date.valueOf());
+  },
+
+  getInitialState() {
+    let startDate;
+
+    if (parseInt(this.props.fieldValue)) {
+      startDate = moment(this.props.fieldValue);
+    } else {
+      startDate = null;
+    }
+
+    return {
+      startDate: startDate
+    }
+  },
+
+  getReadableFieldValue(value) {
+    if (parseInt(value)) {
+      return moment(value).format('DD/MM/YYYY');
+    }
+    return value;
+  },
+
+  renderField() {
+    if(!this.props.editable) {
+      return (
+        <div>
+          <p className="details-list__title">{this.props.fieldName}</p>
+          <p className="details-list__field">{this.getReadableFieldValue(this.props.fieldValue)}</p>
+        </div>
+      )
+    }
+
+    return (
+      <div>
+        <label className="form__label">{this.props.fieldName}</label>
+        <Picker
+          selected={this.state.startDate}
+          onChange={this.handleChange}
+          minDate={moment()}
+          />
+      </div>
+    )
+  },
+
+
+  render() {
+    return (
+      <div>
+        {this.renderField()}
+      </div>
+    )
+  }
+})

--- a/public/video-ui/src/components/FormFields/DatePicker.js
+++ b/public/video-ui/src/components/FormFields/DatePicker.js
@@ -10,7 +10,10 @@ export default React.createClass({
       startDate: date
     });
 
-    this.props.onUpdateField(date.valueOf());
+    if (date) {
+      return this.props.onUpdateField(date.valueOf());
+    }
+    return this.props.onUpdateField(null);
   },
 
   getInitialState() {

--- a/public/video-ui/src/components/FormFields/MaybeFormFieldSaveWrapper.js
+++ b/public/video-ui/src/components/FormFields/MaybeFormFieldSaveWrapper.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import FormFieldSaveWrapper from '../FormFields/FormFieldSaveWrapper';
+import {Field} from 'redux-form';
+
+export default class MaybeFormFieldSaveWrapper extends React.Component {
+
+  render() {
+    if (this.props.disableEditing) {
+      return (
+        <Field
+          name={this.props.name}
+          type={this.props.text}
+          component={this.props.component}
+          video={this.props.video}
+          updateVideo={this.props.updateVideo}
+          editable={this.props.editable}/>
+      );
+    }
+    return (
+      <FormFieldSaveWrapper
+        saveVideo={this.props.saveVideo}
+        resetVideo={this.props.resetVideo}
+        editable={this.props.editable}
+        saveState={this.props.saveState}>
+        <Field
+          name={this.props.name}
+          type={this.props.text}
+          component={this.props.component}
+          video={this.props.video}
+          updateVideo={this.props.updateVideo}
+          editable={this.props.editable}
+        />
+      </FormFieldSaveWrapper>
+    );
+  }
+}

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -60,6 +60,10 @@ class VideoDisplay extends React.Component {
     });
   };
 
+  cannotEditStatus = () => {
+    return this.props.video.expiryDate <= Date.now()
+  };
+
   render() {
     const video = this.props.video && this.props.params.id === this.props.video.id ? this.props.video : undefined;
 
@@ -83,6 +87,7 @@ class VideoDisplay extends React.Component {
                 saveAndUpdateVideo={this.saveAndUpdateVideo}
                 resetVideo={this.resetVideo}
                 saveState={this.props.saveState}
+                disableStatusEditing={this.cannotEditStatus()}
                />
             </form>
           </div>

--- a/public/video-ui/src/components/VideoEdit/VideoEdit.js
+++ b/public/video-ui/src/components/VideoEdit/VideoEdit.js
@@ -57,7 +57,6 @@ const VideoEdit = (props) => {
             name="expiry"
             type="select"
             component={VideoExpiryEdit}
-            component={YoutubeCategorySelect}
             video={props.video}
             updateVideo={props.updateVideo}
             editable={props.editable} />
@@ -120,7 +119,9 @@ const VideoEdit = (props) => {
                 name="expiry"
                 type="number"
                 component={VideoExpiryEdit}
-                {...props} />
+                video={props.video}
+                updateVideo={props.updateVideo}
+                editable={props.editable} />
             </FormFieldSaveWrapper>
 
             <Field

--- a/public/video-ui/src/components/VideoEdit/VideoEdit.js
+++ b/public/video-ui/src/components/VideoEdit/VideoEdit.js
@@ -3,6 +3,7 @@ import VideoTitleEdit from './formComponents/VideoTitle';
 import VideoCategorySelect from './formComponents/VideoCategory';
 import VideoDurationEdit from './formComponents/VideoDuration';
 import FormFieldSaveWrapper from '../FormFields/FormFieldSaveWrapper';
+import MaybeFormFieldSaveWrapper from '../FormFields/MaybeFormFieldSaveWrapper';
 import VideoPosterEdit from './formComponents/VideoPoster';
 import YoutubeCategorySelect from './formComponents/YoutubeCategory';
 import VideoExpiryEdit from './formComponents/VideoExpiry';
@@ -174,19 +175,19 @@ const VideoEdit = (props) => {
               updateVideo={props.updateVideo}
               editable={props.editable} />
 
-            <FormFieldSaveWrapper
+            <MaybeFormFieldSaveWrapper
               saveVideo={props.saveVideo}
               resetVideo={props.resetVideo}
               editable={props.editable}
-              saveState={props.saveState}>
-              <Field
-                name="privacyStatus"
-                type="text"
-                component={PrivacyStatusSelect}
-                video={props.video}
-                updateVideo={props.updateVideo}
-                editable={props.editable} />
-            </FormFieldSaveWrapper>
+              saveState={props.saveState}
+              name={"privacyStatus"}
+              type={"text"}
+              component={PrivacyStatusSelect}
+              video={props.video}
+              updateVideo={props.updateVideo}
+              editable={props.editable}
+              disableEditing={props.disableStatusEditing}>
+            </MaybeFormFieldSaveWrapper>
 
             <Field
               name="youtubeKeywords"

--- a/public/video-ui/src/components/VideoEdit/VideoEdit.js
+++ b/public/video-ui/src/components/VideoEdit/VideoEdit.js
@@ -5,6 +5,7 @@ import VideoDurationEdit from './formComponents/VideoDuration';
 import FormFieldSaveWrapper from '../FormFields/FormFieldSaveWrapper';
 import VideoPosterEdit from './formComponents/VideoPoster';
 import YoutubeCategorySelect from './formComponents/YoutubeCategory';
+import VideoExpiryEdit from './formComponents/VideoExpiry';
 import YoutubeKeywordsSelect from './formComponents/YoutubeKeywords';
 import YoutubeChannelSelect from './formComponents/YoutubeChannel';
 import PrivacyStatusSelect from './formComponents/PrivacyStatus';
@@ -51,7 +52,17 @@ const VideoEdit = (props) => {
             editable={props.editable} />
 
           <Field
-            name="youtubeChannel"
+            name="videoExpiry"
+            name="expiry"
+            type="select"
+            component={VideoExpiryEdit}
+            component={YoutubeCategorySelect}
+            video={props.video}
+            updateVideo={props.updateVideo}
+            editable={props.editable} />
+
+          <Field
+            name="youtube-channel"
             type="select"
             component={YoutubeChannelSelect}
             video={props.video}
@@ -101,6 +112,14 @@ const VideoEdit = (props) => {
                 video={props.video}
                 updateVideo={props.updateVideo}
                 editable={props.editable} />
+            </FormFieldSaveWrapper>
+
+            <FormFieldSaveWrapper {...props}>
+              <Field
+                name="expiry"
+                type="number"
+                component={VideoExpiryEdit}
+                {...props} />
             </FormFieldSaveWrapper>
 
             <Field

--- a/public/video-ui/src/components/VideoEdit/formComponents/VideoExpiry.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/VideoExpiry.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import moment from 'moment';
+import DatePickerField from '../../FormFields/DatePicker';
+
+export default class VideoExpiryEdit extends React.Component {
+
+  onUpdateExpiry = (newDate) => {
+    let newData = Object.assign({}, this.props.video, {
+      expiryDate: newDate
+    });
+
+    this.props.updateVideo(newData);
+  };
+
+  render () {
+    if (!this.props.video) {
+      return false;
+    }
+
+    return (
+        <DatePickerField
+          fieldName="Expiry Date"
+          fieldValue={this.props.video.expiryDate || 'No expiry date set'}
+          onUpdateField={this.onUpdateExpiry}
+          {...this.props} />
+    );
+  }
+}

--- a/public/video-ui/src/components/VideoEdit/formComponents/VideoExpiry.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/VideoExpiry.js
@@ -5,7 +5,7 @@ import DatePickerField from '../../FormFields/DatePicker';
 export default class VideoExpiryEdit extends React.Component {
 
   onUpdateExpiry = (newDate) => {
-    let newData = Object.assign({}, this.props.video, {
+    const newData = Object.assign({}, this.props.video, {
       expiryDate: newDate
     });
 

--- a/test/ThriftUtilSpec.scala
+++ b/test/ThriftUtilSpec.scala
@@ -65,11 +65,11 @@ class ThriftUtilSpec extends FunSpec
     }
 
     it("should correctly generate media atom with metadata") {
-      val meta = "{\"channelId\":\"channelId\",\"commentsEnabled\":true,\"privacyStatus\":\"private\"}"
+      val meta = "{\"channelId\":\"channelId\",\"commentsEnabled\":true,\"privacyStatus\":\"private\",\"expiryDate\":1}"
 
       inside(parseMediaAtom(makeParams("uri" -> youtubeUrl, "metadata" -> meta))) {
         case Right(MediaAtom(assets, Some(1L), "unknown", Category.News, None, None, None, None, None, metadata, None)) =>
-          metadata should matchPattern { case Some(Metadata(_, _, _, Some(true), Some("channelId"), Some(PrivacyStatus.Private))) => }
+          metadata should matchPattern { case Some(Metadata(_, _, _, Some(true), Some("channelId"), Some(PrivacyStatus.Private), Some(1))) => }
       }
     }
   }


### PR DESCRIPTION
-Adds an expiry date field to media atom maker 
-Adds a poller that checks for expired atoms
-The poller marks the assets of these atoms private and marks the atom itself as private
<img width="397" alt="screen shot 2016-12-20 at 15 26 59" src="https://cloud.githubusercontent.com/assets/3066534/21356338/30f55a70-c6c9-11e6-8ab4-0dd48ae3b899.png">

Questions: 

-What should be the relationship between the youtube asset statuses, preview atom privacy status and published atom privacy status? 
- What is an appropriate polling interval?
- Can I have some guidance on how to make the date picker prettier? 
- Should the privacy status field for expired atoms be disabled? What if it gets disabled and someone goes to youtube and changes the status of the assets?
- We should probably add more detailed logging, but I'm not sure what we want logged.

-depends on this: https://github.com/guardian/content-atom/pull/76 and bumping atom maker library

@akash1810 @ShaunYearStrong 