### PR TITLE
populate with empty video

### DIFF
--- a/public/video-ui/src/components/Video/Create.js
+++ b/public/video-ui/src/components/Video/Create.js
@@ -6,7 +6,7 @@ import {blankVideoData} from '../../constants/blankVideoData';
 class VideoCreate extends React.Component {
 
   componentDidMount() {
-    this.props.videoActions.populateEmptyVideo();
+    this.props.videoActions.updateVideo(blankVideoData);
   }
 
   createVideo = () => {
@@ -14,7 +14,7 @@ class VideoCreate extends React.Component {
   };
 
   resetVideo = () => {
-    this.props.videoActions.populateEmptyVideo();
+    this.props.videoActions.updateVideo(blankVideoData);
   };
 
   updateVideo = (video) => {
@@ -27,7 +27,7 @@ class VideoCreate extends React.Component {
         <form className="form create-form">
           <h1>Create new video</h1>
           <VideoEdit
-            video={this.props.video || blankVideoData}
+            video={this.props.video}
             updateVideo={this.updateVideo}
             saveAndUpdateVideo={this.updateVideo}
             createMode

--- a/public/video-ui/src/components/VideoEdit/formComponents/PrivacyStatus.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/PrivacyStatus.js
@@ -17,7 +17,7 @@ export default class PrivacyStatusSelect extends React.Component {
     return (
       <SelectBox
         fieldName="Privacy Status"
-        fieldValue={this.props.video.privacyStatus}
+        fieldValue={this.props.video ? this.props.video.privacyStatus : ''}
         selectValues={privacyStates || []}
         onUpdateField={this.updatePrivacyStatus}
         video={this.props.video}

--- a/public/video-ui/src/components/VideoEdit/formComponents/VideoCategory.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/VideoCategory.js
@@ -23,7 +23,7 @@ export default class VideoCategorySelect extends React.Component {
     return (
         <SelectBox
           fieldName="Category"
-          fieldValue={this.props.video.category}
+          fieldValue={this.props.video ? this.props.video.category : ''}
           selectValues={videoCategories || []}
           onUpdateField={this.updateVideoCategory}
           defaultOption={this.defaultOption}

--- a/public/video-ui/src/components/VideoEdit/formComponents/VideoDescription.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/VideoDescription.js
@@ -4,15 +4,19 @@ import TextArea from '../../FormFields/TextArea';
 export default class VideoDescriptionEdit extends React.Component {
 
   onUpdateDescription = (e) => {
-    const newData = Object.assign({}, this.props.video, {
-      description: e.target.value !== "" ? e.target.value : undefined
-    });
 
-    this.props.updateVideo(newData);
+    const newValue = e.target.value !== "" ? e.target.value : null;
+    if (newValue !== '') {
+      const newData = Object.assign({}, this.props.video, {
+        description: newValue
+      });
+
+      this.props.updateVideo(newData);
+    }
   };
 
   getFieldValue = () => {
-    if (this.props.video.description) {
+    if (this.props.video && this.props.video.description) {
       return this.props.video.description;
     }
 
@@ -20,7 +24,7 @@ export default class VideoDescriptionEdit extends React.Component {
       return 'No Description';
     }
 
-    return undefined;
+    return '';
   };
 
 
@@ -29,7 +33,7 @@ export default class VideoDescriptionEdit extends React.Component {
         <TextArea
           fieldName="Description"
           fieldValue={this.getFieldValue()}
-          noValue={(!this.props.video.description) ? true : false}
+          noValue={(!this.props.video || !this.props.video.description) ? true : false}
           onUpdateField={this.onUpdateDescription}
           video={this.props.video}
           editable={this.props.editable}

--- a/public/video-ui/src/components/VideoEdit/formComponents/VideoPoster.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/VideoPoster.js
@@ -4,7 +4,7 @@ import GridImageSelect from '../../utils/GridImageSelect';
 
 class VideoPosterImageEdit extends React.Component {
   renderImage() {
-    if (!this.props.video.posterImage) {
+    if (!this.props.video || !this.props.video.posterImage) {
       return false;
     }
 

--- a/public/video-ui/src/constants/blankVideoData.js
+++ b/public/video-ui/src/constants/blankVideoData.js
@@ -1,6 +1,6 @@
 export const blankVideoData = {
     title: '',
-    description: undefined,
+    description: null,
     category: '',
     duration: 0,
     channelId: '',


### PR DESCRIPTION
The `populateEmptyVideo` action that is responsible for uploading the create form with an empty video and for resetting the form to empty state did not exist. This PR adds this functionality by updating the video with `blankVideoData`. 
- For this to work, optional description field is represented with null and passed as an empty string to the text field.

@akash1810 @mbarton 