### PR TITLE
Fix crash on special characters in search

### DIFF
--- a/public/video-ui/src/actions/VideoActions/getVideos.js
+++ b/public/video-ui/src/actions/VideoActions/getVideos.js
@@ -66,10 +66,12 @@ function adaptCapiAtom(atom) {
 }
 
 export function searchVideosWithQuery(query) {
+  const encodedQuery = encodeURIComponent(query);
+
   return dispatch => {
     dispatch(requestSearchVideos());
 
-    return searchText(query)
+    return searchText(encodedQuery)
       .then(res => {
         const capiAtoms = res.response.results;
         const atoms = capiAtoms.map(adaptCapiAtom);


### PR DESCRIPTION
URL encode CAPI queries. Ronseal.

Fixes #241 