### PR TITLE
Replace general update end-point with one that just updates the pluto id

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -121,15 +121,6 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
 
   private def atomUrl(id: String) = s"/atom/$id"
 
-  def updateMetadata(atomId: String) = APIHMACAuthAction { implicit req =>
-    implicit val user = req.user
-
-    parse(req) { metadata: UpdatedMetadata =>
-      UpdateMetadataCommand(atomId, metadata).process()
-      Ok
-    }
-  }
-
   def setActiveAsset(atomId: String) = APIHMACAuthAction { implicit req =>
     implicit val user = req.user
 
@@ -137,6 +128,18 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
       (JsPath \ "youtubeId").read[String].map(ActiveAssetCommand(atomId, _))
 
     parse(req) { command: ActiveAssetCommand =>
+      val atom = command.process()
+      Ok(Json.toJson(atom))
+    }
+  }
+
+  def setPlutoId(atomId: String) = APIHMACAuthAction { implicit req =>
+    implicit val user = req.user
+
+    implicit val readCommand: Reads[SetPlutoIdCommand] =
+      (JsPath \ "plutoId").read[String].map(new SetPlutoIdCommand(atomId, _))
+
+    parse(req) { command: SetPlutoIdCommand =>
       val atom = command.process()
       Ok(Json.toJson(atom))
     }

--- a/app/model/commands/SetPlutoIdCommand.scala
+++ b/app/model/commands/SetPlutoIdCommand.scala
@@ -1,0 +1,38 @@
+package model.commands
+
+import com.gu.atom.data.PreviewDataStore
+import com.gu.atom.publish.PreviewAtomPublisher
+import com.gu.pandomainauth.model.{User => PandaUser}
+import data.AuditDataStore
+import model.MediaAtom
+import model.commands.CommandExceptions.AtomNotFound
+import util.Logging
+import util.atom.MediaAtomImplicits
+
+class SetPlutoIdCommand(atomId: String, plutoId: String)
+                       (implicit previewDataStore: PreviewDataStore,
+                        previewPublisher: PreviewAtomPublisher,
+                        auditDataStore: AuditDataStore,
+                        user: PandaUser)
+
+  extends Command with MediaAtomImplicits with Logging {
+
+  override type T = MediaAtom
+
+  override def process(): MediaAtom = {
+    log.info(s"Request received to set pluto id $plutoId for atom $atomId")
+
+    previewDataStore.getAtom(atomId) match {
+      case Some(before) =>
+        val after = before.updateData { data =>
+          data.copy(plutoProjectId = Some(plutoId))
+        }
+
+        UpdateAtomCommand(atomId, MediaAtom.fromThrift(after)).process()
+
+      case None =>
+        log.info(s"Cannot set pluto id $plutoId for atom $atomId. No atom has that id")
+        AtomNotFound
+    }
+  }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -21,8 +21,8 @@ PUT     /api2/atoms/:id                 controllers.Api2.putMediaAtom(id)
 POST    /api2/atoms/:id/assets          controllers.Api2.addAsset(id)
 
 PUT     /api2/atom/:id/publish          controllers.Api2.publishMediaAtom(id)
-PUT     /api/atom/:id/update-metadata   controllers.Api2.updateMetadata(id)
 PUT     /api2/atom/:id/asset-active     controllers.Api2.setActiveAsset(id)
+PUT     /api2/atom/:id/pluto-id         controllers.Api2.setPlutoId(id)
 
 GET     /api2/audits/:id                controllers.Api2.getAuditTrailForAtomId(id)
 


### PR DESCRIPTION
The update metadata end-point is now only used by CDS to set the ID of the corresponding Pluto master. Since the end-point was capable of updating all the metadata, strange bugs would occur with CDS routes removing YouTube categories etc. These are now not possible since the end-point can just change the Pluto ID.

Fixes #219 

cc @akash1810 @Reettaphant 