### PR TITLE
keep query string when redirecting

### DIFF
--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -43,7 +43,7 @@ class Support @Inject() (val authActions: HMACAuthActions,
     }
   }
 
-  def legacyVideosEndpointRedirect(path: String) = Action {
-    Redirect(s"/$path")
+  def legacyVideosEndpointRedirect(path: String) = Action { request =>
+    Redirect(s"/$path?${request.rawQueryString}")
   }
 }


### PR DESCRIPTION
to keep embedded mode working

`embeddedMode` is triggered with the `?embeddedMode=true` query string. Keep it when we redirect.