### PR TITLE
refactor usage

### DIFF
--- a/public/video-ui/src/actions/VideoActions/videoUsages.js
+++ b/public/video-ui/src/actions/VideoActions/videoUsages.js
@@ -7,13 +7,10 @@ function requestVideoUsages() {
   };
 }
 
-function receiveVideoUsages(usages, composerIdsWithUsage, id) {
-
-  const usageObject = {[id]: {usagesWithoutComposer: usages, composerIdsWithUsage: composerIdsWithUsage}};
-
+function receiveVideoUsages(usages) {
   return {
     type:           'VIDEO_USAGE_GET_RECEIVE',
-    usages:         usageObject,
+    usages:         usages,
     receivedAt:     Date.now()
   };
 }
@@ -33,22 +30,7 @@ export function getUsages(id) {
     return VideosApi.getVideoUsages(id)
     .then(res => {
       const usages = res.response.results;
-      Promise.all(usages.map(VideosApi.fetchComposerId))
-      .then((composerIds) => {
-        const composerIdsWithUsage = composerIds.reduce((idsWithUsage, composerId, index) => {
-          if (composerId !== '') {
-            idsWithUsage.push({usage: usages[index], composerId: composerId});
-          }
-          return idsWithUsage;
-        }, []);
-        const usagesWithoutComposer = usages.filter(usage => {
-          return composerIdsWithUsage.every(idWithUsage => {
-            return idWithUsage.usage !== usage;
-          });
-        });
-
-        dispatch(receiveVideoUsages(usagesWithoutComposer, composerIdsWithUsage, id));
-      });
+      dispatch(receiveVideoUsages(usages));
     })
     .catch(error => {
       dispatch(errorReceivingVideoUsages(error));

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -140,8 +140,7 @@ class VideoDisplay extends React.Component {
                   video={this.props.video || {}}
                   publishedVideo={this.props.publishedVideo || {}}
                   fetchUsages={this.props.videoActions.getUsages}
-                  usages={this.props.usages[this.props.video.id] || {}}
-                  composerPageWithUsage={this.props.composerPageWithUsage[this.props.video.id] || {}}
+                  usages={this.props.usages || []}
                   createComposerPage={this.props.videoActions.createVideoPage}
                 />
               </div>

--- a/public/video-ui/src/reducers/usageReducer.js
+++ b/public/video-ui/src/reducers/usageReducer.js
@@ -1,15 +1,10 @@
-export default function usage(state = {}, action) {
+export default function usage(state = [], action) {
   switch (action.type) {
     case 'VIDEO_USAGE_GET_RECEIVE': {
-      return action.usages || {};
+      return action.usages || [];
     }
     case 'VIDEO_PAGE_CREATE_POST_RECEIVE': {
-      const videoId = action.newPage.videoId;
-      if (state[videoId]) {
-        state[videoId].composerIdsWithUsage.push(action.newPage.usage);
-      } else {
-        state[videoId].composerIdsWithUsage = [action.newPage.usage];
-      }
+      state.push(action.newPage.usage);
       return state;
     }
     default: {


### PR DESCRIPTION
As Composer is the only place you can embed atoms, we can get away with making a single capi call to get usages and then use the `find-by-path` endpoint of Composer to link to the article.

-104 +29 😄 