### PR TITLE
don't display default properties

### DIFF
--- a/public/video-ui/src/components/FormFields/SelectBox.js
+++ b/public/video-ui/src/components/FormFields/SelectBox.js
@@ -19,7 +19,7 @@ export default class SelectBox extends React.Component {
     }
   }
   renderDefaultOption = () => {
-    if (this.props.fieldValue === "") {
+    if (this.props.displayDefault || this.props.fieldValue === "") {
       return (
         <option value="">{this.props.defaultOption || "Please select..."}</option>
       );

--- a/public/video-ui/src/components/FormFields/SelectBox.js
+++ b/public/video-ui/src/components/FormFields/SelectBox.js
@@ -18,6 +18,13 @@ export default class SelectBox extends React.Component {
         );
     }
   }
+  renderDefaultOption = () => {
+    if (this.props.fieldValue === "") {
+      return (
+        <option value="">{this.props.defaultOption || "Please select..."}</option>
+      );
+    }
+  }
 
   renderField = () => {
     if(!this.props.editable) {
@@ -41,8 +48,8 @@ export default class SelectBox extends React.Component {
           value={this.props.fieldValue}
           onChange={this.props.onUpdateField}>
 
-          <option value="">{this.props.defaultOption || "Please select..."}</option>
 
+          {this.renderDefaultOption()}
           {this.props.selectValues.map(function(value) {
             return (
               <option value={value.id} key={value.id}>{value.title}</option>

--- a/public/video-ui/src/components/VideoEdit/formComponents/PrivacyStatus.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/PrivacyStatus.js
@@ -15,6 +15,11 @@ export default class PrivacyStatusSelect extends React.Component {
     this.props.updateVideo(newData);
   };
 
+  isPrivacySet = () => {
+    return getPublishErrors(this.props.video).errors.includes('privacyStatus');
+  };
+
+
   render () {
     return (
       <SelectBox
@@ -25,7 +30,8 @@ export default class PrivacyStatusSelect extends React.Component {
         video={this.props.video}
         editable={this.props.editable}
         input={this.props.input}
-        hasNotifications={getPublishErrors(this.props.video).errors.includes('privacyStatus')}
+        displayDefault={this.isPrivacySet()}
+        hasNotifications={this.isPrivacySet()}
         notificationMessage={statusNotification}
         meta={this.props.meta} />
     );

--- a/public/video-ui/src/components/VideoEdit/formComponents/VideoCategory.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/VideoCategory.js
@@ -4,7 +4,14 @@ import { videoCategories } from '../../../constants/videoCategories';
 
 export default class VideoCategorySelect extends React.Component {
 
+  defaultOption = "Select a category";
+
   updateVideoCategory = (e) => {
+
+    if (e.target.value === this.defaultOption) {
+      return;
+    }
+
     const newData = Object.assign({}, this.props.video, {
       category: e.target.value
     });
@@ -19,6 +26,7 @@ export default class VideoCategorySelect extends React.Component {
           fieldValue={this.props.video.category}
           selectValues={videoCategories || []}
           onUpdateField={this.updateVideoCategory}
+          defaultOption={this.defaultOption}
           video={this.props.video}
           editable={this.props.editable}
           input={this.props.input}

--- a/public/video-ui/src/components/VideoEdit/formComponents/YoutubeCategory.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/YoutubeCategory.js
@@ -5,6 +5,8 @@ class YoutubeCategorySelect extends React.Component {
 
   hasCategories = () => this.props.youtube.categories.length !== 0;
 
+  defaultOption = "Select a youtube category";
+
   componentWillMount() {
     if (! this.hasCategories()) {
       this.props.youtubeActions.getCategories();
@@ -12,6 +14,10 @@ class YoutubeCategorySelect extends React.Component {
   }
 
   updateVideoCategory = (e) => {
+
+    if (e.target.value === this.defaultOption) {
+      return;
+    }
     const newId = Object.assign({}, this.props.video, {
       youtubeCategoryId: e.target.value}
     );
@@ -34,7 +40,7 @@ class YoutubeCategorySelect extends React.Component {
       fieldValue={this.props.video.youtubeCategoryId}
       selectValues={this.props.youtube.categories || []}
       onUpdateField={this.updateVideoCategory}
-      defaultOption="Select a category..."
+      defaultOption={this.defaultOption}
       video={this.props.video}
       editable={this.props.editable}
       input={this.props.input}

--- a/public/video-ui/src/components/VideoEdit/formComponents/YoutubeChannel.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/YoutubeChannel.js
@@ -5,6 +5,8 @@ class YoutubeChannelSelect extends React.Component {
 
   hasChannels = () => this.props.youtube.channels.length !== 0;
 
+  defaultOption = "Select a channel";
+
   componentWillMount() {
     if (! this.hasChannels()) {
       this.props.youtubeActions.getChannels();
@@ -12,6 +14,11 @@ class YoutubeChannelSelect extends React.Component {
   }
 
   updateVideoChannel = (e) => {
+
+    if (e.target.value === this.defaultOption) {
+      return;
+    }
+
     const newId = Object.assign({}, this.props.video, {
       channelId: e.target.value
     });
@@ -34,7 +41,7 @@ class YoutubeChannelSelect extends React.Component {
         fieldValue={this.props.video.channelId}
         selectValues={this.props.youtube.channels || []}
         onUpdateField={this.updateVideoChannel}
-        defaultOption="Select a channel..."
+        defaultOption={this.defaultOption}
         video={this.props.video}
         editable={this.props.editable}
         input={this.props.input}


### PR DESCRIPTION
The select boxes in both atom edit and create allow for choosing empty values for required atom fields, causing errors on the server. This PR prevents this by hiding the empty values from the select boxes when the atom already has a property chosen. @mbarton @akash1810 