### PR TITLE
refactor AddAssetCommand

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -117,11 +117,7 @@ class Api2 @Inject() (implicit val previewDataStore: PreviewDataStore,
   def addAsset(atomId: String) = APIHMACAuthAction { implicit req =>
     implicit val user = req.user
 
-    implicit val readCommand: Reads[AddAssetCommand] = (
-      (JsPath \ "uri").read[String] and
-      (JsPath \ "version").readNullable[Long] and
-      (JsPath \ "mimeType").readNullable[String]
-    )(AddAssetCommand(atomId, _, _, _))
+    implicit val readCommand: Reads[AddAssetCommand] = (JsPath \ "uri").read[String].map(AddAssetCommand(atomId, _))
 
     parse(req) { command: AddAssetCommand =>
       val atom = command.process()

--- a/app/model/commands/AddAssetCommand.scala
+++ b/app/model/commands/AddAssetCommand.scala
@@ -39,7 +39,7 @@ case class AddAssetCommand(atomId: String, videoUri: String)
 
   private def getNextAssetVersionNumber (currentAssets: Seq[Asset]): Long = {
     currentAssets.foldLeft(1L){ (acc, asset) => {
-      if (asset.version >= acc) asset.version else acc
+      if (asset.version >= acc) asset.version + 1 else acc
     }}
   }
 


### PR DESCRIPTION
restricting add assets to being youtube videos only and setting version server side

this is part 1 of fixing the add asset form and goes some way to fixing https://github.com/guardian/media-atom-maker/issues/41