### PR TITLE
use lower resolution grid image

### DIFF
--- a/public/video-ui/src/components/VideoEdit/formComponents/VideoPoster.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/VideoPoster.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import GridImageSelect from '../../utils/GridImageSelect';
 import {parseImageFromGridCrop} from '../../../util/parseGridMetadata';
-import {findSmallestAssetAboveHeight} from '../../../util/imageHelpers';
+import {findSmallestAssetAboveWidth} from '../../../util/imageHelpers';
 
 class VideoPosterImageEdit extends React.Component {
 
@@ -21,7 +21,7 @@ class VideoPosterImageEdit extends React.Component {
       return false;
     }
 
-    const image = findSmallestAssetAboveHeight(this.props.video.posterImage.assets, 249)
+    const image = findSmallestAssetAboveWidth(this.props.video.posterImage.assets);
 
     return (
       <div className="form__image" >

--- a/public/video-ui/src/components/Videos/VideoItem.js
+++ b/public/video-ui/src/components/Videos/VideoItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Link} from 'react-router';
+import {findSmallestAssetAboveWidth} from '../../util/imageHelpers';
 
 export default class VideoItem extends React.Component {
 
@@ -22,7 +23,9 @@ export default class VideoItem extends React.Component {
 
   renderItemImage() {
     if (this.props.video.posterImage) {
-      return  <img src={this.props.video.posterImage.master.file} alt={this.props.video.title}/>
+      const image = findSmallestAssetAboveWidth(this.props.video.posterImage.assets);
+
+      return <img src={image.file} alt={this.props.video.title}/>;
     }
 
     return <div className="grid__image__placeholder">No Image</div>

--- a/public/video-ui/src/util/imageHelpers.js
+++ b/public/video-ui/src/util/imageHelpers.js
@@ -1,14 +1,18 @@
 export function findSmallestAsset(assetsArray) {
   return assetsArray.reduce((smallestAsset, newAsset) => {
     if (newAsset.size < smallestAsset.size) {
-      return newAsset
+      return newAsset;
     } else {
-      return smallestAsset
+      return smallestAsset;
     }
   });
 }
 
-export function findSmallestAssetAboveHeight(assetsArray, minSize) {
-  const usefulAssets = assetsArray.filter((asset) => asset.dimensions.height >= minSize)
+export function findSmallestAssetAboveWidth(assetsArray, minSize = 250) {
+  // Grid provides various versions of a crop
+  // their widths are fixed and typically 140, 500, 1000, 2000px
+  // use the first one that's above `minSize` in width
+  // as the resolution is usually good enough for a simple preview
+  const usefulAssets = assetsArray.filter((asset) => asset.dimensions.width > minSize);
   return findSmallestAsset(usefulAssets);
 }


### PR DESCRIPTION
don't need to render the master image in a small preview

before
<img width="380" alt="screen shot 2017-01-27 at 08 55 17" src="https://cloud.githubusercontent.com/assets/836140/22365250/6049c154-e46e-11e6-9e4a-1470b330efae.png">

after
<img width="376" alt="screen shot 2017-01-27 at 08 53 27" src="https://cloud.githubusercontent.com/assets/836140/22365256/65ac0652-e46e-11e6-9392-b43fcab113c1.png">


fixes https://github.com/guardian/media-atom-maker/issues/175