### PR TITLE
Fix alarm so it does not fire as quickly

### DIFF
--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -492,7 +492,7 @@
                 "ActionsEnabled": { "Ref": "AlertActive" },
                 "AlarmDescription": "Repeated 4XX errors reported from media-atom-maker",
                 "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-                "Threshold": "15",
+                "Threshold": "30",
                 "Namespace": "AWS/ELB",
                 "MetricName": "HTTPCode_Backend_4XX",
                 "Dimensions": [
@@ -511,9 +511,9 @@
             "Type": "AWS::CloudWatch::Alarm",
             "Properties": {
                 "ActionsEnabled": { "Ref": "AlertActive" },
-                "AlarmDescription": "Requests to media-atom-maker start taking on average more than 1 second",
+                "AlarmDescription": "Requests to media-atom-maker start taking on average more than 3 seconds",
                 "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-                "Threshold": "1",
+                "Threshold": "3",
                 "Namespace": "AWS/ELB",
                 "MetricName": "Latency",
                 "Dimensions": [
@@ -523,7 +523,7 @@
                     }
                 ],
                 "Period": "300",
-                "EvaluationPeriods": "1",
+                "EvaluationPeriods": "2",
                 "Statistic": "Average",
                 "AlarmActions": [ { "Ref": "AlertTopic" } ]
             }

--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -63,6 +63,10 @@
         "AlertWebhook": {
             "Description": "Where CloudWatch alerts are sent",
             "Type": "String"
+        },
+        "DomainToMonitor": {
+          "Description": "Domain name for the Route53 health check",
+          "Type": "String"
         }
     },
     "Mappings": {
@@ -71,15 +75,13 @@
                 "MinSize": 3,
                 "MaxSize": 6,
                 "DesiredCapacity": 3,
-                "InstanceType": "t2.medium",
-                "Domain": "media-atom-maker.gutools.co.uk"
+                "InstanceType": "t2.medium"
             },
             "CODE": {
                 "MinSize": 1,
                 "MaxSize": 2,
                 "DesiredCapacity": 1,
-                "InstanceType": "t2.small",
-                "Domain": "media-atom-maker.code.dev-gutools.co.uk"
+                "InstanceType": "t2.small"
             }
         }
     },
@@ -532,7 +534,7 @@
                 "HealthCheckConfig": {
                     "Port": 443,
                     "Type": "HTTPS",
-                    "FullyQualifiedDomainName": { "Fn::FindInMap": ["StageMap", {"Ref": "Stage"}, "Domain"] },
+                    "FullyQualifiedDomainName": { "Ref": "DomainToMonitor" },
                     "ResourcePath": "/video/videos",
                     "RequestInterval": "30",
                     "FailureThreshold": "3"
@@ -540,7 +542,7 @@
                 "HealthCheckTags": [
                     {
                         "Key": "Name",
-                        "Value": { "Fn::Join": [ "", [ "https://", { "Fn::FindInMap": ["StageMap", {"Ref": "Stage"}, "Domain"] }, "/video/videos" ] ] }
+                        "Value": { "Fn::Join": [ "", [ "https://", { "Ref": "DomainToMonitor" }, "/video/videos" ] ] }
                     }
                 ]
             }

--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -540,7 +540,7 @@
               }
             ],
             "Period": "300",
-            "EvaluationPeriods": "1",
+            "EvaluationPeriods": "2",
             "Statistic": "Average",
             "AlarmActions": [ { "Ref": "AlertTopic" } ]
           }

--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -71,13 +71,15 @@
                 "MinSize": 3,
                 "MaxSize": 6,
                 "DesiredCapacity": 3,
-                "InstanceType": "t2.medium"
+                "InstanceType": "t2.medium",
+                "Domain": "media-atom-maker.gutools.co.uk"
             },
             "CODE": {
                 "MinSize": 1,
                 "MaxSize": 2,
                 "DesiredCapacity": 1,
-                "InstanceType": "t2.small"
+                "InstanceType": "t2.small",
+                "Domain": "media-atom-maker.code.dev-gutools.co.uk"
             }
         }
     },
@@ -524,26 +526,45 @@
                 "AlarmActions": [ { "Ref": "AlertTopic" } ]
             }
         },
-        "MediaAtomMakerUnhealthy": {
-          "Type": "AWS::CloudWatch::Alarm",
-          "Properties": {
-            "ActionsEnabled": { "Ref": "AlertActive" },
-            "AlarmDescription": "Unexpectedly unhealthy instances",
-            "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-            "Threshold": "1",
-            "Namespace": "AWS/ELB",
-            "MetricName": "UnHealthyHostCount",
-            "Dimensions": [
-              {
-                "Name": "LoadBalancerName",
-                "Value": { "Ref": "MediaAtomMakerLoadBalancer" }
-              }
-            ],
-            "Period": "300",
-            "EvaluationPeriods": "2",
-            "Statistic": "Average",
-            "AlarmActions": [ { "Ref": "AlertTopic" } ]
-          }
+        "MediaAtomMakerPingVideos": {
+            "Type": "AWS::Route53::HealthCheck",
+            "Properties": {
+                "HealthCheckConfig": {
+                    "Port": 443,
+                    "Type": "HTTPS",
+                    "FullyQualifiedDomainName": { "Fn::FindInMap": ["StageMap", {"Ref": "Stage"}, "Domain"] },
+                    "ResourcePath": "/video/videos",
+                    "RequestInterval": "30",
+                    "FailureThreshold": "3"
+                },
+                "HealthCheckTags": [
+                    {
+                        "Key": "Name",
+                        "Value": { "Fn::Join": [ "", [ "https://", { "Fn::FindInMap": ["StageMap", {"Ref": "Stage"}, "Domain"] }, "/video/videos" ] ] }
+                    }
+                ]
+            }
+        },
+        "MediaAtomMakerVideosDown": {
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "ActionsEnabled": { "Ref": "AlertActive" },
+                "AlarmDescription": "Unable to get a response from the videos application",
+                "ComparisonOperator": "LessThanThreshold",
+                "Threshold": "1",
+                "Namespace": "AWS/Route53",
+                "MetricName": "HealthCheckStatus",
+                "Dimensions": [
+                    {
+                      "Name": "HealthCheckId",
+                      "Value": { "Ref": "MediaAtomMakerPingVideos" }
+                    }
+                ],
+                "Period": "60",
+                "EvaluationPeriods": "1",
+                "Statistic": "Minimum",
+                "AlarmActions": [ { "Ref": "AlertTopic" } ]
+            }
         }
     }
 }


### PR DESCRIPTION
The unhealthy alarm was firing during deploys. This replaces it with a Route53 end-point check.

PS @akash1810 your review comment on #195 was completely correct sorry!

cc @jennysivapalan @akash1810 