### PR TITLE
Small UX tweaks to the banners

### DIFF
--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -73,13 +73,11 @@ class VideoDisplay extends React.Component {
 
     return (
       <div>
-        <VideoPublishBar video={this.props.video} saveState={this.props.saveState} publishVideo={this.publishVideo} />
         <VideoSelectBar onSelectVideo={this.selectVideo} embeddedMode={this.props.config.embeddedMode} />
 
         <div className="video">
           <div className="video__sidebar video-details">
             <form className="form video__sidebar__group">
-
               <VideoEdit
                 video={this.props.video || {}}
                 updateVideo={this.updateVideo}
@@ -89,6 +87,7 @@ class VideoDisplay extends React.Component {
                 saveState={this.props.saveState}
                 disableStatusEditing={this.cannotEditStatus()}
                />
+               <VideoPublishBar video={this.props.video} saveState={this.props.saveState} publishVideo={this.publishVideo} />
             </form>
           </div>
 

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -39,8 +39,8 @@ export default class VideoPublishBar extends React.Component {
 
     return (
       <div className="bar">
-        <span className="bar__message">This video atom has unpublished changes</span>
-        <button type="button" className="bar__button" onClick={this.props.publishVideo}>Publish Changes Now</button>
+        <span className="bar__message">This video has unpublished changes</span>
+        <button type="button" className="bar__button" onClick={this.props.publishVideo}>Publish changes to Youtube</button>
       </div>
     )
   }

--- a/public/video-ui/src/components/VideoSelectBar/VideoSelectBar.js
+++ b/public/video-ui/src/components/VideoSelectBar/VideoSelectBar.js
@@ -10,7 +10,6 @@ export default class VideoSelectBar extends React.Component {
 
     return (
       <div className="bar info-bar">
-        <span className="bar__message"></span>
         <button type="button" className="bar__button" onClick={this.props.onSelectVideo}>Select this Video</button>
       </div>
     )

--- a/public/video-ui/src/components/VideoSelectBar/VideoSelectBar.js
+++ b/public/video-ui/src/components/VideoSelectBar/VideoSelectBar.js
@@ -10,7 +10,7 @@ export default class VideoSelectBar extends React.Component {
 
     return (
       <div className="bar info-bar">
-        <span className="bar__message">You are in an embedded version of the media atom maker</span>
+        <span className="bar__message"></span>
         <button type="button" className="bar__button" onClick={this.props.onSelectVideo}>Select this Video</button>
       </div>
     )

--- a/public/video-ui/styles/components/_bar.scss
+++ b/public/video-ui/styles/components/_bar.scss
@@ -1,5 +1,4 @@
 .bar {
-  width: 100%;
   background-color: $cGreen32;
   border-bottom: 1px solid darken($cGreen32, 9);
 

--- a/public/video-ui/styles/components/_bar.scss
+++ b/public/video-ui/styles/components/_bar.scss
@@ -1,4 +1,5 @@
 .bar {
+  width: 100%;
   background-color: $cGreen32;
   border-bottom: 1px solid darken($cGreen32, 9);
 


### PR DESCRIPTION
A couple of frontend tweaks for my first PR to MAM!

1. Moved the green bar to the bottom left column. 
2. Tweaked the copy of both bars: The green one to say this will publish to yt and blue I just removed the copy for now as it's duplicated when in composer.

![image](https://cloud.githubusercontent.com/assets/2067172/21806281/4b690b78-d730-11e6-924a-9317daee160d.png)

cc @akash1810 @ShaunYearStrong 