### PR TITLE
No unpub embed

### DIFF
--- a/public/video-ui/src/components/VideoPage/VideoPage.js
+++ b/public/video-ui/src/components/VideoPage/VideoPage.js
@@ -96,14 +96,21 @@ export default class VideoPage extends React.Component {
 
     //If there are no composer pages, display a button that allows for creating one
     else {
+
+      if (this.props.video && this.props.video.contentChangeDetails && this.props.video.contentChangeDetails.published) {
+        return (
+          <button
+            type="button"
+            className="btn page__add__button"
+            disabled={this.state.pageCreated}
+            onClick={this.pageCreate}>
+            Create video page
+          </button>
+        );
+      }
+
       return (
-        <button
-          type="button"
-          className="btn page__add__button"
-          disabled={this.state.pageCreated}
-          onClick={this.pageCreate}>
-          Create video page
-        </button>
+        <div>Publish this atom to enable the creation of composer pages</div>
       );
     }
   }

--- a/public/video-ui/src/components/VideoSelectBar/VideoSelectBar.js
+++ b/public/video-ui/src/components/VideoSelectBar/VideoSelectBar.js
@@ -20,6 +20,14 @@ export default class VideoSelectBar extends React.Component {
 
   }
 
+  renderEmbedButton() {
+    return <button type="button" className="bar__button" onClick={this.props.onSelectVideo}>Select this Video</button>
+  }
+
+  renderCannotEmbedMessage() {
+    return <div>This atom cannot be embedded because it has not been published</div>
+  }
+
   render() {
     if (!this.props.embeddedMode) {
        return false;
@@ -31,7 +39,7 @@ export default class VideoSelectBar extends React.Component {
         <div className="bar__image">{this.renderItemImage()}</div>
         <div>
           <span className="grid__item__title">{this.props.video.title}</span>
-          <button type="button" className="bar__button" onClick={this.props.onSelectVideo}>Select this Video</button>
+          {this.renderEmbedButton()}
         </div>
         </div>
       )
@@ -41,7 +49,7 @@ export default class VideoSelectBar extends React.Component {
         <div className="bar__image">{this.renderItemImage()}</div>
         <div>
           <span className="grid__item__title">{this.props.video.title}</span>
-          <div>This atom has not been embedded because it has not been published</div>
+          {this.renderCannotEmbedMessage()}
         </div>
         </div>
       )

--- a/public/video-ui/src/components/VideoSelectBar/VideoSelectBar.js
+++ b/public/video-ui/src/components/VideoSelectBar/VideoSelectBar.js
@@ -15,19 +15,36 @@ export default class VideoSelectBar extends React.Component {
     return <div className="bar__image-placeholder">No Image</div>
   }
 
+  isVideoPublished() {
+    return this.props.video && this.props.video.contentChangeDetails && this.props.video.contentChangeDetails.published;
+
+  }
+
   render() {
     if (!this.props.embeddedMode) {
        return false;
     }
 
-    return (
-      <div className="bar info-bar">
-      <div className="bar__image">{this.renderItemImage()}</div>
-      <div>
-        <span className="grid__item__title">{this.props.video.title}</span>
-        <button type="button" className="bar__button" onClick={this.props.onSelectVideo}>Select this Video</button>
-      </div>
-      </div>
-    )
+    if (this.isVideoPublished()) {
+      return (
+        <div className="bar info-bar">
+        <div className="bar__image">{this.renderItemImage()}</div>
+        <div>
+          <span className="grid__item__title">{this.props.video.title}</span>
+          <button type="button" className="bar__button" onClick={this.props.onSelectVideo}>Select this Video</button>
+        </div>
+        </div>
+      )
+    } else {
+      return (
+        <div className="bar info-bar">
+        <div className="bar__image">{this.renderItemImage()}</div>
+        <div>
+          <span className="grid__item__title">{this.props.video.title}</span>
+          <div>This atom has not been embedded because it has not been published</div>
+        </div>
+        </div>
+      )
+    }
   }
 }


### PR DESCRIPTION
- Don't allow for embedding unpublished media atoms from composer and creating composer pages for unpublished atoms from media-atom-maker
- There are plans for adding unpublished icons to media-atoms, so we don't have to change the way that media-atoms appear in search now
