### PR TITLE
Audit autorefresh

### DIFF
--- a/public/video-ui/src/actions/VideoActions/getAudits.js
+++ b/public/video-ui/src/actions/VideoActions/getAudits.js
@@ -30,9 +30,7 @@ export function getAudits(id) {
   return dispatch => {
     dispatch(requestAudits(id));
     return VideosApi.fetchAudits(id)
-        .then(res => {
-          dispatch(receiveAudits(res));
-        })
+        .then(res => dispatch(receiveAudits(res)))
         .catch(error => dispatch(errorReceivingAudits(error)));
   };
 }

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -14,6 +14,12 @@ class VideoDisplay extends React.Component {
     editable: false
   };
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.video != this.props.video) {
+      this.props.videoActions.getAudits(nextProps.video.id);
+    }
+  }
+
   componentWillMount() {
     this.props.videoActions.getVideo(this.props.params.id);
   }
@@ -22,7 +28,7 @@ class VideoDisplay extends React.Component {
     this.props.videoActions.saveVideo(this.props.video);
     this.setState({
       editable: false
-    })
+    });
   };
 
   saveAndUpdateVideo = (video) => {
@@ -110,7 +116,7 @@ class VideoDisplay extends React.Component {
 
             <div className="video__detailbox">
               <span className="video__detailbox__header">Atom Audit Trail</span>
-              <VideoAuditTrail video={this.props.video || {}} />
+              <VideoAuditTrail video={this.props.video || {}} audits={this.props.audits || []}/>
             </div>
           </div>
         </div>
@@ -128,6 +134,7 @@ import * as updateVideo from '../../actions/VideoActions/updateVideo';
 import * as publishVideo from '../../actions/VideoActions/publishVideo';
 import * as videoUsages from '../../actions/VideoActions/videoUsages';
 import * as videoPageCreate from '../../actions/VideoActions/videoPageCreate';
+import * as getAudits from '../../actions/VideoActions/getAudits';
 
 function mapStateToProps(state) {
   return {
@@ -135,13 +142,14 @@ function mapStateToProps(state) {
     saveState: state.saveState,
     config: state.config,
     usages: state.usage,
-    composerPageWithUsage: state.pageCreate
+    composerPageWithUsage: state.pageCreate,
+    audits: state.audits
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
-    videoActions: bindActionCreators(Object.assign({}, getVideo, saveVideo, updateVideo, publishVideo, videoUsages, videoPageCreate), dispatch)
+    videoActions: bindActionCreators(Object.assign({}, getVideo, saveVideo, updateVideo, publishVideo, videoUsages, videoPageCreate, getAudits), dispatch)
   };
 }
 

--- a/public/video-ui/src/components/VideoAuditTrail/VideoAuditTrail.js
+++ b/public/video-ui/src/components/VideoAuditTrail/VideoAuditTrail.js
@@ -1,13 +1,7 @@
 import React, {PropTypes}  from 'react';
 import moment from 'moment';
 
-class VideoAuditTrail extends React.Component {
-
-  componentDidMount() {
-    if (this.props.video) {
-      this.props.videoActions.getAudits(this.props.video.id);
-    }
-  }
+export default class VideoAuditTrail extends React.Component {
 
   state = {
     renderAll: false
@@ -33,15 +27,7 @@ class VideoAuditTrail extends React.Component {
   }
 
   renderList() {
-    const audits = this.props.audits.map(x => x).sort((a, b) => {
-      if (a.date < b.date) {
-        return 1;
-      }
-      if (a.date > b.date) {
-        return -1;
-      }
-      return 0;
-    });
+    const audits = this.props.audits.map(x => x).sort((a, b) => b.date - a.date);
 
     if (this.state.renderAll) {
       return (<tbody>{audits.map((a) => this.renderAudit(a))}</tbody>);
@@ -77,22 +63,3 @@ class VideoAuditTrail extends React.Component {
     return (<div>Loading...</div>);
   }
 }
-
-//REDUX CONNECTIONS
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import * as getAudits from '../../actions/VideoActions/getAudits';
-
-function mapStateToProps(state) {
-  return {
-    audits: state.audits
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    videoActions: bindActionCreators(Object.assign({}, getAudits), dispatch)
-  };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(VideoAuditTrail);


### PR DESCRIPTION
Also makes the AuditTrail component a simple data receiver from the video display, rather than fetching it's own data, which is neater architecturally imo.

Using `componentWillReceiveProps` to ensure the `props.video` has certainly be updated. If you simply sequentially call the actions some of the async stuff hasn't yet completed so you get what might appear to be an out of date set of audits, but actually you requested them too quickly.

HAVE A NICE CHRISTMAS! 🎅 🎄 