### PR TITLE
update usage to have links to Composer and Frontend

### DIFF
--- a/app/controllers/VideoUIApp.scala
+++ b/app/controllers/VideoUIApp.scala
@@ -31,7 +31,8 @@ class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfi
       capiProxyUrl = "/support/previewCapi",
       composerUrl = composerUrl,
       ravenUrl = conf.getString("raven.url").get,
-      stage = conf.getString("stage").get
+      stage = conf.getString("stage").get,
+      viewerUrl = awsConfig.viewerUrl
     )
 
     Ok(views.html.VideoUIApp.app("Media Atom Maker", jsLocation, Json.toJson(clientConfig).toString()))

--- a/app/model/ClientConfig.scala
+++ b/app/model/ClientConfig.scala
@@ -13,7 +13,8 @@ case class ClientConfig(username: String,
                         capiProxyUrl: String,
                         composerUrl: String,
                         ravenUrl: String,
-                        stage: String
+                        stage: String,
+                        viewerUrl: String
                        )
 
 object ClientConfig {

--- a/app/util/AWS.scala
+++ b/app/util/AWS.scala
@@ -29,6 +29,7 @@ class AWSConfig(override val config: Config)
   override val stage = readTag("Stage").getOrElse("DEV")
 
   lazy val composerUrl = getMandatoryString("flexible.url")
+  lazy val viewerUrl = getMandatoryString("viewer.url")
 
   lazy val gridUrl = stage match {
     case "PROD" => "https://media.gutools.co.uk"

--- a/public/video-ui/src/actions/VideoActions/getVideos.js
+++ b/public/video-ui/src/actions/VideoActions/getVideos.js
@@ -1,5 +1,5 @@
 import VideosApi from '../../services/VideosApi';
-import {searchText} from '../../services/capi';
+import ContentApi from '../../services/capi';
 
 function requestVideos() {
   return {
@@ -66,12 +66,10 @@ function adaptCapiAtom(atom) {
 }
 
 export function searchVideosWithQuery(query) {
-  const encodedQuery = encodeURIComponent(query);
-
   return dispatch => {
     dispatch(requestSearchVideos());
 
-    return searchText(encodedQuery)
+    return ContentApi.search(query)
       .then(res => {
         const capiAtoms = res.response.results;
         const atoms = capiAtoms.map(adaptCapiAtom);

--- a/public/video-ui/src/actions/VideoActions/videoUsages.js
+++ b/public/video-ui/src/actions/VideoActions/videoUsages.js
@@ -32,6 +32,8 @@ export function getUsages(id) {
     .then(res => {
       const usagePaths = res.response.results;
 
+      // the atom usage endpoint in capi only returns article paths,
+      // lookup the articles in capi to get their fields
       Promise.all(usagePaths.map(ContentApi.getByPath))
         .then(capiResponse => {
           const usages = capiResponse.reduce((all, item) => {

--- a/public/video-ui/src/components/Icon.js
+++ b/public/video-ui/src/components/Icon.js
@@ -24,6 +24,21 @@ export class ComposerIcon extends React.Component {
   }
 }
 
+export class ViewerIcon extends React.Component {
+  render () {
+    return (
+      <span className="icon svg-icon">
+        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+          <g fill="#FFF">
+            <path d="M16 5.2C5.7 5.2 0 16 0 16s5.7 10.8 16 10.8S32 16 32 16 26.3 5.2 16 5.2zm0 18.4c-4.4 0-8-3.6-8-8s3.6-8 8-8 8 3.6 8 8-3.6 8-8 8z"/>
+            <path d="M16 11.9c-2.1 0-3.8 1.7-3.8 3.8 0 2.1 1.7 3.7 3.8 3.7 2.1 0 3.7-1.7 3.7-3.7.1-2.1-1.6-3.8-3.7-3.8z"/>
+          </g>
+        </svg>
+      </span>
+    );
+  }
+}
+
 export default class Icon extends React.Component {
   renderText () {
     if (this.props.children) {

--- a/public/video-ui/src/components/Icon.js
+++ b/public/video-ui/src/components/Icon.js
@@ -1,5 +1,29 @@
 import React from 'react';
 
+export class FrontendIcon extends React.Component {
+  render () {
+    return (
+      <span className="icon svg-icon">
+        <svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+          <path fill="#231F20" d="M25.7 30.4c0 11.6 6.2 19.4 14.6 25l.4.3c-5 3.4-15 11.4-15 20.5 0 7 4.4 13.6 14 15.7-10.2 1.8-21.2 6.3-21.2 17.5v1C7.3 98.7 0 83.4 0 65.7c0-26 15.6-48 37.2-58.4-7 5.3-11.5 13-11.5 23zm50.5 66.8c8 0 12.4 4 12.4 10 0 7-5 12.2-24 12.2-16.6 0-22.3-5.6-22.3-12 0-4.6 2-10.2 10.2-10.2h23.7zm32.6 14c2.2-4.4 3.5-9.5 3.5-15.2 0-17.4-9.3-25-29-25H51.8c-3.4 0-6.3-2.8-6.3-5.8 0-2.2 1.8-4.7 4-6.4 4.8 1.6 8.8 1.7 14.5 1.7 22.5 0 38-11 37.8-30.2 0-11-4.8-18.7-12.5-23.3C112 16.7 128 39 128 65.8c0 18-7.4 34-19.2 45.5zM64 50c-6.3 0-11.5-1.5-11.5-19.4 0-18 5.2-20.2 11.5-20.2 6.5 0 11.5 2.8 11.5 20.2 0 17.5-5.2 19.4-11.5 19.4z"/>
+        </svg>
+      </span>
+    );
+  }
+}
+
+export class ComposerIcon extends React.Component {
+  render () {
+    return (
+      <span className="icon svg-icon">
+        <svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+          <path fill="#231F20" d="M12.2 64.8C12.2 16.6 45.2 0 76.8 0c15.3 0 28 2.4 35.6 5.4l1.2 33.4H98l-8-19.2c-3.5-1.5-8.3-3-14.2-3C58.4 16.6 49.6 29 49.6 62c0 38.7 8.4 49.7 27.2 49.7 6 0 11.5-1.8 14.8-3.5l8-20h15l-1.2 33c-8.8 4-20.5 6.8-40 6.8-34.2 0-61.2-17.8-61.2-63.2z"/>
+        </svg>
+      </span>
+    );
+  }
+}
+
 export default class Icon extends React.Component {
   renderText () {
     if (this.props.children) {

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import {getVideoBlock} from '../../util/getVideoBlock';
 import {getStore} from '../../util/storeAccessor';
 import {isVideoPublished} from '../../util/isVideoPublished';
@@ -72,18 +73,24 @@ export default class VideoUsages extends React.Component {
   };
 
   renderUsage = (usage) => {
-    const composerLink = `${this.getComposerUrl()}/find-by-path/${usage}`;
-    const websiteLink = `https://gu.com/${usage}`;
+    const composerLink = `${this.getComposerUrl()}/content/${usage.fields.internalComposerCode}`;
+    const websiteLink = `https://gu.com/${usage.id}`;
 
+    const usageDateFromNow = moment(usage.fields.creationDate).fromNow();
+
+    //TODO add an icon to indicate atom usage on a video page
     return (
-      <li key={usage} className="detail__list__item">
-        <a className="usage--platform-link" href={websiteLink} title="Open on theguardian.com" target="_blank">
-          <FrontendIcon />
-        </a>
-        <a className="usage--platform-link" href={composerLink} title="Open in Composer" target="_blank">
-          <ComposerIcon />
-        </a>
-        {usage}
+      <li key={usage.id} className="detail__list__item">
+        {usage.fields.headline}
+        <div>
+          Created: <span title={usage.fields.creationDate}>{usageDateFromNow}</span>
+          <a className="usage--platform-link" href={websiteLink} title="Open on theguardian.com" target="_blank">
+            <FrontendIcon />
+          </a>
+          <a className="usage--platform-link" href={composerLink} title="Open in Composer" target="_blank">
+            <ComposerIcon />
+          </a>
+        </div>
       </li>
     );
   };

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -52,10 +52,6 @@ export default class VideoUsages extends React.Component {
     return this.props.createComposerPage(this.props.video.id, metadata, this.getComposerUrl(), videoBlock);
   };
 
-  noExistingComposerPages = (composerUsages) => {
-    return !((this.props.composerPageWithUsage && this.props.composerPageWithUsage.composerId) || (composerUsages && composerUsages.length > 0));
-  };
-
   videoHasUnpublishedChanges() {
     return hasUnpublishedChanges(this.props.video, this.props.publishedVideo);
   }
@@ -125,3 +121,10 @@ export default class VideoUsages extends React.Component {
   }
 }
 
+VideoUsages.propTypes = {
+  usages: React.PropTypes.array.isRequired,
+  video: React.PropTypes.object.isRequired,
+  publishedVideo: React.PropTypes.object.isRequired,
+  createComposerPage: React.PropTypes.func.isRequired,
+  fetchUsages: React.PropTypes.func.isRequired
+};

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -4,7 +4,7 @@ import {getVideoBlock} from '../../util/getVideoBlock';
 import {getStore} from '../../util/storeAccessor';
 import {isVideoPublished} from '../../util/isVideoPublished';
 import {hasUnpublishedChanges} from '../../util/hasUnpublishedChanges';
-import {FrontendIcon, ComposerIcon} from '../Icon';
+import {FrontendIcon, ComposerIcon, ViewerIcon} from '../Icon';
 
 export default class VideoUsages extends React.Component {
 
@@ -30,6 +30,10 @@ export default class VideoUsages extends React.Component {
 
   getComposerUrl = () => {
     return getStore().getState().config.composerUrl;
+  };
+
+  getViewerUrl = () => {
+    return getStore().getState().config.viewerUrl;
   };
 
   pageCreate = () => {
@@ -74,6 +78,7 @@ export default class VideoUsages extends React.Component {
 
   renderUsage = (usage) => {
     const composerLink = `${this.getComposerUrl()}/content/${usage.fields.internalComposerCode}`;
+    const viewerLink = `${this.getViewerUrl()}/preview/${usage.id}`;
     const websiteLink = `https://gu.com/${usage.id}`;
 
     const usageDateFromNow = moment(usage.fields.creationDate).fromNow();
@@ -89,6 +94,9 @@ export default class VideoUsages extends React.Component {
           </a>
           <a className="usage--platform-link" href={composerLink} title="Open in Composer" target="_blank">
             <ComposerIcon />
+          </a>
+          <a className="usage--platform-link" href={viewerLink} title="Open in Viewer" target="_blank">
+            <ViewerIcon />
           </a>
         </div>
       </li>

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -75,7 +75,7 @@ export default class VideoUsages extends React.Component {
   renderUsage = (usage) => {
     const composerLink = `${this.getComposerUrl()}/content/${usage.fields.internalComposerCode}`;
     const viewerLink = `${this.getViewerUrl()}/preview/${usage.id}`;
-    const websiteLink = `https://gu.com/${usage.id}`;
+    const websiteLink = `https://www.theguardian.com/${usage.id}`;
 
     const usageDateFromNow = moment(usage.fields.creationDate).fromNow();
 

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -82,7 +82,7 @@ export default class VideoUsages extends React.Component {
     //TODO add an icon to indicate atom usage on a video page
     return (
       <li key={usage.id} className="detail__list__item">
-        {usage.fields.headline}
+        {usage.fields.headline || usage.id}
         <div>
           Created: <span title={usage.fields.creationDate}>{usageDateFromNow}</span>
           <a className="usage--platform-link" href={websiteLink} title="Open on theguardian.com" target="_blank">

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -3,6 +3,7 @@ import {getVideoBlock} from '../../util/getVideoBlock';
 import {getStore} from '../../util/storeAccessor';
 import {isVideoPublished} from '../../util/isVideoPublished';
 import {hasUnpublishedChanges} from '../../util/hasUnpublishedChanges';
+import {FrontendIcon, ComposerIcon} from '../Icon';
 
 export default class VideoUsages extends React.Component {
 
@@ -72,10 +73,17 @@ export default class VideoUsages extends React.Component {
 
   renderUsage = (usage) => {
     const composerLink = `${this.getComposerUrl()}/find-by-path/${usage}`;
+    const websiteLink = `https://gu.com/${usage}`;
 
     return (
       <li key={usage} className="detail__list__item">
-        <a href={composerLink}>{usage}</a>
+        <a className="usage-icon" href={websiteLink} title="Open on theguardian.com" target="_blank">
+          <FrontendIcon />
+        </a>
+        <a className="usage-icon" href={composerLink} title="Open in Composer" target="_blank">
+          <ComposerIcon />
+        </a>
+        {usage}
       </li>
     );
   };

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -77,10 +77,10 @@ export default class VideoUsages extends React.Component {
 
     return (
       <li key={usage} className="detail__list__item">
-        <a className="usage-icon" href={websiteLink} title="Open on theguardian.com" target="_blank">
+        <a className="usage--platform-link" href={websiteLink} title="Open on theguardian.com" target="_blank">
           <FrontendIcon />
         </a>
-        <a className="usage-icon" href={composerLink} title="Open in Composer" target="_blank">
+        <a className="usage--platform-link" href={composerLink} title="Open in Composer" target="_blank">
           <ComposerIcon />
         </a>
         {usage}

--- a/public/video-ui/src/reducers/usageReducer.js
+++ b/public/video-ui/src/reducers/usageReducer.js
@@ -4,7 +4,8 @@ export default function usage(state = [], action) {
       return action.usages || [];
     }
     case 'VIDEO_PAGE_CREATE_POST_RECEIVE': {
-      state.push(action.newPage.usage);
+      // usages are sorted creation date DESC, new usage goes to the top
+      state.unshift(action.newPage);
       return state;
     }
     default: {

--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -138,7 +138,6 @@ export default {
         return resp.response.content.fields.internalComposerCode;
       }
       return "";
-  });
-}
-
+    });
+  }
 };

--- a/public/video-ui/src/services/capi.js
+++ b/public/video-ui/src/services/capi.js
@@ -15,10 +15,12 @@ export default class ContentApi {
     });
   }
 
-  static getByPath(path) {
+  static getByPath(path, retry = false) {
+    const retryTimeout = retry ? 10 * 1000 : 0; // retry up to 10 seconds
+
     return pandaReqwest({
       url: `${ContentApi.proxyUrl}/${path}?show-fields=all`,
       method: 'get'
-    });
+    }, retryTimeout);
   }
 }

--- a/public/video-ui/src/services/capi.js
+++ b/public/video-ui/src/services/capi.js
@@ -1,10 +1,24 @@
 import {pandaReqwest} from './pandaReqwest';
 import {getStore} from '../util/storeAccessor';
 
-export function searchText(query) {
-  const capiProxyUrl = getStore().getState().config.capiProxyUrl;
-  return pandaReqwest({
-    url: capiProxyUrl + "/atoms?types=media&q=" + query + "&searchFields=data.title",
-    method: 'get'
-  });
+export default class ContentApi {
+  static get proxyUrl () {
+    return getStore().getState().config.capiProxyUrl;
+  }
+
+  static search(query) {
+    const encodedQuery = encodeURIComponent(query);
+
+    return pandaReqwest({
+      url: `${ContentApi.proxyUrl}/atoms?types=media&q=${encodedQuery}&searchFields=data.title`,
+      method: 'get'
+    });
+  }
+
+  static getByPath(path) {
+    return pandaReqwest({
+      url: `${ContentApi.proxyUrl}/${path}?show-fields=all`,
+      method: 'get'
+    });
+  }
 }

--- a/public/video-ui/styles/abstracts/_variables.scss
+++ b/public/video-ui/styles/abstracts/_variables.scss
@@ -89,3 +89,4 @@ $anchorColor: $cWhite;
 $toolbarHeight: 50px;
 $videoBlockWidth: 230px;
 $standard-padding: 10px;
+$iconSize: 16px; /* Preferred icon size */

--- a/public/video-ui/styles/components/_usage.scss
+++ b/public/video-ui/styles/components/_usage.scss
@@ -1,0 +1,3 @@
+.usage-icon {
+  padding-right: 10px;
+}

--- a/public/video-ui/styles/components/_usage.scss
+++ b/public/video-ui/styles/components/_usage.scss
@@ -1,3 +1,3 @@
-.usage-icon {
+.usage--platform-link {
   padding-right: 10px;
 }

--- a/public/video-ui/styles/components/_usage.scss
+++ b/public/video-ui/styles/components/_usage.scss
@@ -1,3 +1,3 @@
 .usage--platform-link {
-  padding-right: 10px;
+  padding-left: 10px;
 }

--- a/public/video-ui/styles/layout/_icons.scss
+++ b/public/video-ui/styles/layout/_icons.scss
@@ -54,10 +54,6 @@
   }
 }
 
-.icon__warning {
-  padding: 0px 20px 20px 0px;
-}
-
 .svg-icon {
   svg {
     width: $iconSize;

--- a/public/video-ui/styles/layout/_icons.scss
+++ b/public/video-ui/styles/layout/_icons.scss
@@ -2,7 +2,7 @@
     font-family: 'Material Icons';
     font-weight: normal;
     font-style: normal;
-    font-size: 16px;  /* Preferred icon size */
+    font-size: $iconSize;
     display: inline-block;
     width: 1em;
     height: 1em;
@@ -54,3 +54,23 @@
   }
 }
 
+.icon__warning {
+  padding: 0px 20px 20px 0px;
+}
+
+.svg-icon {
+  svg {
+    width: $iconSize;
+    height: $iconSize;
+  }
+
+  path {
+    fill: $color600Grey;
+  }
+
+  &:hover {
+    path {
+      fill: $color300Grey;
+    }
+  }
+}

--- a/public/video-ui/styles/main.scss
+++ b/public/video-ui/styles/main.scss
@@ -38,4 +38,5 @@
   'components/keywords',
   'components/section-header',
   'components/bar',
-  'components/header';
+  'components/header',
+  'components/usage';


### PR DESCRIPTION
Previously, we were just linking to Composer. Now we have icons linking to Frontend and Composer.

Also, show creation date relative to now.

![image](https://cloud.githubusercontent.com/assets/836140/23206721/9c13821a-f8e6-11e6-8f5f-2607f5671af6.png)

Before Deploying
- [x] update configuration with url to Viewer