### PR TITLE
add initial channel and youtube category fields

### DIFF
--- a/public/video-ui/src/constants/blankVideoData.js
+++ b/public/video-ui/src/constants/blankVideoData.js
@@ -2,5 +2,7 @@ export const blankVideoData = {
     title: '',
     category: '',
     duration: 0,
+    channelId: '',
+    youtubeCategoryId: '',
     privacyStatus: 'Unlisted'
 };


### PR DESCRIPTION
Add initial channel id and youtube category id fields. Without these, the create form will be populated by previous fields used that do not get posted to the server, causing an error on the server. @akash1810 @mbarton 