### PR TITLE
Disable sentry in dev

### DIFF
--- a/app/controllers/VideoUIApp.scala
+++ b/app/controllers/VideoUIApp.scala
@@ -5,10 +5,11 @@ import javax.inject._
 import com.gu.pandahmac.HMACAuthActions
 import com.typesafe.config.ConfigFactory
 import model.ClientConfig
+import play.api.Configuration
 import play.api.libs.json.Json
 import util.AWSConfig
 
-class VideoUIApp @Inject() (val authActions: HMACAuthActions, awsConfig: AWSConfig)
+class VideoUIApp @Inject() (val authActions: HMACAuthActions, conf: Configuration, awsConfig: AWSConfig)
   extends AtomController {
 
   import authActions.AuthAction
@@ -31,7 +32,8 @@ class VideoUIApp @Inject() (val authActions: HMACAuthActions, awsConfig: AWSConf
       gridUrl = awsConfig.gridUrl,
       capiProxyUrl = "/support/previewCapi",
       composerUrl = composerUrl,
-      ravenUrl = ConfigFactory.load().getString("raven.url")
+      ravenUrl = conf.getString("raven.url").get,
+      stage = conf.getString("stage").get
     )
 
     Ok(views.html.VideoUIApp.app("Media Atom Maker", jsLocation, Json.toJson(clientConfig).toString()))

--- a/app/model/ClientConfig.scala
+++ b/app/model/ClientConfig.scala
@@ -12,7 +12,8 @@ case class ClientConfig(username: String,
                         gridUrl: String,
                         capiProxyUrl: String,
                         composerUrl: String,
-                        ravenUrl: String
+                        ravenUrl: String,
+                        stage: String
                        )
 
 object ClientConfig {

--- a/public/video-ui/src/app.js
+++ b/public/video-ui/src/app.js
@@ -29,7 +29,8 @@ const store = configureStore();
 const config = extractConfigFromPage();
 
 // publish uncaught errors to sentry.io
-Raven.config(config.ravenUrl).install();
+if(config.stage !== 'DEV')
+  Raven.config(config.ravenUrl).install();
 
 setStore(store);
 

--- a/public/video-ui/src/app.js
+++ b/public/video-ui/src/app.js
@@ -29,7 +29,7 @@ const store = configureStore();
 const config = extractConfigFromPage();
 
 // publish uncaught errors to sentry.io
-if(config.stage !== 'DEV')
+if(config.stage !== 'PROD')
   Raven.config(config.ravenUrl).install();
 
 setStore(store);

--- a/public/video-ui/src/app.js
+++ b/public/video-ui/src/app.js
@@ -29,7 +29,7 @@ const store = configureStore();
 const config = extractConfigFromPage();
 
 // publish uncaught errors to sentry.io
-if(config.stage !== 'PROD')
+if(config.stage === 'PROD')
   Raven.config(config.ravenUrl).install();
 
 setStore(store);


### PR DESCRIPTION
Only catch and send JS errors to sentry if we are running in CODE or PROD

cc @akash1810 @Reettaphant 
Fixes #224 