### PR TITLE
Fix search results to be less confusing

### DIFF
--- a/public/video-ui/src/actions/VideoActions/getVideos.js
+++ b/public/video-ui/src/actions/VideoActions/getVideos.js
@@ -54,6 +54,7 @@ export function getVideos() {
 function adaptCapiAtom(atom) {
   const ret = {
     id: atom.id,
+    activeVersion: -1, // not known
     title: atom.data.media.title,
     contentChangeDetails: atom.contentChangeDetails,
     assets: atom.data.media.assets

--- a/public/video-ui/src/actions/VideoActions/getVideos.js
+++ b/public/video-ui/src/actions/VideoActions/getVideos.js
@@ -51,22 +51,33 @@ export function getVideos() {
   };
 }
 
+function adaptCapiAtom(atom) {
+  const ret = {
+    id: atom.id,
+    title: atom.data.media.title,
+    contentChangeDetails: atom.contentChangeDetails,
+    assets: atom.data.media.assets
+  };
+
+  if(atom.data.media.posterImage)
+    ret.posterImage = atom.data.media.posterImage;
+
+  return ret;
+}
+
 export function searchVideosWithQuery(query) {
   return dispatch => {
     dispatch(requestSearchVideos());
+
     return searchText(query)
       .then(res => {
         const capiAtoms = res.response.results;
-        const atoms = capiAtoms.map((capiAtom) => {
-          return {
-            id: capiAtom.id,
-            title: capiAtom.data.media.title,
-            contentChangeDetails: capiAtom.contentChangeDetails,
-            assets: capiAtom.data.media.assets
-          }
-        });
+        const atoms = capiAtoms.map(adaptCapiAtom);
+
         dispatch(receiveSearchVideos(atoms));
       })
-      .catch(error => dispatch(errorReceivingVideos(error)));
+      .catch(error => {
+        dispatch(errorReceivingVideos(error))
+      });
   };
 }

--- a/public/video-ui/src/components/Videos/VideoItem.js
+++ b/public/video-ui/src/components/Videos/VideoItem.js
@@ -4,17 +4,20 @@ import {Link} from 'react-router';
 export default class VideoItem extends React.Component {
 
   renderActiveAssetName() {
+    const activeVersion = this.props.video.activeVersion ? this.props.video.activeVersion : 0;
 
-    if (this.props.video.activeVersion && this.props.video.assets.length) {
-      const activeAssets = this.props.video.assets.filter((asset) => asset.version === this.props.video.activeVersion)
-      if (activeAssets.length) {
-        if (activeAssets[0] && activeAssets[0].platform) {
-          return <span className="success">Active {activeAssets[0].platform} video</span>
-        }
+    if(activeVersion === -1) {
+      // search results do not contain the version
+      return "";
+    } else {
+      const assets = this.props.video.assets.filter((asset) => asset.version === activeVersion);
+
+      if(assets.length && assets[0] && assets[0].platform) {
+        return <span className="success">Active {assets[0].platform} video</span>
+      } else {
+        return <span className="error">No Active Assets</span>
       }
     }
-
-    return <span className="error">No Active Assets</span>
   }
 
   renderItemImage() {


### PR DESCRIPTION
Currently, video search results are returned without an image and marked as 'No Active Assets' even if they have some. It's kind of confusing and threw me off on a tangent when debugging some other things.

The reason (I think) is that search is powered by CAPI results which are then massaged into the right shape client side. This process was not including the images, which is now fixed. The fix also hides the 'active assets' text when displaying results from the search.

**Before**

<img width="1274" alt="1d1da401-422f-43ec-9b49-c5bbe3a9751e" src="https://cloud.githubusercontent.com/assets/395805/22061316/519adbb0-dd6c-11e6-9cda-c7bc2cf02560.png">

**After**

<img width="1273" alt="cbd6f85a-b6a1-419c-9a45-8dd90a792bf7" src="https://cloud.githubusercontent.com/assets/395805/22061187/b84d8836-dd6b-11e6-84a7-ca5fbc15ae36.png">

**Notes to reviewers**

I've hidden the 'active assets' text by passing `activeVersion` as -1 from search results. This is 
smelly but was the best I could think of without touching too much code. Any other suggestions very welcome!

cc @ShaunYearStrong @akash1810 @Reettaphant 
Fixes #191 