### PR TITLE
Fix sorting on front-page by removing comparator

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -45,6 +45,7 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
   }
 
   def getMediaAtoms = APIHMACAuthAction {
+    def created(atom: MediaAtom) = atom.contentChangeDetails.created.map(_.date.getMillis)
 
     previewDataStore.listAtoms.fold(
       err =>   InternalServerError(jsonError(err.msg)),
@@ -56,7 +57,9 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
         val mediaAtoms = atoms.map(MediaAtom.fromThrift)
           .toList
           .filter(_.category != Hosted)
-          .sorted
+          .sortBy(created)
+          .reverse // newest atoms first
+
         Ok(Json.toJson(mediaAtoms))
       }
     )

--- a/app/model/MediaAtom.scala
+++ b/app/model/MediaAtom.scala
@@ -29,14 +29,7 @@ case class MediaAtom(
   commentsEnabled: Boolean = false,
   legallySensitive: Option[Boolean],
   privacyStatus: Option[PrivacyStatus],
-  expiryDate: Option[Long] = None) extends Ordered[MediaAtom] {
-
-  def compare(that: MediaAtom): Int = (this.contentChangeDetails.created, that.contentChangeDetails.created) match {
-    case (Some(me), Some(other)) => other.date.compareTo(me.date) // `contentChangeDetails.created` DESC
-    case (None, _) => 1
-    case (_, None) => -1
-    case (None, None) => 0
-  }
+  expiryDate: Option[Long] = None) {
 
   def asThrift = ThriftAtom(
       id = id,


### PR DESCRIPTION
Fixes a nasty error that was caused by a dodgy comparator on `MediaAtom`:

```
IllegalArgumentException: Comparison method violates its general contract!
```

The fix replaces the ordering on `MediaAtom` itself in favour of sorting in the list atoms route.
Atoms that do not have a created time appear after those that do, in any order.