### PR TITLE
remove prevent default to allow updating checkbox

### DIFF
--- a/public/video-ui/src/components/VideoEdit/formComponents/ContentFlags.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/ContentFlags.js
@@ -17,7 +17,6 @@ export default class ContentFlags extends React.Component {
   }
 
   updateFlag(e) {
-    e.preventDefault();
     const flag = {[e.target.id]: e.target.checked};
     const video = Object.assign({}, this.props.video, flag);
     this.props.updateVideo(video);


### PR DESCRIPTION
Previously the checkbox was only updating the checked field after a page refresh. @akash1810 @mbarton 