### PR TITLE
Use versioned config bucket in S3

### DIFF
--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -148,6 +148,15 @@
                                     ]
                                 },
                                 {
+                                  "Effect": "Allow",
+                                  "Action": [
+                                    "s3:GetObject"
+                                  ],
+                                  "Resource": [
+                                    "arn:aws:s3:::atom-maker-conf/*"
+                                  ]
+                                },
+                                {
                                     "Effect": "Allow",
                                     "Action": [
                                         "ec2:DescribeTags"
@@ -336,7 +345,7 @@
                                         ]
                                     ]
                                 },
-                                "aws s3 cp 's3://atom-maker-dist/conf/media-atom-maker.",
+                                "aws s3 cp 's3://atom-maker-conf/media-atom-maker.",
                                 {
                                     "Ref": "Stage"
                                 },

--- a/scripts/setup-dev-conf.sh
+++ b/scripts/setup-dev-conf.sh
@@ -43,9 +43,9 @@ sed -e "s/{DOMAIN}/${DOMAIN}/g" \
     -e "s/{DYNAMO_AUDIT_TABLE}/${DYNAMO_AUDIT_TABLE}/g" \
     ../conf/reference.conf > ../conf/application.conf
 
-aws s3 cp s3://atom-maker-dist/conf/youtube-DEV.conf ../conf/youtube-DEV.conf --profile $MEDIA_AWS_PROFILE
-aws s3 cp s3://atom-maker-dist/conf/capi-DEV.conf ../conf/capi-DEV.conf --profile $MEDIA_AWS_PROFILE
-aws s3 cp s3://atom-maker-dist/conf/flexible-DEV.conf ../conf/flexible-DEV.conf --profile $MEDIA_AWS_PROFILE
-aws s3 cp s3://atom-maker-dist/conf/kinesis-DEV.conf ../conf/kinesis-DEV.conf --profile $MEDIA_AWS_PROFILE
-aws s3 cp s3://atom-maker-dist/conf/sentry-DEV.conf ../conf/sentry-DEV.conf --profile $MEDIA_AWS_PROFILE
+aws s3 cp s3://atom-maker-conf/youtube-DEV.conf ../conf/youtube-DEV.conf --profile $MEDIA_AWS_PROFILE
+aws s3 cp s3://atom-maker-conf/capi-DEV.conf ../conf/capi-DEV.conf --profile $MEDIA_AWS_PROFILE
+aws s3 cp s3://atom-maker-conf/flexible-DEV.conf ../conf/flexible-DEV.conf --profile $MEDIA_AWS_PROFILE
+aws s3 cp s3://atom-maker-conf/kinesis-DEV.conf ../conf/kinesis-DEV.conf --profile $MEDIA_AWS_PROFILE
+aws s3 cp s3://atom-maker-conf/sentry-DEV.conf ../conf/sentry-DEV.conf --profile $MEDIA_AWS_PROFILE
 


### PR DESCRIPTION
Ronseal. Point media-atom-maker at a new S3 bucket that is just for config and has versioning enabled.

I will delete the configuration from the old S3 bucket once this PR is merged.

cc @akash1810 @Reettaphant @jennysivapalan 