### PR TITLE
use a filter to redirect

### DIFF
--- a/app/controllers/MainApp.scala
+++ b/app/controllers/MainApp.scala
@@ -4,14 +4,10 @@ import javax.inject._
 
 import com.gu.atom.data._
 import com.gu.pandahmac.HMACAuthActions
-import com.gu.pandomainauth.service.GoogleAuthException
-import play.api.{Configuration, Logger}
+import play.api.Configuration
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import views.html.MediaAtom._
-
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class MainApp @Inject() (previewDataStore: PreviewDataStore,
                          publishedDataStore: PublishedDataStore,
@@ -27,15 +23,7 @@ class MainApp @Inject() (previewDataStore: PreviewDataStore,
   }
 
   def oauthCallback = Action.async { implicit req =>
-    try {
-      processGoogleCallback()
-    } catch {
-      case e: GoogleAuthException => {
-        val redirectTo = "https://" + conf.getString("host").get
-        Logger.info(s"Authentication failure. ${e.message}. Redirecting to $redirectTo")
-        Future(Redirect(redirectTo, MOVED_PERMANENTLY))
-      }
-    }
+    processGoogleCallback()
   }
 
   def listAtoms = AuthAction { implicit req =>

--- a/app/util/Filters.scala
+++ b/app/util/Filters.scala
@@ -1,0 +1,7 @@
+package util
+
+import javax.inject.Inject
+import play.api.http.DefaultHttpFilters
+import play.filters.gzip.GzipFilter
+
+class Filters @Inject() (gzip: GzipFilter, redirectFilter: RedirectFilter) extends DefaultHttpFilters(gzip, redirectFilter)

--- a/app/util/RedirectFilter.scala
+++ b/app/util/RedirectFilter.scala
@@ -1,0 +1,27 @@
+package util
+
+import javax.inject.Inject
+
+import akka.stream.Materializer
+import play.api.Configuration
+import play.api.http.Status
+import play.api.mvc._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class RedirectFilter @Inject() (implicit val mat: Materializer,
+                                ec: ExecutionContext,
+                                val conf: Configuration) extends Filter with Results with Status {
+
+  def apply(nextFilter: RequestHeader => Future[Result])
+           (requestHeader: RequestHeader): Future[Result] = {
+
+    conf.getString("host").flatMap(host => {
+      if (host != requestHeader.host) {
+        Some(Future.successful(Redirect(s"https://$host", MOVED_PERMANENTLY)))
+      } else {
+        None
+      }
+    }).getOrElse(nextFilter(requestHeader))
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,8 @@ libraryDependencies ++= Seq(
   "com.gu"                     % "kinesis-logback-appender"      % "1.3.0",
   "org.slf4j"                  % "slf4j-api"                     % "1.7.21",
   "org.slf4j"                  % "jcl-over-slf4j"                % "1.7.21",
-  "com.gu"                     %% "content-atom-model"           %  "2.4.17"
+  "com.gu"                     %% "content-atom-model"           %  "2.4.17",
+  filters
 
 ) ++ scanamoDeps
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -3,3 +3,5 @@ include file("/etc/gu/media-atom-maker.private.conf")
 name = "gu-media-atom-maker"
 
 play.http.errorHandler = "util.RequestLogging"
+
+play.http.filters = "util.Filters"


### PR DESCRIPTION
We were previously using a Google Auth error as a means to redirect which is flaky. Now, we intercept the request early in a filter.