### PR TITLE
Improved server side JSON validation

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -2,23 +2,22 @@ package controllers
 
 import javax.inject.Inject
 
+import _root_.util.{AWSConfig, ExpiryPoller, YouTubeConfig, YouTubeVideoUpdateApi}
 import akka.actor.ActorSystem
 import com.gu.atom.data.{PreviewDataStore, PublishedDataStore}
 import com.gu.atom.play.AtomAPIActions
 import com.gu.atom.publish.{LiveAtomPublisher, PreviewAtomPublisher}
-import com.gu.contentatom.thrift.Atom
 import com.gu.pandahmac.HMACAuthActions
-import data.JsonConversions._
+import com.gu.pandomainauth.action.UserRequest
 import data.AuditDataStore
 import model.Category.Hosted
 import model.commands.CommandExceptions._
 import model.commands._
+import model.{MediaAtom, UpdatedMetadata}
 import play.api.Configuration
-import model.commands.CommandExceptions._
-import _root_.util.{YouTubeVideoUpdateApi, YouTubeConfig, AWSConfig, ExpiryPoller}
 import util.atom.MediaAtomImplicits
 import play.api.libs.json._
-import model.{MediaAtom, UpdatedMetadata}
+import play.api.mvc.{AnyContent, Result}
 
 class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
                      implicit val publishedDataStore: PublishedDataStore,
@@ -70,69 +69,52 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
 
   def publishMediaAtom(id: String) = APIHMACAuthAction { implicit req =>
     implicit val user = req.user
-    try {
-      val updatedAtom = PublishAtomCommand(id).process()
-      Ok(Json.toJson(updatedAtom))
-    } catch {
-      commandExceptionAsResult
-    }
+
+    val updatedAtom = PublishAtomCommand(id).process()
+    Ok(Json.toJson(updatedAtom))
   }
 
   def createMediaAtom = APIHMACAuthAction { implicit req =>
     implicit val user = req.user
-    req.body.asJson.map { json =>
-      try {
-        val request = json.as[CreateAtomCommandData]
 
-        val atom = CreateAtomCommand(request).process()
-        Created(Json.toJson(atom)).withHeaders("Location" -> atomUrl(atom.id))
-
-      } catch {
-        commandExceptionAsResult
-      }
-
-    }.getOrElse {
-      BadRequest("Could not read json")
+    parse(req) { command: CreateAtomCommandData =>
+      val atom = CreateAtomCommand(command).process()
+      Created(Json.toJson(atom)).withHeaders("Location" -> atomUrl(atom.id))
     }
   }
 
   def putMediaAtom(id: String) = APIHMACAuthAction { implicit req =>
     implicit val user = req.user
-    req.body.asJson.map { json =>
-      try {
-        val atom = json.as[MediaAtom]
-        val thriftAtom = atom.asThrift
-        val atomWithExpiryChecked = YouTubeVideoUpdateApi(youtubeConfig).updateStatusIfExpired(thriftAtom) match {
-          case Some(expiredAtom) => expiredAtom
-          case _ => atom
-        }
-        val updatedAtom = UpdateAtomCommand(id, atomWithExpiryChecked).process()
-        Ok(Json.toJson(updatedAtom))
-      } catch {
-        commandExceptionAsResult
+
+    parse(req) { atom: MediaAtom =>
+      val thriftAtom = atom.asThrift
+      val atomWithExpiryChecked = YouTubeVideoUpdateApi(youtubeConfig).updateStatusIfExpired(thriftAtom) match {
+        case Some(expiredAtom) => expiredAtom
+        case _ => atom
       }
-    }.getOrElse {
-      BadRequest("Could not read json")
+
+      val updatedAtom = UpdateAtomCommand(id, atomWithExpiryChecked).process()
+      Ok(Json.toJson(updatedAtom))
     }
   }
 
   def addAsset(atomId: String) = APIHMACAuthAction { implicit req =>
     implicit val user = req.user
 
-    req.body.asJson.map { json =>
-      try {
-        val videoId = (json \ "uri").as[String]
-        val mimeType: Option[String] = (json \ "mimeType").asOpt[String]
-        val version: Option[Long] = (json \ "version").asOpt[Long]
+    implicit val readAssetCommand = new Reads[AddAssetCommand] {
+      override def reads(json: JsValue): JsResult[AddAssetCommand] = {
+        (json \ "uri").validate[String].map { videoId =>
+          val mimeType = (json \ "mimeType").asOpt[String]
+          val version = (json \ "version").asOpt[Long]
 
-        val atom = AddAssetCommand(atomId, videoId, version, mimeType).process()
-
-        Ok(Json.toJson(atom))
-      } catch {
-        commandExceptionAsResult
+          AddAssetCommand(atomId, videoId, version, mimeType)
+        }
       }
-    }.getOrElse {
-      BadRequest("Could not read json")
+    }
+
+    parse(req) { command: AddAssetCommand =>
+      val atom = command.process()
+      Ok(Json.toJson(atom))
     }
   }
 
@@ -141,35 +123,50 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
 
   def updateMetadata(atomId: String) = APIHMACAuthAction { implicit req =>
     implicit val user = req.user
-    req.body.asJson.map { json =>
-      json.validate[UpdatedMetadata] match {
-        case JsSuccess(metadata, _) =>
-          UpdateMetadataCommand(atomId, metadata).process()
-          Ok
-        case JsError(e) => BadRequest(s"Json doesn't contain the right fields. $e")
-      }
 
-    }.getOrElse {
-      BadRequest("Could not read json")
+    parse(req) { metadata: UpdatedMetadata =>
+      UpdateMetadataCommand(atomId, metadata).process()
+      Ok
     }
   }
 
   def setActiveAsset(atomId: String) = APIHMACAuthAction { implicit req =>
     implicit val user = req.user
-    req.body.asJson.map { json =>
-      try {
-        val videoId = (json \ "youtubeId").as[String]
-        val atom = ActiveAssetCommand(atomId, videoId).process()
-        Ok(Json.toJson(atom))
-      } catch {
-        commandExceptionAsResult
+
+    implicit val readActiveAssetCommand = new Reads[ActiveAssetCommand] {
+      override def reads(json: JsValue): JsResult[ActiveAssetCommand] = {
+        (json \ "youtubeId").validate[String].map(ActiveAssetCommand(atomId, _))
       }
-    }.getOrElse {
-      BadRequest("Could not read json")
+    }
+
+    parse(req) { command: ActiveAssetCommand =>
+      val atom = command.process()
+      Ok(Json.toJson(atom))
     }
   }
 
   def getAuditTrailForAtomId(id: String) = APIHMACAuthAction { implicit req =>
     Ok(Json.toJson(auditDataStore.getAuditTrailForAtomId(id)))
+  }
+
+  private def parse[T](raw: UserRequest[AnyContent])(fn: T => Result)(implicit reads: Reads[T]): Result = try {
+    raw.body.asJson match {
+      case Some(rawJson) =>
+        rawJson.validate[T] match {
+          case JsSuccess(request, _) =>
+            fn(request)
+
+          case JsError(errors) =>
+            val errorsByPath = errors.flatMap { case(p, e) => e.map(p -> _) } // flatten
+            val msg = errorsByPath.map { case(p, e) => s"$p -> $e" }.mkString("\n")
+
+            BadRequest(msg)
+        }
+
+      case None =>
+        BadRequest("Unable to parse body as JSON")
+    }
+  } catch {
+    commandExceptionAsResult
   }
 }

--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -71,8 +71,12 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
   def publishMediaAtom(id: String) = APIHMACAuthAction { implicit req =>
     implicit val user = req.user
 
-    val updatedAtom = PublishAtomCommand(id).process()
-    Ok(Json.toJson(updatedAtom))
+    try {
+      val updatedAtom = PublishAtomCommand(id).process()
+      Ok(Json.toJson(updatedAtom))
+    } catch {
+      commandExceptionAsResult
+    }
   }
 
   def createMediaAtom = APIHMACAuthAction { implicit req =>

--- a/public/video-ui/src/reducers/saveStateReducer.js
+++ b/public/video-ui/src/reducers/saveStateReducer.js
@@ -63,6 +63,14 @@ export default function saveState(state = {
       return Object.assign({}, state, {
         searching: false
       });
+
+    case 'SHOW_ERROR':
+      return Object.assign({}, state, {
+        searching: false,
+        saving: false,
+        publishing: false
+      });
+
     default:
       return state;
   }


### PR DESCRIPTION
Refactored out JSON validation in `Api2` into a single method, which returns a `BadRequest` response detailing the errors.

For example, missing out fields in the `create` UI no longer causes a 500 but returns a list of the missing fields:

```
/posterImage -> ValidationError(List(error.path.missing),WrappedArray())
/youtubeCategoryId -> ValidationError(List(error.path.missing),WrappedArray())
/channelId -> ValidationError(List(error.path.missing),WrappedArray())
```

Also update the front-end to clear out saving/publishing/searching state when an error occurs. This stops the save button from spinning forever.

NB: the error still shows up in red at the top forever (#187)