### PR TITLE
Only respect disallowedVideos and allowedChannels if non-empty

### DIFF
--- a/app/util/Youtube.scala
+++ b/app/util/Youtube.scala
@@ -39,7 +39,7 @@ case class YouTubeVideoUpdateApi(config: YouTubeConfig) extends Logging {
   private def protectAgainstMistakesInDev(video: Video) = {
     val videoChannelId = video.getSnippet.getChannelId
 
-    if (config.disallowedVideos.nonEmpty && config.disallowedVideos.contains(video.getId)) {
+    if (config.disallowedVideos.contains(video.getId)) {
       val msg = s"Failed to edit video ${video.getId} as its in config.youtube.disallowedVideos"
       Logger.info(msg)
       throw new Exception(msg)

--- a/app/util/Youtube.scala
+++ b/app/util/Youtube.scala
@@ -39,13 +39,13 @@ case class YouTubeVideoUpdateApi(config: YouTubeConfig) extends Logging {
   private def protectAgainstMistakesInDev(video: Video) = {
     val videoChannelId = video.getSnippet.getChannelId
 
-    if (config.disallowedVideos.contains(video.getId)) {
+    if (config.disallowedVideos.nonEmpty && config.disallowedVideos.contains(video.getId)) {
       val msg = s"Failed to edit video ${video.getId} as its in config.youtube.disallowedVideos"
       Logger.info(msg)
       throw new Exception(msg)
     }
 
-    if (!config.allowedChannels.contains(videoChannelId)) {
+    if (config.allowedChannels.nonEmpty && !config.allowedChannels.contains(videoChannelId)) {
       val msg = s"Failed to edit video ${video.getId} as its channel ($videoChannelId) isn't in config.youtube.allowedChannels"
       Logger.info(msg)
       throw new Exception(msg)


### PR DESCRIPTION
A production outage (inability to publish) was caused by an error in reading the `youtube.allowedChannels` setting.

Prior to the changes in #272, the setting was only respected if it was present in the config file. That PR changed the code to read the setting, meaning that if the setting was missing the result was an empty list.

Before: `Option[List[String]]`
After: `List[String]`

As such, we need to treat the empty list as "no instruction" and not refuse any operations.