### PR TITLE
HTTP 500 alarm and webhook

### DIFF
--- a/app/controllers/MainApp.scala
+++ b/app/controllers/MainApp.scala
@@ -23,6 +23,10 @@ class MainApp @Inject() (previewDataStore: PreviewDataStore,
     Ok("ok")
   }
 
+  def unhealthcheck = Action {
+    InternalServerError("this is a test")
+  }
+
   def oauthCallback = Action.async { implicit req =>
     processGoogleCallback()
   }

--- a/app/controllers/MainApp.scala
+++ b/app/controllers/MainApp.scala
@@ -23,10 +23,6 @@ class MainApp @Inject() (previewDataStore: PreviewDataStore,
     Ok("ok")
   }
 
-  def unhealthcheck = Action {
-    InternalServerError("this is a test")
-  }
-
   def oauthCallback = Action.async { implicit req =>
     processGoogleCallback()
   }

--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -55,6 +55,14 @@
         "AuditTable": {
             "Description": "Name of the audit dynamo table",
             "Type": "String"
+        },
+        "AlertWebhook": {
+          "Description": "Where CloudWatch alerts are sent",
+          "Type": "String"
+        },
+        "AlertActive": {
+          "Description": "Whether to send CloudWatch alerts to the AlertWebhook",
+          "Type": "String"
         }
     },
     "Mappings": {
@@ -442,6 +450,37 @@
                 },
                 "Roles": [{"Ref": "DistributionRole"}]
             }
+        },
+        "AlertTopic": {
+          "Type": "AWS::SNS::Topic",
+          "Properties": {
+            "DisplayName": { "Fn::Join" : [ "-", [ { "Ref": "Stage" },"Alerts"]] },
+            "Subscription": [{
+              "Endpoint": { "Ref": "AlertWebhook" },
+              "Protocol": "https"
+            }]
+          }
+        },
+        "MediaAtomMaker5XXAlarm": {
+          "Type": "AWS::CloudWatch::Alarm",
+          "Properties": {
+            "ActionsEnabled": { "Ref": "AlertActive" },
+            "AlarmDescription": "500 Error reported from media-atom-maker",
+            "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+            "Threshold": "1",
+            "Namespace": "AWS/ELB",
+            "MetricName": "HTTPCode_Backend_5XX",
+            "Dimensions": [
+              {
+                "Name": "LoadBalancerName",
+                "Value": { "Ref": "MediaAtomMakerLoadBalancer" }
+              }
+            ],
+            "Period": "300",
+            "EvaluationPeriods": "1",
+            "Statistic": "Sum",
+            "AlarmActions": [ { "Ref": "AlertTopic" } ]
+          }
         }
     }
 }

--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -59,10 +59,6 @@
         "AlertWebhook": {
           "Description": "Where CloudWatch alerts are sent",
           "Type": "String"
-        },
-        "AlertActive": {
-          "Description": "Whether to send CloudWatch alerts to the AlertWebhook",
-          "Type": "String"
         }
     },
     "Mappings": {
@@ -464,7 +460,6 @@
         "MediaAtomMaker5XXAlarm": {
           "Type": "AWS::CloudWatch::Alarm",
           "Properties": {
-            "ActionsEnabled": { "Ref": "AlertActive" },
             "AlarmDescription": "500 Error reported from media-atom-maker",
             "ComparisonOperator": "GreaterThanOrEqualToThreshold",
             "Threshold": "1",

--- a/conf/routes
+++ b/conf/routes
@@ -1,4 +1,6 @@
 GET     /healthcheck                    controllers.MainApp.healthcheck()
+GET     /unhealthcheck                  controllers.MainApp.unhealthcheck()
+
 GET     /oauthCallback                  controllers.MainApp.oauthCallback()
 GET     /atoms                          controllers.MainApp.listAtoms()
 

--- a/conf/routes
+++ b/conf/routes
@@ -1,5 +1,4 @@
 GET     /healthcheck                    controllers.MainApp.healthcheck()
-GET     /unhealthcheck                  controllers.MainApp.unhealthcheck()
 
 GET     /oauthCallback                  controllers.MainApp.oauthCallback()
 GET     /atoms                          controllers.MainApp.listAtoms()


### PR DESCRIPTION
This PR updates the cloud formation JSON to include an alarm on HTTP 500 responses which routes through to a webhook via SNS.

When deployed with the right parameters, this hooks up media-atom-maker to pager duty.