### PR TITLE
.fail isn't a function apparently

### DIFF
--- a/public/video-ui/src/services/pandaReqwest.js
+++ b/public/video-ui/src/services/pandaReqwest.js
@@ -19,8 +19,7 @@ export function pandaReqwest(reqwestBody) {
             reqwest(reqwestBody)
               .then(res => resolve(res))
               .fail(err => reject(err));
-          })
-          .fail(error => {
+          }, error => {
               throw error;
           });
       });


### PR DESCRIPTION
this was a bad refactor introduced in https://github.com/guardian/media-atom-maker/pull/276