### PR TITLE
Update composer live end-point when creating page

### DIFF
--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -87,9 +87,9 @@ export default {
     });
   },
 
-  addVideoToComposerPage(pageId, data, composerUrl) {
-    // The composer client (whilst in draft) keeps both the preview and live data in sync so we must do the same
-    const requests = ['preview', 'live'].map((stage) => {
+  addVideoToComposerPage(pageId, previewData, composerUrl) {
+
+    function updateMainBlock(stage, data) {
       return pandaReqwest({
         url: `${composerUrl}/api/content/${pageId}/${stage}/mainblock`,
         method: 'post',
@@ -98,8 +98,12 @@ export default {
         withCredentials: true,
         data: JSON.stringify(data)
       });
-    });
+    }
 
-    return Promise.all(requests);
+    // The composer client (whilst in draft) keeps both the preview and live data in sync so we must do the same
+    updateMainBlock('preview', previewData).then((preview) => {
+      const liveData = preview.data.block;
+      return updateMainBlock('live', liveData);
+    });
   }
 }

--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -101,7 +101,7 @@ export default {
     }
 
     // The composer client (whilst in draft) keeps both the preview and live data in sync so we must do the same
-    updateMainBlock('preview', previewData).then((preview) => {
+    return updateMainBlock('preview', previewData).then((preview) => {
       const liveData = preview.data.block;
       return updateMainBlock('live', liveData);
     });

--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -88,13 +88,18 @@ export default {
   },
 
   addVideoToComposerPage(pageId, data, composerUrl) {
-    return pandaReqwest({
-      url: composerUrl + '/api/content/' + pageId + '/preview/mainblock',
-      method: 'post',
-      contentType: 'application/json',
-      crossOrigin: true,
-      withCredentials: true,
-      data: JSON.stringify(data)
+    // The composer client (whilst in draft) keeps both the preview and live data in sync so we must do the same
+    const requests = ['preview', 'live'].map((stage) => {
+      return pandaReqwest({
+        url: `${composerUrl}/api/content/${pageId}/${stage}/mainblock`,
+        method: 'post',
+        contentType: 'application/json',
+        crossOrigin: true,
+        withCredentials: true,
+        data: JSON.stringify(data)
+      });
     });
+
+    return Promise.all(requests);
   }
 }


### PR DESCRIPTION
Draft pages in composer have the `preview` and `live` data kept in sync by the client side. media-atom-maker was only setting the `preview` data, leading to missing videos when the page was published.

The fix is to set them both. This is safe as we are always creating a new page so it will inherently be a draft.

cc @akash1810 @Reettaphant 