### PR TITLE
fix issue with auditing when hmac api authed

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -56,7 +56,7 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
   }
 
   def publishMediaAtom(id: String) = APIHMACAuthAction { implicit req =>
-    implicit val username = Option(req.user.email)
+    implicit val user = req.user
     try {
       val updatedAtom = PublishAtomCommand(id).process()
       Ok(Json.toJson(updatedAtom))
@@ -66,7 +66,7 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
   }
 
   def createMediaAtom = APIHMACAuthAction { implicit req =>
-    implicit val username = Option(req.user.email)
+    implicit val user = req.user
     req.body.asJson.map { json =>
       try {
         val request = json.as[CreateAtomCommandData]
@@ -84,7 +84,7 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
   }
 
   def putMediaAtom(id: String) = APIHMACAuthAction { implicit req =>
-    implicit val username = Option(req.user.email)
+    implicit val user = req.user
     req.body.asJson.map { json =>
       try {
         val atom = json.as[MediaAtom]
@@ -99,7 +99,8 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
   }
 
   def addAsset(atomId: String) = APIHMACAuthAction { implicit req =>
-    implicit val username = Option(req.user.email)
+    implicit val user = req.user
+
     req.body.asJson.map { json =>
       try {
         val videoId = (json \ "uri").as[String]
@@ -121,7 +122,7 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
   private def atomUrl(id: String) = s"/atom/$id"
 
   def updateMetadata(atomId: String) = APIHMACAuthAction { implicit req =>
-    implicit val username = Option(req.user.email)
+    implicit val user = req.user
     req.body.asJson.map { json =>
       json.validate[UpdatedMetadata] match {
         case JsSuccess(metadata, _) =>
@@ -136,7 +137,7 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
   }
 
   def setActiveAsset(atomId: String) = APIHMACAuthAction { implicit req =>
-    implicit val username = Option(req.user.email)
+    implicit val user = req.user
     req.body.asJson.map { json =>
       try {
         val videoId = (json \ "youtubeId").as[String]

--- a/app/model/commands/ActiveAssetCommand.scala
+++ b/app/model/commands/ActiveAssetCommand.scala
@@ -16,6 +16,8 @@ import com.gu.contentatom.thrift.atom.media.Asset
 import util.atom.MediaAtomImplicits
 import util.{YoutubeResponse, YouTubeConfig, YouTubeVideoInfoApi, SuccesfulYoutubeResponse, YoutubeException}
 
+import com.gu.pandomainauth.model.{User => PandaUser}
+
 case class ActiveAssetCommand(atomId: String, youtubeId: String)
                              (implicit previewDataStore: PreviewDataStore,
                               previewPublisher: PreviewAtomPublisher,
@@ -23,7 +25,7 @@ case class ActiveAssetCommand(atomId: String, youtubeId: String)
                               livePublisher: LiveAtomPublisher,
                               val youtubeConfig: YouTubeConfig,
                               auditDataStore: AuditDataStore,
-                              username: Option[String])
+                              user: PandaUser)
   extends Command
   with MediaAtomImplicits {
 

--- a/app/model/commands/AddAssetCommand.scala
+++ b/app/model/commands/AddAssetCommand.scala
@@ -16,6 +16,8 @@ import data.AuditDataStore
 
 import scala.util.{Failure, Success}
 
+import com.gu.pandomainauth.model.{User => PandaUser}
+
 case class AddAssetCommand(atomId: String,
                            videoUri: String,
                            version: Option[Long],
@@ -24,7 +26,7 @@ case class AddAssetCommand(atomId: String,
                            previewPublisher: PreviewAtomPublisher,
                            val youtubeConfig: YouTubeConfig,
                            auditDataStore: AuditDataStore,
-                           username: Option[String])
+                           user: PandaUser)
     extends Command
     with MediaAtomImplicits {
 

--- a/app/model/commands/CreateAtomCommand.scala
+++ b/app/model/commands/CreateAtomCommand.scala
@@ -15,6 +15,8 @@ import scala.util.{Failure, Success}
 import com.gu.contentatom.thrift.{Atom => ThriftAtom}
 import com.gu.contentatom.thrift.atom.media.{Category => ThriftCategory, MediaAtom => ThriftMediaAtom, Metadata => ThriftMetadata, PrivacyStatus => ThriftPrivacyStatus}
 
+import com.gu.pandomainauth.model.{User => PandaUser}
+
 // Since the data store and publisher are injected rather than being objects we cannot serialize JSON directly into a
 // command so we'll use a small POD for easy JSONification
 case class CreateAtomCommandData(
@@ -35,7 +37,7 @@ case class CreateAtomCommand(data: CreateAtomCommandData)
                             (implicit previewDataStore: PreviewDataStore,
                              previewPublisher: PreviewAtomPublisher,
                              auditDataStore: AuditDataStore,
-                             username: Option[String]) extends Command {
+                             user: PandaUser) extends Command {
   type T = MediaAtom
 
   def process() = {
@@ -64,7 +66,7 @@ case class CreateAtomCommand(data: CreateAtomCommandData)
       contentChangeDetails = ContentChangeDetails(None, None, None, 1L)
     )
 
-    auditDataStore.auditCreate(atom.id, username)
+    auditDataStore.auditCreate(atom.id, user)
 
     previewDataStore.createAtom(atom).fold({
         case IDConflictError => AtomIdConflict

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -18,13 +18,15 @@ import data.AuditDataStore
 import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
 
+import com.gu.pandomainauth.model.{User => PandaUser}
+
 case class PublishAtomCommand(id: String)(implicit val previewDataStore: PreviewDataStore,
                                           val previewPublisher: PreviewAtomPublisher,
                                           val publishedDataStore: PublishedDataStore,
                                           val livePublisher: LiveAtomPublisher,
                                           auditDataStore: AuditDataStore,
                                           youtubeConfig: YouTubeConfig,
-                                          username: Option[String]) extends Command with AtomAPIActions {
+                                          user: PandaUser) extends Command with AtomAPIActions {
   type T = MediaAtom
 
   def process(): T = {
@@ -59,7 +61,7 @@ case class PublishAtomCommand(id: String)(implicit val previewDataStore: Preview
           )
         )
 
-        auditDataStore.auditPublish(id, username)
+        auditDataStore.auditPublish(id, user)
         UpdateAtomCommand(id, MediaAtom.fromThrift(updatedAtom)).process()
 
         publishAtomToLive(updatedAtom)

--- a/app/model/commands/UpdateAtomCommand.scala
+++ b/app/model/commands/UpdateAtomCommand.scala
@@ -16,11 +16,13 @@ import org.joda.time.DateTime
 import ai.x.diff.DiffShow
 import ai.x.diff.conversions._
 
+import com.gu.pandomainauth.model.{User => PandaUser}
+
 case class UpdateAtomCommand(id: String, atom: MediaAtom)
                             (implicit previewDataStore: PreviewDataStore,
                              previewPublisher: PreviewAtomPublisher,
                              auditDataStore: AuditDataStore,
-                             username: Option[String])
+                             user: PandaUser)
     extends Command
     with MediaAtomImplicits {
 
@@ -56,7 +58,7 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom)
 
         previewPublisher.publishAtomEvent(event) match {
           case Success(_) => {
-            auditDataStore.auditUpdate(id, username, diffString)
+            auditDataStore.auditUpdate(id, user, diffString)
             MediaAtom.fromThrift(thrift)
           }
           case Failure(err) => AtomPublishFailed(s"could not publish: ${err.toString}")

--- a/app/model/commands/UpdateMetadataCommand.scala
+++ b/app/model/commands/UpdateMetadataCommand.scala
@@ -13,13 +13,15 @@ import data.AuditDataStore
 
 import scala.util.{Failure, Success}
 
+import com.gu.pandomainauth.model.{User => PandaUser}
+
 case class UpdateMetadataCommand(atomId: String,
                                  metadata: UpdatedMetadata)
                                 (implicit previewDataStore: PreviewDataStore,
                                  previewPublisher: PreviewAtomPublisher,
                                  val youtubeConfig: YouTubeConfig,
                                  auditDataStore: AuditDataStore,
-                                 username: Option[String])
+                                 user: PandaUser)
     extends Command
     with MediaAtomImplicits {
 


### PR DESCRIPTION
The User of an hmac authed action has an `email` property of `""`, dynamo isn't comfortable with this and raises an exception:

`play.api.http.HttpErrorHandlerExceptions$$anon$1: Execution exception[[AmazonDynamoDBException: One or more parameter values were invalid: An AttributeValue may not contain an empty string (Service: AmazonDynamoDBv2; Status Code: 400; Error Code: ValidationException; Request ID: KF11D27416N4T1945546I375DNVV4KQNSO5AEMVJF66Q9ASUAAJG)]]`

Although we're doing:

```scala
implicit val username = Option(req.user.email)
username.getOrElse("unknown user")
```

`req.user.email` is [being set to `""`](https://github.com/guardian/panda-hmac/blob/master/src/main/scala/com/gu/pandahmac/HmacAuthActions.scala#L38) so we never `OrElse`.

Fix this by pattern matching on `email` - if empty string (i.e. hmac authed) use `firstName` else (i.e. panda user) use `email`.

Pattern matching on `email` is temporary until https://github.com/guardian/panda-hmac/pull/2 is released.

NB: CDS auths with hmac and MAM API is currently 500ing because of `AmazonDynamoDBException` above... so the MAM routes in CDS are failing atm 😱.