### PR TITLE
Removed warnings and update to sbt

### DIFF
--- a/app/controllers/PanDomainAuthActions.scala
+++ b/app/controllers/PanDomainAuthActions.scala
@@ -32,7 +32,7 @@ class PanDomainAuthActions @Inject() (
   override lazy val awsCredentialsProvider: AWSCredentialsProvider =
     new AWSCredentialsProviderChain(
       new ProfileCredentialsProvider(conf.getString("panda.awsCredsProfile").getOrElse("panda")),
-      new InstanceProfileCredentialsProvider
+      new InstanceProfileCredentialsProvider(false)
     )
 
   override def validateUser(authedUser: AuthenticatedUser): Boolean = {

--- a/app/util/AWS.scala
+++ b/app/util/AWS.scala
@@ -34,9 +34,12 @@ class AWSConfig @Inject() (config: Configuration) {
 
   lazy val stsRoleToAssume = config.getString("aws.kinesis.stsRoleToAssume").getOrElse("")
 
+  lazy val stsAssumeRoleSessionCredentialsProvider =
+    new STSAssumeRoleSessionCredentialsProvider.Builder(stsRoleToAssume, "media-atom-maker").build()
+
   lazy val atomsCredProvider = new AWSCredentialsProviderChain(
     new ProfileCredentialsProvider("composer"),
-    new STSAssumeRoleSessionCredentialsProvider(credProvider, stsRoleToAssume, sessionId)
+    stsAssumeRoleSessionCredentialsProvider
   )
 
   lazy val dynamoDB = region.createClient(

--- a/app/util/AWS.scala
+++ b/app/util/AWS.scala
@@ -25,7 +25,7 @@ class AWSConfig @Inject() (config: Configuration) {
 
   lazy val credProviders = Seq(
     config.getString("aws.profile").map(new ProfileCredentialsProvider(_)),
-    Some(new InstanceProfileCredentialsProvider)
+    Some(new InstanceProfileCredentialsProvider(false))
   )
 
   lazy val credProvider = new AWSCredentialsProviderChain(credProviders.flatten: _*)

--- a/circle.yml
+++ b/circle.yml
@@ -15,10 +15,7 @@ dependencies:
     - sbt update
   cache_directories:
     - "project/project/target/resolution-cache"
-    - "project/project/target/streams"
-    - "project/target/resolution-cache"
     - "project/target/streams"
-    - ".dynamodb-local"
     - "~/.ivy2"
     - "~/.sbt"
 

--- a/circle.yml
+++ b/circle.yml
@@ -11,13 +11,13 @@ dependencies:
     - gulp js
     - wget -q https://dl.bintray.com/sbt/debian/sbt-0.13.13.deb
     - sudo dpkg -i sbt-0.13.13.deb
-  override:
-    - sbt update
   cache_directories:
     - "project/project/target/resolution-cache"
     - "project/target/streams"
     - "~/.ivy2"
     - "~/.sbt"
+  override:
+    - sbt test:compile
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,8 @@ dependencies:
     - npm install -g gulp
     - npm install
     - gulp js
+    - wget -q https://dl.bintray.com/sbt/debian/sbt-0.13.13.deb
+    - sudo dpkg -i sbt-0.13.13.deb
   override:
     - sbt update
   cache_directories:
@@ -17,6 +19,8 @@ dependencies:
     - "project/target/resolution-cache"
     - "project/target/streams"
     - ".dynamodb-local"
+    - "~/.ivy2"
+    - "~/.sbt"
 
 test:
   override:

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.13


### PR DESCRIPTION
I tried to look at improving the build time in Circle but haven't had much luck. In the meantime I fixed some of the compilation warnings and upgraded us to sbt 0.13.13 which a few projects have done as compilation is faster (https://github.com/guardian/identity-frontend/pull/201).