### PR TITLE
remove content atom model depency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,6 @@ resolvers += "Guardian Bintray" at "https://dl.bintray.com/guardian/editorial-to
 
 libraryDependencies ++= Seq(
   "ai.x"                       %% "diff"                         % "1.2.0",
-  "com.gu"                     %% "content-atom-model"           % contentAtomVersion,
   "org.apache.thrift"          %  "libthrift"                    % "0.9.3",
   "com.twitter"                %% "scrooge-core"                 % scroogeVersion,
   "com.twitter"                %% "scrooge-serializer"           % scroogeVersion,

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,6 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.11.48"
-  lazy val contentAtomVersion = "2.4.17"
   lazy val scroogeVersion     = "4.2.0"
   lazy val pandaVer           = "0.4.0"
   lazy val mockitoVersion     = "2.0.97-beta"


### PR DESCRIPTION
The content atom models dependency is coming through from the media atom libraries, so it can be removed from the build.sbt

