### PR TITLE
Atom status

### DIFF
--- a/public/video-ui/src/components/FormFields/SelectBox.js
+++ b/public/video-ui/src/components/FormFields/SelectBox.js
@@ -8,13 +8,13 @@ export default class SelectBox extends React.Component {
 
   getClassName = () => {
 
-    return "form__field form__field--select " + (this.hasError() ? "form__field--error" : "") + (this.props.hasNotifications ? "form__field--notification" : "")
+    return "form__field form__field--select " + (this.hasError() ? "form__field--error" : "") + (this.props.hasNotifications ? "form__field--notification" : "");
   }
 
   renderNotification = () => {
     if (this.props.hasNotifications) {
       return (
-        <span className="details-list__notification-text">Atoms with private status cannot be published</span>
+        <span className="details-list__notification-text">{this.props.notificationMessage}</span>
         );
     }
   }
@@ -25,11 +25,9 @@ export default class SelectBox extends React.Component {
       const displayValue = matchingValues.length ? matchingValues[0].title : this.props.fieldValue;
       return (
         <div>
-          <div className="details-list__heading">
-            <p className="details-list__title">{this.props.fieldName}</p>
-            {this.renderNotification()}
-          </div>
+          <p className="details-list__title">{this.props.fieldName}</p>
           <p className={"details-list__field" + (this.props.hasNotifications ? " details-list__notification" : "")}>{displayValue}</p>
+          {this.renderNotification()}
         </div>
       );
     }
@@ -51,6 +49,7 @@ export default class SelectBox extends React.Component {
             );
           })}
         </select>
+        {this.renderNotification()}
         {this.hasError() ? <p className="form__message form__message--error">{this.props.meta.error}</p> : ""}
       </div>
     );

--- a/public/video-ui/src/components/FormFields/SelectBox.js
+++ b/public/video-ui/src/components/FormFields/SelectBox.js
@@ -2,26 +2,44 @@ import React from 'react';
 
 export default class SelectBox extends React.Component {
 
+  hasError = () => {
+    return this.props.meta.touched && this.props.meta.error;
+  };
+
+  getClassName = () => {
+
+    return "form__field form__field--select " + (this.hasError() ? "form__field--error" : "") + (this.props.hasNotifications ? "form__field--notification" : "")
+  }
+
+  renderNotification = () => {
+    if (this.props.hasNotifications) {
+      return (
+        <span className="details-list__notification-text">Atoms with private status cannot be published</span>
+        );
+    }
+  }
+
   renderField = () => {
     if(!this.props.editable) {
       const matchingValues = this.props.selectValues.filter((fieldValue) => this.props.fieldValue && (fieldValue.id.toString() === this.props.fieldValue.toString()));
       const displayValue = matchingValues.length ? matchingValues[0].title : this.props.fieldValue;
       return (
         <div>
-          <p className="details-list__title">{this.props.fieldName}</p>
-          <p className="details-list__field">{displayValue}</p>
+          <div className="details-list__heading">
+            <p className="details-list__title">{this.props.fieldName}</p>
+            {this.renderNotification()}
+          </div>
+          <p className={"details-list__field" + (this.props.hasNotifications ? " details-list__notification" : "")}>{displayValue}</p>
         </div>
       );
     }
-
-    const hasError = this.props.meta.touched && this.props.meta.error;
 
     return (
       <div className="form__row">
         <label className="form__label">{this.props.fieldName}</label>
         <select
           {...this.props.input}
-          className={"form__field form__field--select " + (hasError ? "form__field--error" : "") }
+          className={this.getClassName()}
           value={this.props.fieldValue}
           onChange={this.props.onUpdateField}>
 
@@ -33,7 +51,7 @@ export default class SelectBox extends React.Component {
             );
           })}
         </select>
-        {hasError ? <p className="form__message form__message--error">{this.props.meta.error}</p> : ""}
+        {this.hasError() ? <p className="form__message form__message--error">{this.props.meta.error}</p> : ""}
       </div>
     );
   };

--- a/public/video-ui/src/components/Video/Create.js
+++ b/public/video-ui/src/components/Video/Create.js
@@ -2,6 +2,7 @@ import React from 'react';
 import VideoEdit from '../VideoEdit/VideoEdit';
 import SaveButton from '../utils/SaveButton';
 import {blankVideoData} from '../../constants/blankVideoData';
+import {previewPrivacyState} from '../../constants/privacyStates';
 
 class VideoCreate extends React.Component {
 
@@ -12,7 +13,7 @@ class VideoCreate extends React.Component {
   createVideo = () => {
 
     const videoWithStatus = Object.assign({}, this.props.video, {
-      privacyStatus: 'Private'
+      privacyStatus: previewPrivacyState
     });
 
     this.props.videoActions.createVideo(videoWithStatus);

--- a/public/video-ui/src/components/Video/Create.js
+++ b/public/video-ui/src/components/Video/Create.js
@@ -10,7 +10,12 @@ class VideoCreate extends React.Component {
   }
 
   createVideo = () => {
-    this.props.videoActions.createVideo(this.props.video);
+
+    const videoWithStatus = Object.assign({}, this.props.video, {
+      privacyStatus: 'Private'
+    });
+
+    this.props.videoActions.createVideo(videoWithStatus);
   };
 
   resetVideo = () => {

--- a/public/video-ui/src/components/VideoEdit/VideoEdit.js
+++ b/public/video-ui/src/components/VideoEdit/VideoEdit.js
@@ -70,14 +70,6 @@ const VideoEdit = (props) => {
             updateVideo={props.updateVideo}
             editable={props.editable} />
 
-          <Field
-            name="privacyStatus"
-            type="text"
-            component={PrivacyStatusSelect}
-            video={props.video}
-            updateVideo={props.updateVideo}
-            editable={props.editable} />
-
           <SaveButton saveState={props.saveState.saving} onSaveClick={props.saveVideo} onResetClick={props.resetVideo} />
         </div>
       );

--- a/public/video-ui/src/components/VideoEdit/VideoEdit.js
+++ b/public/video-ui/src/components/VideoEdit/VideoEdit.js
@@ -6,7 +6,6 @@ import VideoPosterEdit from './formComponents/VideoPoster';
 import YoutubeCategorySelect from './formComponents/YoutubeCategory';
 import VideoExpiryEdit from './formComponents/VideoExpiry';
 import YoutubeChannelSelect from './formComponents/YoutubeChannel';
-import PrivacyStatusSelect from './formComponents/PrivacyStatus';
 import SaveButton from '../utils/SaveButton';
 import {validate} from '../../constants/videoEditValidation';
 import { Field, reduxForm } from 'redux-form';

--- a/public/video-ui/src/components/VideoEdit/formComponents/PrivacyStatus.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/PrivacyStatus.js
@@ -3,7 +3,7 @@ import React from 'react';
 import SelectBox from '../../FormFields/SelectBox';
 import { publishedPrivacyStates } from '../../../constants/privacyStates';
 import { statusNotification } from '../../../constants/notificationMessages';
-import { isPublishable } from '../../../util/isPublishable';
+import { getPublishErrors } from '../../../util/getPublishErrors';
 
 export default class PrivacyStatusSelect extends React.Component {
 
@@ -25,7 +25,7 @@ export default class PrivacyStatusSelect extends React.Component {
         video={this.props.video}
         editable={this.props.editable}
         input={this.props.input}
-        hasNotifications={isPublishable(this.props.video).errors.includes('privacyStatus')}
+        hasNotifications={getPublishErrors(this.props.video).errors.includes('privacyStatus')}
         notificationMessage={statusNotification}
         meta={this.props.meta} />
     );

--- a/public/video-ui/src/components/VideoEdit/formComponents/PrivacyStatus.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/PrivacyStatus.js
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import SelectBox from '../../FormFields/SelectBox';
-import { privacyStates } from '../../../constants/privacyStates';
+import { publishedPrivacyStates } from '../../../constants/privacyStates';
+import { isPublishable } from '../../../util/isPublishable';
 
 export default class PrivacyStatusSelect extends React.Component {
 
@@ -18,12 +19,12 @@ export default class PrivacyStatusSelect extends React.Component {
       <SelectBox
         fieldName="Privacy Status"
         fieldValue={this.props.video.privacyStatus}
-        selectValues={privacyStates || []}
+        selectValues={publishedPrivacyStates || []}
         onUpdateField={this.updatePrivacyStatus}
         video={this.props.video}
         editable={this.props.editable}
         input={this.props.input}
-        hasNotifications={this.props.video.privacyStatus === 'Private'}
+        hasNotifications={isPublishable(this.props.video).errors.includes('privacyStatus')}
         meta={this.props.meta} />
     );
   }

--- a/public/video-ui/src/components/VideoEdit/formComponents/PrivacyStatus.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/PrivacyStatus.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import SelectBox from '../../FormFields/SelectBox';
 import { publishedPrivacyStates } from '../../../constants/privacyStates';
+import { statusNotification } from '../../../constants/notificationMessages';
 import { isPublishable } from '../../../util/isPublishable';
 
 export default class PrivacyStatusSelect extends React.Component {
@@ -25,6 +26,7 @@ export default class PrivacyStatusSelect extends React.Component {
         editable={this.props.editable}
         input={this.props.input}
         hasNotifications={isPublishable(this.props.video).errors.includes('privacyStatus')}
+        notificationMessage={statusNotification}
         meta={this.props.meta} />
     );
   }

--- a/public/video-ui/src/components/VideoEdit/formComponents/PrivacyStatus.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/PrivacyStatus.js
@@ -23,6 +23,7 @@ export default class PrivacyStatusSelect extends React.Component {
         video={this.props.video}
         editable={this.props.editable}
         input={this.props.input}
+        hasNotifications={this.props.video.privacyStatus === 'Private'}
         meta={this.props.meta} />
     );
   }

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {saveStateVals} from '../../constants/saveStateVals';
 import {isVideoPublished} from '../../util/isVideoPublished';
 import {hasUnpublishedChanges} from '../../util/hasUnpublishedChanges';
-import Icon from '../../components/Icon';
 import {getPublishErrors} from '../../util/getPublishErrors';
 
 export default class VideoPublishBar extends React.Component {

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -3,6 +3,7 @@ import {saveStateVals} from '../../constants/saveStateVals';
 import {isVideoPublished} from '../../util/isVideoPublished';
 import {hasUnpublishedChanges} from '../../util/hasUnpublishedChanges';
 import Icon from '../../components/Icon';
+import {isPublishable} from '../../util/isPublishable';
 
 export default class VideoPublishBar extends React.Component {
 
@@ -14,31 +15,40 @@ export default class VideoPublishBar extends React.Component {
     return hasUnpublishedChanges(this.props.video, this.props.publishedVideo);
   }
 
-  renderUnpublishedNote() {
-    return (
-      <span className="publish-bar__message__block">
-        <Icon icon="repeat"/>
-        <span className="bar__message">This video atom has unpublished changes</span>
-      </span>
-    );
+  videoIsPublishable() {
+    return isPublishable(this.props.video).errors.length === 0;
   }
 
   renderPublishButton() {
-    return (<button
-        type="button"
-        className="btn"
-        disabled={!this.videoHasUnpublishedChanges() || this.videoIsCurrentlyPublishing()}
-        onClick={this.props.publishVideo}
-      >
-        Publish
-      </button>
-    );
-  }
-
-  renderPublishMessage() {
-    return (
-      <span className="bar__message publish-bar__message">Publishing...</span>
-    );
+    if (this.videoIsCurrentlyPublishing()) {
+      return (<button
+          type="button"
+          className="btn"
+          disabled={true}
+        >
+          Publishing
+        </button>
+      );
+    } else if (isVideoPublished(this.props.publishedVideo) && !this.videoHasUnpublishedChanges()) {
+      return (<button
+          type="button"
+          className="btn"
+          disabled={true}
+        >
+          Published
+        </button>
+      );
+    } else {
+      return (<button
+          type="button"
+          className="btn"
+          disabled={!this.videoIsPublishable()}
+          onClick={this.props.publishVideo}
+        >
+          Publish
+        </button>
+      );
+    }
   }
 
   renderVideoPublishedInfo() {
@@ -55,32 +65,10 @@ export default class VideoPublishBar extends React.Component {
         return false;
     }
 
-    if (this.videoIsCurrentlyPublishing()) {
-      return (
-        <div className="flex-container flex-grow publish-bar">
-          {this.renderVideoPublishedInfo()}
-          <div className="flex-spacer"></div>
-          {this.renderPublishButton()}
-          {this.renderPublishMessage()}
-        </div>
-      );
-    }
-
-    if (!this.videoHasUnpublishedChanges()) {
-      return (
-        <div className="flex-container flex-grow publish-bar">
-          {this.renderVideoPublishedInfo()}
-          <div className="flex-spacer"></div>
-          {this.renderPublishButton()}
-        </div>
-      );
-    }
-
     return (
       <div className="flex-container flex-grow publish-bar">
         {this.renderVideoPublishedInfo()}
         <div className="flex-spacer"></div>
-        {this.renderUnpublishedNote()}
         {this.renderPublishButton()}
       </div>
     );

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -3,7 +3,7 @@ import {saveStateVals} from '../../constants/saveStateVals';
 import {isVideoPublished} from '../../util/isVideoPublished';
 import {hasUnpublishedChanges} from '../../util/hasUnpublishedChanges';
 import Icon from '../../components/Icon';
-import {isPublishable} from '../../util/isPublishable';
+import {getPublishErrors} from '../../util/getPublishErrors';
 
 export default class VideoPublishBar extends React.Component {
 
@@ -16,7 +16,7 @@ export default class VideoPublishBar extends React.Component {
   }
 
   videoIsPublishable() {
-    return isPublishable(this.props.video).errors.length === 0;
+    return getPublishErrors(this.props.video).errors.length === 0;
   }
 
   isPublishingDisabled() {

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -19,36 +19,43 @@ export default class VideoPublishBar extends React.Component {
     return isPublishable(this.props.video).errors.length === 0;
   }
 
-  renderPublishButton() {
+  isPublishingDisabled() {
+    return this.videoIsCurrentlyPublishing() ||
+      !this.videoHasUnpublishedChanges() ||
+      !this.videoIsPublishable();
+  }
+
+  renderPublishButtonText() {
     if (this.videoIsCurrentlyPublishing()) {
-      return (<button
-          type="button"
-          className="btn"
-          disabled={true}
-        >
-          Publishing
-        </button>
-      );
-    } else if (isVideoPublished(this.props.publishedVideo) && !this.videoHasUnpublishedChanges()) {
-      return (<button
-          type="button"
-          className="btn"
-          disabled={true}
-        >
-          Published
-        </button>
-      );
-    } else {
-      return (<button
-          type="button"
-          className="btn"
-          disabled={!this.videoIsPublishable()}
-          onClick={this.props.publishVideo}
-        >
-          Publish
-        </button>
-      );
+      return (<span>Publishing</span>);
     }
+
+    if (isVideoPublished(this.props.publishedVideo) && !this.videoHasUnpublishedChanges()){
+      return (<span>Published</span>);
+
+    }
+
+    if (!this.videoIsPublishable()) {
+      return (<span>
+        <i className="icon icon__warning">warning</i>
+        <span>Publish</span>
+      </span>);
+    } else {
+      return (<span>Publish</span>);
+    }
+
+  }
+
+  renderPublishButton() {
+    return (<button
+        type="button"
+        className="btn"
+        disabled={this.isPublishingDisabled()}
+        onClick={this.props.publishVideo}
+      >
+        {this.renderPublishButtonText()}
+      </button>
+    );
   }
 
   renderVideoPublishedInfo() {

--- a/public/video-ui/src/constants/notificationMessages.js
+++ b/public/video-ui/src/constants/notificationMessages.js
@@ -1,0 +1,1 @@
+export const statusNotification = 'Atoms with status set to "Private" cannot be published';

--- a/public/video-ui/src/constants/privacyStates.js
+++ b/public/video-ui/src/constants/privacyStates.js
@@ -1,5 +1,4 @@
 export const privacyStates = [
-  'Private',
   'Public',
   'Unlisted'
 ].map(state => {return {id: state, title: state};});

--- a/public/video-ui/src/constants/privacyStates.js
+++ b/public/video-ui/src/constants/privacyStates.js
@@ -1,4 +1,6 @@
-export const privacyStates = [
+export const publishedPrivacyStates = [
   'Public',
   'Unlisted'
 ].map(state => {return {id: state, title: state};});
+
+export const previewPrivacyState = 'Private';

--- a/public/video-ui/src/util/getPublishErrors.js
+++ b/public/video-ui/src/util/getPublishErrors.js
@@ -1,8 +1,8 @@
 import { previewPrivacyState } from '../constants/privacyStates';
 
-export function isPublishable(video) {
+export function getPublishErrors(video) {
 
-  let publishState = {
+  const publishState = {
     errors: []
   };
 

--- a/public/video-ui/src/util/isPublishable.js
+++ b/public/video-ui/src/util/isPublishable.js
@@ -1,0 +1,15 @@
+import { previewPrivacyState } from '../constants/privacyStates';
+
+export function isPublishable(video) {
+
+  let publishState = {
+    errors: []
+  };
+
+  if (previewPrivacyState === video.privacyStatus) {
+    publishState.errors.push('privacyStatus');
+  }
+
+  return publishState;
+}
+

--- a/public/video-ui/styles/components/_details-list.scss
+++ b/public/video-ui/styles/components/_details-list.scss
@@ -11,7 +11,7 @@
   word-wrap: inherit;
   text-overflow: ellipsis;
   margin: 0 0 10px;
-  padding: 0;
+  padding-left: 3px;
 }
 
 .details-list__labeled-filter {
@@ -24,4 +24,22 @@
 
 .details-list__empty {
   font-style: italic;
+}
+
+.details-list__notification {
+  border: solid 1px;
+  border-color: $brandColor;
+}
+
+.details-list__notification-text {
+  font-style: italic;
+  font-size: 10px;
+  padding: 12px 0 0;
+}
+
+.details-list__heading {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+>>>>>>> add warning if status is private
 }

--- a/public/video-ui/styles/components/_details-list.scss
+++ b/public/video-ui/styles/components/_details-list.scss
@@ -41,5 +41,5 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
->>>>>>> add warning if status is private
+  color: $brandColor;
 }

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -58,6 +58,11 @@
     border-color: $dangerColor;
   }
 
+  &--notification {
+    border-color: $brandColor;
+  }
+
+
   &--loading {
     background: {
       image: url(/assets/video-ui/images/progress-spinner.gif);
@@ -84,6 +89,7 @@
   &--error {
     color: $dangerColor;
   }
+
 }
 
 .form__image {

--- a/public/video-ui/styles/layout/_icons.scss
+++ b/public/video-ui/styles/layout/_icons.scss
@@ -26,13 +26,6 @@
     margin-left: 5px;
   }
 }
-.icon__search-magnifier,
-.icon__add,
-.icon__done,
-.icon__edit {
-  align-self: center;
-  padding: 0 5px;
-}
 
 .icon__done,
 .icon__edit {

--- a/public/video-ui/styles/layout/_icons.scss
+++ b/public/video-ui/styles/layout/_icons.scss
@@ -26,6 +26,13 @@
     margin-left: 5px;
   }
 }
+.icon__search-magnifier,
+.icon__add,
+.icon__done,
+.icon__edit {
+  align-self: center;
+  padding: 0 5px;
+}
 
 .icon__done,
 .icon__edit {
@@ -53,3 +60,8 @@
     background-color: darken($brandColor, 5%);
   }
 }
+
+.icon__warning {
+  padding: 0px 20px 20px 0px;
+}
+


### PR DESCRIPTION
This PR aligns the process of setting the atom status with the publishing workflow. 

- All newly created atoms are created with status set to private
- They cannot be published until the status is changed. 
- Introduces the concept of preflight checks to media atom maker. As a part of this work, the publish button messaging is also streamlined (no notifications next to the button, the text on the button is either Published, Publishing or Publish). 
- After some thought I decided that at the moment, only the atom status should be in the preflight checks because it is the only thing with different validation in preview and published state. Other errors should be displayed as error messages.

<img width="535" alt="screen shot 2017-02-06 at 14 50 25" src="https://cloud.githubusercontent.com/assets/3066534/22651697/ca418334-ec7b-11e6-81cc-75d0e6147a3c.png">
<img width="568" alt="screen shot 2017-02-06 at 14 50 10" src="https://cloud.githubusercontent.com/assets/3066534/22651705/ce211032-ec7b-11e6-9f6c-2fc0a232f5a1.png">

@mbarton @akash1810 @mr-mr 