### PR TITLE
allow channel to be edited iff no assets

### DIFF
--- a/public/video-ui/src/components/YoutubeMetaData/YoutubeMetaData.js
+++ b/public/video-ui/src/components/YoutubeMetaData/YoutubeMetaData.js
@@ -7,6 +7,7 @@ import YoutubeCategorySelect from '../VideoEdit/formComponents/YoutubeCategory';
 import PrivacyStatusSelect from '../VideoEdit/formComponents/PrivacyStatus';
 
 const YoutubeMetaData = (props) => {
+  const hasAssets = props.video.assets.length > 0;
 
     return (
       <div className="form__group">
@@ -23,7 +24,7 @@ const YoutubeMetaData = (props) => {
           type="select"
           component={YoutubeChannelSelect}
           video={props.video}
-          editable={false} />
+          editable={!hasAssets && props.editable} />
 
         <Field
           name="privacyStatus"


### PR DESCRIPTION
Requested by James C as sometimes he creates an atom on the wrong channel and has to create a brand new one in its place with the right channel 😢.

This change will let you edit the channel iff there are no assets on the atom.