### PR TITLE
Publishing expired atoms

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -19,7 +19,8 @@ import util.{Logging, YouTubeConfig, YouTubeVideoUpdateApi}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 
-case class PublishAtomCommand(id: String)(implicit val previewDataStore: PreviewDataStore,
+case class PublishAtomCommand(id: String, fromExpiryPoller: Boolean = false)
+                                        (implicit val previewDataStore: PreviewDataStore,
                                           val previewPublisher: PreviewAtomPublisher,
                                           val publishedDataStore: PublishedDataStore,
                                           val livePublisher: LiveAtomPublisher,
@@ -40,8 +41,8 @@ case class PublishAtomCommand(id: String)(implicit val previewDataStore: Preview
         val atom = MediaAtom.fromThrift(thriftAtom)
         val api = YouTubeVideoUpdateApi(youtubeConfig)
 
-        atom.privacyStatus match {
-          case Some(PrivacyStatus.Private) =>
+        (atom.privacyStatus, !fromExpiryPoller) match {
+          case (Some(PrivacyStatus.Private), false) =>
             log.error(s"Unable to publish atom ${atom.id}, privacy status is set to private")
             AtomPublishFailed("Atom status set to private")
 

--- a/app/util/ExpiryPoller.scala
+++ b/app/util/ExpiryPoller.scala
@@ -41,9 +41,9 @@ case class ExpiryPoller @Inject () (
           case Some(expiredAtom) => {
 
             val atomId = expiredAtom.id
-            
+
             publishedDataStore.getAtom(atomId) match {
-              case Some(atom) => PublishAtomCommand(atomId).process()
+              case Some(atom) => PublishAtomCommand(atomId, true).process()
               case None => UpdateAtomCommand(expiredAtom.id, expiredAtom).process()
             }
           }


### PR DESCRIPTION
Expired atoms have a 'private' status and should be published so we should remove the server side check for atom status prior to publishing them. @mbarton @akash1810 