### PR TITLE
sort atoms by `contentChangeDetails.created` DESC

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -56,6 +56,7 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
         val mediaAtoms = atoms.map(MediaAtom.fromThrift)
           .toList
           .filter(_.category != Hosted)
+          .sorted
         Ok(Json.toJson(mediaAtoms))
       }
     )

--- a/app/model/MediaAtom.scala
+++ b/app/model/MediaAtom.scala
@@ -29,7 +29,14 @@ case class MediaAtom(
   commentsEnabled: Boolean = false,
   legallySensitive: Option[Boolean],
   privacyStatus: Option[PrivacyStatus],
-  expiryDate: Option[Long] = None) {
+  expiryDate: Option[Long] = None) extends Ordered[MediaAtom] {
+
+  def compare(that: MediaAtom): Int = (this.contentChangeDetails.created, that.contentChangeDetails.created) match {
+    case (Some(me), Some(other)) => other.date.compareTo(me.date) // `contentChangeDetails.created` DESC
+    case (None, _) => 1
+    case (_, None) => -1
+    case (None, None) => 0
+  }
 
   def asThrift = ThriftAtom(
       id = id,


### PR DESCRIPTION
depends on https://github.com/guardian/media-atom-maker/pull/253 as we're not setting `contentChangeDetails.created` currently

