### PR TITLE
Add prout

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,0 +1,5 @@
+{
+  "checkpoints": {
+    "PROD": { "url": "https://video.gutools.co.uk/healthcheck", "overdue": "1H" }
+  }
+}

--- a/app/controllers/MainApp.scala
+++ b/app/controllers/MainApp.scala
@@ -23,7 +23,7 @@ class MainApp @Inject() (previewDataStore: PreviewDataStore,
   import authActions.{AuthAction, processGoogleCallback}
 
   def healthcheck = Action {
-    Ok("ok")
+    Ok("ok " + app.BuildInfo.gitCommitId)
   }
 
   def oauthCallback = Action.async { implicit req =>

--- a/app/controllers/MainApp.scala
+++ b/app/controllers/MainApp.scala
@@ -23,7 +23,7 @@ class MainApp @Inject() (previewDataStore: PreviewDataStore,
   import authActions.{AuthAction, processGoogleCallback}
 
   def healthcheck = Action {
-    Ok("ok " + app.BuildInfo.gitCommitId)
+    Ok(s"ok\ngitCommitID ${app.BuildInfo.gitCommitId}")
   }
 
   def oauthCallback = Action.async { implicit req =>

--- a/build.sbt
+++ b/build.sbt
@@ -63,5 +63,16 @@ lazy val appDistSettings = Seq(
   )
 
 lazy val root = (project in file("."))
-  .enablePlugins(PlayScala, SbtWeb, RiffRaffArtifact, UniversalPlugin)
-  .settings(appDistSettings)
+  .enablePlugins(PlayScala, SbtWeb, RiffRaffArtifact, UniversalPlugin, BuildInfoPlugin)
+  .settings(
+    appDistSettings,
+    buildInfoKeys := Seq[BuildInfoKey](
+      name,
+      BuildInfoKey.constant("gitCommitId", Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse(try {
+        "git rev-parse HEAD".!!.trim
+      } catch {
+        case e: Exception => "unknown"
+      }))
+    ),
+    buildInfoPackage := "app"
+  )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,3 +23,5 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 // for creating test cases that use a local dynamodb
 
 addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.4.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")


### PR DESCRIPTION
Continuous deployment on production feels a bit risky especially with cloudformation changes that need to go out before a code change. As chatted with @mbarton and @akash1810 we thought we should remove continuous deployment on prod and use [prout](https://github.com/guardian/prout) instead to remind ourselves to get changes out.