### PR TITLE
Update to primary colours and subsequent buttons

### DIFF
--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -78,6 +78,7 @@ class VideoDisplay extends React.Component {
         <div className="video">
           <div className="video__sidebar video-details">
             <form className="form video__sidebar__group">
+            <VideoPublishBar video={this.props.video} saveState={this.props.saveState} publishVideo={this.publishVideo} />
               <VideoEdit
                 video={this.props.video || {}}
                 updateVideo={this.updateVideo}
@@ -87,7 +88,6 @@ class VideoDisplay extends React.Component {
                 saveState={this.props.saveState}
                 disableStatusEditing={this.cannotEditStatus()}
                />
-               <VideoPublishBar video={this.props.video} saveState={this.props.saveState} publishVideo={this.publishVideo} />
             </form>
           </div>
 

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -39,7 +39,8 @@ export default class VideoPublishBar extends React.Component {
 
     return (
       <div className="bar">
-        <span className="bar__message">This video has unpublished changes</span>
+        <i className="icon">repeat</i>
+        <span className="bar__message">This video has unpublished meta data</span>
         <button type="button" className="bar__button" onClick={this.props.publishVideo}>Publish changes to Youtube</button>
       </div>
     )

--- a/public/video-ui/styles/abstracts/_variables.scss
+++ b/public/video-ui/styles/abstracts/_variables.scss
@@ -78,8 +78,8 @@ $darkGreyBorderColor: $color650Grey;
 /*
 Text colours
 */
-$brandColor: #297f5d;
-$darkBrandColor: #21674b;
+$brandColor: #ffbc01;
+$darkBrandColor: darken($brandColor, 2%);
 $lightBrandColor: lighten($brandColor, 60);
 $textColor: $color400Grey;
 $anchorColor: $cWhite;

--- a/public/video-ui/styles/abstracts/_variables.scss
+++ b/public/video-ui/styles/abstracts/_variables.scss
@@ -79,7 +79,7 @@ $darkGreyBorderColor: $color650Grey;
 Text colours
 */
 $brandColor: #ffbc01;
-$darkBrandColor: darken($brandColor, 2%);
+$darkBrandColor: darken($brandColor, 5);
 $lightBrandColor: lighten($brandColor, 60);
 $textColor: $color400Grey;
 $anchorColor: $cWhite;

--- a/public/video-ui/styles/components/_asset-list.scss
+++ b/public/video-ui/styles/components/_asset-list.scss
@@ -55,9 +55,7 @@ $assetThumbnailHeight: 40px;
 
   &__current {
     text-align: center;
-    background: $brandColor;
     color: $cWhite;
-    font-weight: bold;
     border-radius: 2em;
     padding: 3px 5px;
     flex-shrink: 0;

--- a/public/video-ui/styles/components/_bar.scss
+++ b/public/video-ui/styles/components/_bar.scss
@@ -1,6 +1,5 @@
 .bar {
   width: 100%;
-  // background-color: $color700Grey;
   padding: 15px;
   text-align: left;
   font-size: 15px;

--- a/public/video-ui/styles/components/_bar.scss
+++ b/public/video-ui/styles/components/_bar.scss
@@ -1,19 +1,21 @@
 .bar {
   width: 100%;
-  background-color: $cGreen32;
-  border-bottom: 1px solid darken($cGreen32, 9);
-
-  padding: 5px;
-  text-align: center;
-
+  // background-color: $color700Grey;
+  padding: 15px;
+  text-align: left;
   font-size: 15px;
 
   &__button {
-    background-color: $color650Grey;
+    background-color: $brandColor;
     font-size: 12px;
-    padding: 5px 10px;
-    margin-bottom: 2px;
-    color: $color300Grey;
+    font-weight: bold;
+    padding: 10px;
+    margin:5px 0 2px;
+    color: $color800Grey;
+
+    &:hover {
+      background-color: darken($brandColor, 5%);
+    }
 
     &:focus {
       outline: 1px solid $cWhite;
@@ -21,7 +23,7 @@
   }
 
   &__message {
-    margin-right: 15px;
+    margin-left: 5px;
   }
 }
 

--- a/public/video-ui/styles/components/_buttons.scss
+++ b/public/video-ui/styles/components/_buttons.scss
@@ -15,7 +15,7 @@ button {
   display: block;
   padding: 10px;
   background: $darkBrandColor;
-  color: $cWhite;
+  color: $color800Grey;
   font-size: 12px;
   font-weight: bold;
 

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -18,9 +18,9 @@
   flex-grow: 1;
   padding: 10px 15px;
 
-  background-color: $color700Grey;
+  background-color: $color800Grey;
 
-  box-shadow: inset 2px 2px 4px $color800Grey;
+  // box-shadow: inset 2px 2px 4px $color800Grey;
 
 
   &__header {

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -20,9 +20,6 @@
 
   background-color: $color800Grey;
 
-  // box-shadow: inset 2px 2px 4px $color800Grey;
-
-
   &__header {
     display: flex;
   }


### PR DESCRIPTION
Switched the primary colour to media yellow
Move YT publish back up as colour was messy and CTA brought in line with primary

Current asset identifier now transparent text.

![image](https://cloud.githubusercontent.com/assets/2067172/21889912/292906e6-d8c3-11e6-883d-956f2856c08a.png)

cc @akash1810 @ShaunYearStrong @Reettaphant 