### PR TITLE
Revert "Temporary error message change"

### DIFF
--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -13,7 +13,7 @@ object CommandExceptions extends Results {
   def NotYoutubeAsset = throw new CommandException("Asset is not a youtube video", 400)
   def AssetVersionConflict = throw new CommandException("Asset version conflict", 400)
   def AssetParseFailed = throw new CommandException("Failed to parse asset", 400)
-  def AssetEncodingInProcess = throw new CommandException("Asset encoding in process", 400) //This is a temporary fix to match the CDS message
+  def AssetEncodingInProcess = throw new CommandException("Asset encoding in progress", 400)
   def AssetNotFound = throw new CommandException("Asset not found", 404)
 
   def AssetNotFound(assetId: String) = throw new CommandException(s"Asset with id $assetId not found", 404)


### PR DESCRIPTION
Reverts guardian/media-atom-maker#157

Making a revert commit because too lazy to branch 😄 

CDS is only looking at the [response code](https://github.com/guardian/content_delivery_system/blob/master/CDS/scripts/js_utils/media-atom/media-atom.js#L60-L61) now; anything other than a 200 and it continues polling. So this message can be reverted.