### PR TITLE
4XX request logging and more cloudwatch alarms

### DIFF
--- a/app/util/RequestLogging.scala
+++ b/app/util/RequestLogging.scala
@@ -1,0 +1,25 @@
+package util
+
+import javax.inject.{Inject, Provider, Singleton}
+
+import play.api.http.DefaultHttpErrorHandler
+import play.api.mvc.{RequestHeader, Result}
+import play.api._
+import play.api.routing.Router
+
+import scala.concurrent.Future
+
+@Singleton
+class RequestLogging @Inject() (env: Environment, config: Configuration, sourceMapper: OptionalSourceMapper,
+                                router: Provider[Router]) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) {
+
+  override def onProdServerError(request: RequestHeader, exception: UsefulException): Future[Result] = {
+    super.logServerError(request, exception)
+    super.onProdServerError(request, exception)
+  }
+
+  override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
+    Logger.info(s"$statusCode for (${request.method}) [${request.uri}] - $message")
+    super.onClientError(request, statusCode, message)
+  }
+}

--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -56,9 +56,13 @@
             "Description": "Name of the audit dynamo table",
             "Type": "String"
         },
+        "AlertActive": {
+            "Description": "Whether to send CloudWatch alerts",
+            "Type": "String"
+        },
         "AlertWebhook": {
-          "Description": "Where CloudWatch alerts are sent",
-          "Type": "String"
+            "Description": "Where CloudWatch alerts are sent",
+            "Type": "String"
         }
     },
     "Mappings": {
@@ -448,74 +452,77 @@
             }
         },
         "AlertTopic": {
-          "Type": "AWS::SNS::Topic",
-          "Properties": {
-            "DisplayName": { "Fn::Join" : [ "-", [ { "Ref": "Stage" },"Alerts"]] },
-            "Subscription": [{
-              "Endpoint": { "Ref": "AlertWebhook" },
-              "Protocol": "https"
-            }]
-          }
+            "Type": "AWS::SNS::Topic",
+            "Properties": {
+                "DisplayName": { "Fn::Join" : [ "-", [ { "Ref": "Stage" },"Alerts"]] },
+                "Subscription": [{
+                  "Endpoint": { "Ref": "AlertWebhook" },
+                  "Protocol": "https"
+                }]
+            }
         },
         "MediaAtomMaker5XXAlarm": {
-          "Type": "AWS::CloudWatch::Alarm",
-          "Properties": {
-            "AlarmDescription": "500 Error reported from media-atom-maker",
-            "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-            "Threshold": "1",
-            "Namespace": "AWS/ELB",
-            "MetricName": "HTTPCode_Backend_5XX",
-            "Dimensions": [
-              {
-                "Name": "LoadBalancerName",
-                "Value": { "Ref": "MediaAtomMakerLoadBalancer" }
-              }
-            ],
-            "Period": "300",
-            "EvaluationPeriods": "1",
-            "Statistic": "Sum",
-            "AlarmActions": [ { "Ref": "AlertTopic" } ]
-          }
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "ActionsEnabled": { "Ref": "AlertActive" },
+                "AlarmDescription": "500 Error reported from media-atom-maker",
+                "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+                "Threshold": "1",
+                "Namespace": "AWS/ELB",
+                "MetricName": "HTTPCode_Backend_5XX",
+                "Dimensions": [
+                    {
+                      "Name": "LoadBalancerName",
+                      "Value": { "Ref": "MediaAtomMakerLoadBalancer" }
+                    }
+                ],
+                "Period": "300",
+                "EvaluationPeriods": "1",
+                "Statistic": "Sum",
+                "AlarmActions": [ { "Ref": "AlertTopic" } ]
+            }
         },
         "MediaAtomMaker4XXAlarm": {
-          "Type": "AWS::CloudWatch::Alarm",
-          "Properties": {
-            "AlarmDescription": "Repeated 4XX errors reported from media-atom-maker",
-            "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-            "Threshold": "15",
-            "Namespace": "AWS/ELB",
-            "MetricName": "HTTPCode_Backend_4XX",
-            "Dimensions": [
-              {
-                "Name": "LoadBalancerName",
-                "Value": { "Ref": "MediaAtomMakerLoadBalancer" }
-              }
-            ],
-            "Period": "300",
-            "EvaluationPeriods": "2",
-            "Statistic": "Sum",
-            "AlarmActions": [ { "Ref": "AlertTopic" } ]
-          }
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "ActionsEnabled": { "Ref": "AlertActive" },
+                "AlarmDescription": "Repeated 4XX errors reported from media-atom-maker",
+                "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+                "Threshold": "15",
+                "Namespace": "AWS/ELB",
+                "MetricName": "HTTPCode_Backend_4XX",
+                "Dimensions": [
+                    {
+                      "Name": "LoadBalancerName",
+                      "Value": { "Ref": "MediaAtomMakerLoadBalancer" }
+                    }
+                ],
+                "Period": "300",
+                "EvaluationPeriods": "2",
+                "Statistic": "Sum",
+                "AlarmActions": [ { "Ref": "AlertTopic" } ]
+            }
         },
         "MediaAtomMakerLatency": {
-          "Type": "AWS::CloudWatch::Alarm",
-          "Properties": {
-            "AlarmDescription": "Requests to media-atom-maker start taking on average more than 1 second",
-            "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-            "Threshold": "1",
-            "Namespace": "AWS/ELB",
-            "MetricName": "Latency",
-            "Dimensions": [
-              {
-                "Name": "LoadBalancerName",
-                "Value": { "Ref": "MediaAtomMakerLoadBalancer" }
-              }
-            ],
-            "Period": "300",
-            "EvaluationPeriods": "1",
-            "Statistic": "Average",
-            "AlarmActions": [ { "Ref": "AlertTopic" } ]
-          }
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "ActionsEnabled": { "Ref": "AlertActive" },
+                "AlarmDescription": "Requests to media-atom-maker start taking on average more than 1 second",
+                "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+                "Threshold": "1",
+                "Namespace": "AWS/ELB",
+                "MetricName": "Latency",
+                "Dimensions": [
+                    {
+                      "Name": "LoadBalancerName",
+                      "Value": { "Ref": "MediaAtomMakerLoadBalancer" }
+                    }
+                ],
+                "Period": "300",
+                "EvaluationPeriods": "1",
+                "Statistic": "Average",
+                "AlarmActions": [ { "Ref": "AlertTopic" } ]
+            }
         }
     }
 }

--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -476,6 +476,46 @@
             "Statistic": "Sum",
             "AlarmActions": [ { "Ref": "AlertTopic" } ]
           }
+        },
+        "MediaAtomMaker4XXAlarm": {
+          "Type": "AWS::CloudWatch::Alarm",
+          "Properties": {
+            "AlarmDescription": "Repeated 4XX errors reported from media-atom-maker",
+            "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+            "Threshold": "15",
+            "Namespace": "AWS/ELB",
+            "MetricName": "HTTPCode_Backend_4XX",
+            "Dimensions": [
+              {
+                "Name": "LoadBalancerName",
+                "Value": { "Ref": "MediaAtomMakerLoadBalancer" }
+              }
+            ],
+            "Period": "300",
+            "EvaluationPeriods": "2",
+            "Statistic": "Sum",
+            "AlarmActions": [ { "Ref": "AlertTopic" } ]
+          }
+        },
+        "MediaAtomMakerLatency": {
+          "Type": "AWS::CloudWatch::Alarm",
+          "Properties": {
+            "AlarmDescription": "Requests to media-atom-maker start taking on average more than 1 second",
+            "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+            "Threshold": "1",
+            "Namespace": "AWS/ELB",
+            "MetricName": "Latency",
+            "Dimensions": [
+              {
+                "Name": "LoadBalancerName",
+                "Value": { "Ref": "MediaAtomMakerLoadBalancer" }
+              }
+            ],
+            "Period": "300",
+            "EvaluationPeriods": "1",
+            "Statistic": "Average",
+            "AlarmActions": [ { "Ref": "AlertTopic" } ]
+          }
         }
     }
 }

--- a/conf/reference.conf
+++ b/conf/reference.conf
@@ -38,6 +38,8 @@ host = "media-atom-maker.{DOMAIN}"
 # This secret is shared with other machines for machine-to-machine communication
 secret = "secret sauce"
 
+play.http.errorHandler = "util.RequestLogging"
+
 include "youtube-DEV.conf"
 include "capi-DEV.conf"
 include "flexible-DEV.conf"


### PR DESCRIPTION
Adds logging for 4XX client errors. I think this will be useful whilst media-atom-maker is still under trial but may need removing if it gets spammy.

Also adds a few more alarms:

- Repeated 4XX errors (as seen from the load balancer)
- Request latency exceeding 1 second

Again, these will be reviewed as the trial continues (right now they're pretty much copied from the grid :) )