### PR TITLE
Clearer publishing logic

### DIFF
--- a/app/model/Metadata.scala
+++ b/app/model/Metadata.scala
@@ -4,7 +4,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 case class UpdatedMetadata (
-  title: String,
+  title: Option[String],
   description: Option[String],
   tags: Option[List[String]],
   categoryId: Option[String],
@@ -16,7 +16,7 @@ case class UpdatedMetadata (
 
 object UpdatedMetadata {
   implicit val metadataRead: Reads[UpdatedMetadata] = (
-    (__ \ "title").read[String] ~
+    (__ \ "title").readNullable[String] ~
     (__ \ "description").readNullable[String] ~
     (__ \ "tags").readNullable[List[String]] ~
     (__ \ "categoryId").readNullable[String] ~

--- a/app/model/Metadata.scala
+++ b/app/model/Metadata.scala
@@ -4,6 +4,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 case class UpdatedMetadata (
+  title: String,
   description: Option[String],
   tags: Option[List[String]],
   categoryId: Option[String],
@@ -15,6 +16,7 @@ case class UpdatedMetadata (
 
 object UpdatedMetadata {
   implicit val metadataRead: Reads[UpdatedMetadata] = (
+    (__ \ "title").read[String] ~
     (__ \ "description").readNullable[String] ~
     (__ \ "tags").readNullable[List[String]] ~
     (__ \ "categoryId").readNullable[String] ~

--- a/app/model/commands/ActiveAssetCommand.scala
+++ b/app/model/commands/ActiveAssetCommand.scala
@@ -2,6 +2,7 @@ package model.commands
 
 import java.util.Date
 import model.MediaAtom
+import org.joda.time.DateTime
 
 import scala.util.{Failure, Success}
 import CommandExceptions._
@@ -59,7 +60,6 @@ case class ActiveAssetCommand(atomId: String, youtubeId: String)
               ))
 
             UpdateAtomCommand(atomId, MediaAtom.fromThrift(updatedAtom)).process()
-            PublishAtomCommand(atomId).process()
 
           case None => AssetNotFound
         }

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -51,6 +51,7 @@ case class PublishAtomCommand(id: String)(implicit val previewDataStore: Preview
         }
 
         api.updateMetadata(id, UpdatedMetadata(
+          atom.title,
           atom.description,
           Some(atom.tags),
           atom.youtubeCategoryId,

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -50,15 +50,25 @@ case class PublishAtomCommand(id: String)(implicit val previewDataStore: Preview
           case None => Logger.info(s"No active YouTube asset found for atom: ${id}")
         }
 
-        api.updateMetadata(id, UpdatedMetadata(
-          atom.title,
-          atom.description,
-          Some(atom.tags),
-          atom.youtubeCategoryId,
-          atom.license,
-          atom.privacyStatus,
-          atom.expiryDate,
-          atom.plutoProjectId))
+        atom.activeVersion match {
+          case Some(atomVersion) => {
+
+            val activeAssetId = atom.assets.find(asset => {
+              asset.version == atomVersion
+            }).get.id
+
+            api.updateMetadata(activeAssetId, UpdatedMetadata(
+              atom.title,
+              atom.description,
+              Some(atom.tags),
+              atom.youtubeCategoryId,
+              atom.license,
+              atom.privacyStatus,
+              atom.expiryDate,
+              atom.plutoProjectId))
+          }
+          case None =>
+        }
 
         val changeRecord = ChangeRecord((new Date()).getTime(), None) // Todo: User...
         val updatedAtom = thriftAtom.copy(

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -58,7 +58,7 @@ case class PublishAtomCommand(id: String)(implicit val previewDataStore: Preview
             }).get.id
 
             api.updateMetadata(activeAssetId, UpdatedMetadata(
-              atom.title,
+              Some(atom.title),
               atom.description,
               Some(atom.tags),
               atom.youtubeCategoryId,

--- a/app/model/commands/UpdateMetadataCommand.scala
+++ b/app/model/commands/UpdateMetadataCommand.scala
@@ -48,7 +48,6 @@ case class UpdateMetadataCommand(atomId: String,
 
             val updatedAtom = atom.updateData { media =>
                 media.copy(
-                  title = metadata.title,
                   description = metadata.description,
                   metadata = newMetadata,
                   duration = activeYTAssetDuration,

--- a/app/model/commands/UpdateMetadataCommand.scala
+++ b/app/model/commands/UpdateMetadataCommand.scala
@@ -35,7 +35,6 @@ case class UpdateMetadataCommand(atomId: String,
 
         MediaAtom.getActiveYouTubeAsset(mediaAtom) match {
           case Some(youtubeAsset) =>
-            YouTubeVideoUpdateApi(youtubeConfig).updateMetadata(youtubeAsset.id, metadata)
 
             val newMetadata = thriftMediaAtom.metadata.map(_.copy(
               tags = metadata.tags,

--- a/app/model/commands/UpdateMetadataCommand.scala
+++ b/app/model/commands/UpdateMetadataCommand.scala
@@ -49,6 +49,7 @@ case class UpdateMetadataCommand(atomId: String,
 
             val updatedAtom = atom.updateData { media =>
                 media.copy(
+                  title = metadata.title,
                   description = metadata.description,
                   metadata = newMetadata,
                   duration = activeYTAssetDuration,

--- a/app/util/ExpiryPoller.scala
+++ b/app/util/ExpiryPoller.scala
@@ -4,6 +4,7 @@ import java.util.Date
 import javax.inject.Inject
 import akka.actor.Scheduler
 import data.AuditDataStore
+import model.MediaAtom
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -38,13 +39,12 @@ case class ExpiryPoller @Inject () (
 
         YouTubeVideoUpdateApi(youtubeConfig).updateStatusIfExpired(atom) match {
           case Some(expiredAtom) => {
-            UpdateAtomCommand(expiredAtom.id, expiredAtom).process()
 
-            publishedDataStore.getAtom(expiredAtom.id) match {
-
-              case Some(atom) => PublishAtomCommand(expiredAtom.id).process()
-              case _ =>
-
+            val atomId = expiredAtom.id
+            
+            publishedDataStore.getAtom(atomId) match {
+              case Some(atom) => PublishAtomCommand(atomId).process()
+              case None => UpdateAtomCommand(expiredAtom.id, expiredAtom).process()
             }
           }
           case _ =>

--- a/app/util/Youtube.scala
+++ b/app/util/Youtube.scala
@@ -91,6 +91,8 @@ case class YouTubeVideoUpdateApi(config: YouTubeConfig) extends YouTubeBuilder {
         val snippet = video.getSnippet
         val status = video.getStatus
 
+        snippet.setTitle(metadata.title)
+
         metadata.categoryId match {
           case Some(cat) => snippet.setCategoryId(cat)
           case _ => None

--- a/app/util/Youtube.scala
+++ b/app/util/Youtube.scala
@@ -91,7 +91,10 @@ case class YouTubeVideoUpdateApi(config: YouTubeConfig) extends YouTubeBuilder {
         val snippet = video.getSnippet
         val status = video.getStatus
 
-        snippet.setTitle(metadata.title)
+        metadata.title match {
+          case Some(title) => snippet.setTitle(title)
+          case _ => None
+        }
 
         metadata.categoryId match {
           case Some(cat) => snippet.setCategoryId(cat)


### PR DESCRIPTION
Clears publishing logic: 

- Fixes a bug that prevented the publish action from pushing changes to youtube
- Updating the atom title now also updates the youtube title
- Pressing the publish button is the only way to publish an atom: atom will no longer be published when an atom is added to it
- Publishing is the only way of syncing with youtube (for some reason the update metadata method used by cds did this as well

@akash1810 @mbarton @jennysivapalan 