### PR TITLE
Allow for adding assets 

### DIFF
--- a/public/video-ui/src/actions/VideoActions/updateAsset.js
+++ b/public/video-ui/src/actions/VideoActions/updateAsset.js
@@ -1,8 +1,0 @@
-//NOTE: THIS DOESN'T SAVE THE ASSET, ONLY UPDATES THE CLIENT STATE. USE saveVideo TO SAVE
-export function updateAsset(asset) {
-  return {
-    type:       'ASSET_UPDATE_REQUEST',
-    asset:      asset,
-    receivedAt: Date.now()
-  };
-}

--- a/public/video-ui/src/components/VideoAssetAdd/VideoAssetAdd.js
+++ b/public/video-ui/src/components/VideoAssetAdd/VideoAssetAdd.js
@@ -1,6 +1,5 @@
 import React, {PropTypes} from 'react';
 import VideoAssetUrl from './formComponents/VideoAssetUrl';
-import validate from '../../constants/videoAssetAddValidation';
 import { Field, reduxForm } from 'redux-form';
 
 const VideoAssetAdd = (props) => {
@@ -13,6 +12,5 @@ const VideoAssetAdd = (props) => {
 };
 
 export default reduxForm({
-  form: 'VideoAssetAdd',
-  validate
+  form: 'VideoAssetAdd'
 })(VideoAssetAdd)

--- a/public/video-ui/src/components/VideoAssetAdd/formComponents/VideoAssetUrl.js
+++ b/public/video-ui/src/components/VideoAssetAdd/formComponents/VideoAssetUrl.js
@@ -5,28 +5,47 @@ import React from 'react';
 
 export default class VideoAssetUrl extends React.Component {
 
+  state = {
+    asset: {
+      uri: ""
+    }
+  }
+
   onUpdateAssetUrl = (e) => {
     const newVersion = this.props.video.activeVersion === undefined ? 0 : Math.max(...this.props.video.assets.map(x => x.version)) + 1;
-    this.props.updateAsset(Object.assign({}, this.props.asset, {
+    const newAsset = Object.assign({}, this.props.asset, {
       uri: e.target.value,
       version: newVersion
-    }));
+    });
+    this.setState({
+      asset: newAsset
+    });
+  };
+
+  onAssetSave = () => {
+    this.props.createAsset(this.state.asset);
+    this.props.hideAssetForm();
   };
 
   render () {
     if (!this.props.video) {
-      console.log('VideoAssetAdd loaded without video provided');
       return false;
     }
 
     const hasError = this.props.meta.touched && this.props.meta.error;
 
     return (
+      <div>
         <div className="form__row">
           <label className="form__label">Asset Url</label>
-          <input { ...this.props.input} className={"form__field " + (hasError ? "form__field--error" : "")} type="text" value={this.props.asset.uri || ""} onChange={this.onUpdateAssetUrl} />
+          <input { ...this.props.input} className={"form__field " + (hasError ? "form__field--error" : "")} type="text" value={this.state.asset.uri || ""} onChange={this.onUpdateAssetUrl} />
           {hasError ? <p className="form__message form__message--error">{this.props.meta.error}</p> : ""}
         </div>
+        <div className="btn__group">
+          <button className="btn" type="button" disabled={!this.state.asset.uri} onClick={this.onAssetSave}>Save</button>
+          <button className="btn" type="button" onClick={this.props.hideAssetForm}>Cancel</button>
+        </div>
+      </div>
     );
   }
 }

--- a/public/video-ui/src/components/VideoAssets/VideoAssets.js
+++ b/public/video-ui/src/components/VideoAssets/VideoAssets.js
@@ -39,8 +39,8 @@ class VideoAssets extends React.Component {
     });
   };
 
-  createAsset = () => {
-    this.props.videoActions.createAsset(this.props.asset, this.props.video.id);
+  createAsset = (asset) => {
+    this.props.videoActions.createAsset(asset, this.props.video.id);
   };
 
   revertAsset = (videoId, version) => {
@@ -50,10 +50,6 @@ class VideoAssets extends React.Component {
 
   updateVideo = (video) => {
     this.props.videoActions.updateVideo(video);
-  };
-
-  updateAsset = (asset) => {
-    this.props.videoActions.updateAsset(asset);
   };
 
   renderList() {
@@ -107,11 +103,7 @@ class VideoAssets extends React.Component {
     if (this.state.showAssetForm) {
       return (
         <form className="form baseline-margin">
-          <VideoAssetAdd updateAsset={this.updateAsset} {...this.props} />
-          <div className="btn__group">
-            <button className="btn" type="button" onClick={this.createAsset}>Save</button>
-            <button className="btn" type="button" onClick={this.hideAssetForm}>Cancel</button>
-          </div>
+          <VideoAssetAdd createAsset={this.createAsset} hideAssetForm={this.hideAssetForm} {...this.props} />
         </form>
       )
     }
@@ -142,7 +134,6 @@ import { bindActionCreators } from 'redux';
 import * as createAsset from '../../actions/VideoActions/createAsset';
 import * as updateVideo from '../../actions/VideoActions/updateVideo';
 import * as revertAsset from '../../actions/VideoActions/revertAsset';
-import * as updateAsset from '../../actions/VideoActions/updateAsset';
 
 function mapStateToProps(state) {
   return {
@@ -153,7 +144,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    videoActions: bindActionCreators(Object.assign({}, createAsset, updateVideo, revertAsset, updateAsset), dispatch)
+    videoActions: bindActionCreators(Object.assign({}, createAsset, updateVideo, revertAsset), dispatch)
   };
 }
 

--- a/public/video-ui/src/constants/videoAssetAddValidation.js
+++ b/public/video-ui/src/constants/videoAssetAddValidation.js
@@ -1,9 +1,0 @@
-const validate = (values) => {
-  const errors = {};
-  if (!values.url) {
-    errors.url = 'Required'
-  }
-  return errors
-};
-
-export default validate;

--- a/public/video-ui/src/reducers/assetReducer.js
+++ b/public/video-ui/src/reducers/assetReducer.js
@@ -4,9 +4,6 @@ export default function asset(state = null, action) {
     case 'ASSET_CREATE_RECEIVE':
       return action.asset || false;
 
-    case 'ASSET_UPDATE_REQUEST':
-      return action.asset;
-
     case 'ASSET_POPULATE_BLANK':
       return action.asset;
 


### PR DESCRIPTION
Fixes the form for adding new assets. 

There are still problems with creating new assets: 

- should the asset version number be calculated in the client? 
- Is the version number set correctly on the client? Currently if no asset is marked as active, the version number for the new asset is set to 0. This behaviour does not seem correct.
- The functionality for the video asset uri component does not make sense. It now contains the button for saving a new asset, and also contains logic for creating new assets and their versions numbers. It seems that there should be just one component for creating new assets.

We should decide if this functionality is going to stay in MAM and what it is going to look like. @akash1810 @clloyd 