### PR TITLE
Saving workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {
     "aws-sdk": "^2.10.0",
-    "debounce-promise": "^3.0.1",
     "moment": "^2.17.1",
     "panda-session": "^0.1.6",
     "querystringify": "0.0.4",

--- a/public/video-ui/src/actions/VideoActions/saveVideo.js
+++ b/public/video-ui/src/actions/VideoActions/saveVideo.js
@@ -1,7 +1,4 @@
 import VideosApi from '../../services/VideosApi';
-import debounce from 'debounce-promise';
-
-const debounceInterval = 500;
 
 function requestVideoSave(video) {
   return {
@@ -37,12 +34,3 @@ export function saveVideo(video) {
   };
 }
 
-const debouncedSave = debounce(VideosApi.saveVideo, debounceInterval);
-export function debouncedSaveVideo(video) {
-  return dispatch => {
-    dispatch(requestVideoSave(video));
-    debouncedSave(video.id, video)
-        .then(res => dispatch(receiveVideoSave(res)))
-        .catch(error => dispatch(errorVideoSave(error)));
-  };
-}

--- a/public/video-ui/src/actions/VideoActions/updateVideoEditState.js
+++ b/public/video-ui/src/actions/VideoActions/updateVideoEditState.js
@@ -1,0 +1,7 @@
+export function updateVideoEditState(editState) {
+  return {
+    type:       'VIDEO_EDIT_STATE_REQUEST',
+    editState:  editState,
+    receivedAt: Date.now()
+  };
+}

--- a/public/video-ui/src/components/Video/Create.js
+++ b/public/video-ui/src/components/Video/Create.js
@@ -34,7 +34,7 @@ class VideoCreate extends React.Component {
             editable
             saveState={this.props.saveState}
           />
-          <SaveButton saveState={this.props.saveState} onSaveClick={this.createVideo} onResetClick={this.resetVideo} />
+          <SaveButton video={this.props.video} saveState={this.props.saveState} onSaveClick={this.createVideo} onResetClick={this.resetVideo} />
         </form>
       </div>
     );

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -32,24 +32,23 @@ class VideoDisplay extends React.Component {
     this.props.videoActions.debouncedSaveVideo(video);
   };
 
+  updateVideo = (video) => {
+    this.props.videoActions.updateVideo(video);
+  };
+
   selectVideo = () => {
     window.parent.postMessage({atomId: this.props.video.id}, '*');
   };
 
-  manageEditingState = (value, property) => {
+  manageEditingState = (property) => {
 
-    if (property === 'metadata') {
+    if (this.props.editState[property]) {
 
-      this.setState({
-        metadataEditable: value
-      });
-
-    } else if (property === 'youtube') {
-
-      this.setState({
-        youtubeEditable: value
-      });
+      this.saveAndUpdateVideo(this.props.video);
     }
+
+    const newEditableState = Object.assign(this.props.editState, {[property]: !this.props.editState[property]});
+    this.props.videoActions.updateVideoEditState(newEditableState);
   };
 
   disableEditing = () => {
@@ -62,15 +61,15 @@ class VideoDisplay extends React.Component {
     return this.props.video.expiryDate <= Date.now();
   };
 
-  renderEditButton = (editable, property) => {
+  renderEditButton = (property) => {
 
-    if (editable) {
+    if (this.props && this.props.editState[property]) {
       return (
-        <Icon className="icon__done" icon="done" onClick={this.manageEditingState.bind(this, false, property)}/>
+        <Icon className="icon__done" icon="done" onClick={this.manageEditingState.bind(this, property)}/>
       );
     } else {
       return (
-        <Icon className="icon__edit" icon="edit" onClick={this.manageEditingState.bind(this, true, property)}/>
+        <Icon className="icon__edit" icon="edit" onClick={this.manageEditingState.bind(this, property)}/>
       );
     }
   }
@@ -98,27 +97,27 @@ class VideoDisplay extends React.Component {
               <div className="video__detailbox">
                 <div className="video__detailbox__header__container">
                   <header className="video__detailbox__header">Video Meta Data</header>
-                  {this.renderEditButton(this.state.metadataEditable, 'metadata')}
+                  {this.renderEditButton('metadataEditable')}
                 </div>
                 <VideoMetaData
                   component={VideoMetaData}
                   video={this.props.video || {}}
-                  saveAndUpdateVideo={this.saveAndUpdateVideo}
-                  editable={this.state.metadataEditable}
+                  updateVideo={this.updateVideo}
+                  editable={this.props.editState.metadataEditable}
                  />
               </div>
               <div className="video__detailbox">
                 <div className="video__detailbox__header__container">
                   <header className="video__detailbox__header">Youtube Meta Data</header>
-                  {this.renderEditButton(this.state.youtubeEditable, 'youtube')}
+                  {this.renderEditButton('youtubeEditable')}
                 </div>
                 <YoutubeMetaData
                   component={YoutubeMetaData}
                   video={this.props.video || {}}
                   saveVideo={this.saveVideo}
-                  saveAndUpdateVideo={this.saveAndUpdateVideo}
+                  updateVideo={this.updateVideo}
                   disableStatusEditing={this.cannotEditStatus()}
-                  editable={this.state.youtubeEditable}
+                  editable={this.props.editState.youtubeEditable}
                 />
               </div>
               <div className="video__detailbox">
@@ -160,9 +159,11 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as getVideo from '../../actions/VideoActions/getVideo';
 import * as saveVideo from '../../actions/VideoActions/saveVideo';
+import * as updateVideo from '../../actions/VideoActions/updateVideo';
 import * as videoUsages from '../../actions/VideoActions/videoUsages';
 import * as videoPageCreate from '../../actions/VideoActions/videoPageCreate';
 import * as getPublishedVideo from '../../actions/VideoActions/getPublishedVideo';
+import * as updateVideoEditState from '../../actions/VideoActions/updateVideoEditState';
 
 function mapStateToProps(state) {
   return {
@@ -170,13 +171,14 @@ function mapStateToProps(state) {
     config: state.config,
     usages: state.usage,
     composerPageWithUsage: state.pageCreate,
-    publishedVideo: state.publishedVideo
+    publishedVideo: state.publishedVideo,
+    editState: state.editState
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
-    videoActions: bindActionCreators(Object.assign({}, getVideo, saveVideo, videoUsages, videoPageCreate, getPublishedVideo), dispatch)
+    videoActions: bindActionCreators(Object.assign({}, getVideo, saveVideo, updateVideo, videoUsages, videoPageCreate, getPublishedVideo, updateVideoEditState), dispatch)
   };
 }
 

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -8,6 +8,7 @@ import YoutubeMetaData from '../YoutubeMetaData/YoutubeMetaData';
 import VideoPoster from '../VideoPoster/VideoPoster';
 import GridImageSelect from '../utils/GridImageSelect';
 import Icon from '../Icon';
+import {validate} from '../../constants/videoEditValidation';
 
 class VideoDisplay extends React.Component {
 
@@ -61,15 +62,41 @@ class VideoDisplay extends React.Component {
     return this.props.video.expiryDate <= Date.now();
   };
 
+  isButtonDisabled = (property) => {
+
+    const formFields = [];
+    if (property === 'metadataEditable') {
+      formFields.splice(0, 0, 'title', 'category');
+    } else if (property === 'youtubeEditable') {
+      formFields.splice(0, 0, 'youtubeCategory', 'youtubeChannel', 'privacyStatus');
+    }
+    const errors  = validate(Object.assign(this.props.video, {
+      youtubeCategory: this.props.video.youtubeCategoryId,
+      youtubeChannel: this.props.video.channelId
+    }));
+
+    if (formFields.some(field => {
+      return Object.keys(errors).includes(field);
+    })) {
+      return true;
+    }
+    return false;
+
+  };
+
   renderEditButton = (property) => {
 
     if (this.props && this.props.editState[property]) {
       return (
-        <Icon className="icon__done" icon="done" onClick={this.manageEditingState.bind(this, property)}/>
+        <button disabled={this.isButtonDisabled(property)} onClick={() => this.manageEditingState(property)}>
+          <Icon className={"icon__done " + (this.isButtonDisabled(property) ? "disabled": "")} icon="done" />
+        </button>
       );
     } else {
       return (
-        <Icon className="icon__edit" icon="edit" onClick={this.manageEditingState.bind(this, property)}/>
+        <button onClick={() => this.manageEditingState(property)}>
+          <Icon className="icon__edit" icon="edit" />
+        </button>
       );
     }
   }

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -12,22 +12,13 @@ import {validate} from '../../constants/videoEditValidation';
 
 class VideoDisplay extends React.Component {
 
-  state = {
-    metadataEditable: false,
-    youtubeEditable: false
-  };
-
   componentWillMount() {
     this.props.videoActions.getVideo(this.props.params.id);
   }
 
   saveVideo = () => {
     this.props.videoActions.saveVideo(this.props.video);
-
-    this.setState({
-      editable: false
-    });
-  };
+  }
 
   saveAndUpdateVideo = (video) => {
     this.props.videoActions.saveVideo(video);
@@ -52,17 +43,20 @@ class VideoDisplay extends React.Component {
     this.props.videoActions.updateVideoEditState(newEditableState);
   };
 
-  disableEditing = () => {
-    this.setState({
-      editable: false
-    });
-  };
-
   cannotEditStatus = () => {
     return this.props.video.expiryDate <= Date.now();
   };
 
-  isButtonDisabled = (property) => {
+  cannotOpenEditForm = () => {
+    if (this.props.editState && (this.props.editState.metadataEditable || this.props.editState.youtubeEditable)) {
+      return true;
+    }
+
+    return false;
+  }
+
+
+  cannotCloseEditForm = (property) => {
 
     const formFields = [];
     if (property === 'metadataEditable') {
@@ -88,14 +82,14 @@ class VideoDisplay extends React.Component {
 
     if (this.props && this.props.editState[property]) {
       return (
-        <button disabled={this.isButtonDisabled(property)} onClick={() => this.manageEditingState(property)}>
-          <Icon className={"icon__done " + (this.isButtonDisabled(property) ? "disabled": "")} icon="done" />
+        <button disabled={this.cannotCloseEditForm(property)} onClick={() => this.manageEditingState(property)}>
+          <Icon className={"icon__done " + (this.cannotCloseEditForm(property) ? "disabled": "")} icon="done" />
         </button>
       );
     } else {
       return (
-        <button onClick={() => this.manageEditingState(property)}>
-          <Icon className="icon__edit" icon="edit" />
+        <button disabled={this.cannotOpenEditForm()} onClick={() => this.manageEditingState(property)}>
+          <Icon className={"icon__edit " + (this.cannotOpenEditForm() ? "disabled" : "")} icon="edit" />
         </button>
       );
     }
@@ -150,12 +144,11 @@ class VideoDisplay extends React.Component {
               <div className="video__detailbox">
                 <div className="video__detailbox__header__container">
                   <header className="video__detailbox__header">Poster Image</header>
-                  <GridImageSelect video={this.props.video || {}} updateVideo={this.saveAndUpdateVideo} gridUrl={this.props.config.gridUrl} createMode={false}/>
+                  <GridImageSelect editState={this.props.editState} video={this.props.video || {}} updateVideo={this.saveAndUpdateVideo} gridUrl={this.props.config.gridUrl} createMode={false}/>
                 </div>
                 <VideoPoster
                   video={this.props.video || {}}
                   updateVideo={this.saveAndUpdateVideo}
-                  editable={this.state.editable}
                 />
               </div>
               <div className="video__detailbox">

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -29,7 +29,7 @@ class VideoDisplay extends React.Component {
   };
 
   saveAndUpdateVideo = (video) => {
-    this.props.videoActions.debouncedSaveVideo(video);
+    this.props.videoActions.saveVideo(video);
   };
 
   updateVideo = (video) => {

--- a/public/video-ui/src/components/VideoEdit/VideoEdit.js
+++ b/public/video-ui/src/components/VideoEdit/VideoEdit.js
@@ -6,7 +6,6 @@ import VideoPosterEdit from './formComponents/VideoPoster';
 import YoutubeCategorySelect from './formComponents/YoutubeCategory';
 import VideoExpiryEdit from './formComponents/VideoExpiry';
 import YoutubeChannelSelect from './formComponents/YoutubeChannel';
-import SaveButton from '../utils/SaveButton';
 import PrivacyStatusSelect from './formComponents/PrivacyStatus';
 import {validate} from '../../constants/videoEditValidation';
 import { Field, reduxForm } from 'redux-form';
@@ -78,7 +77,6 @@ const VideoEdit = (props) => {
             updateVideo={props.updateVideo}
             editable={props.editable} />
 
-          <SaveButton saveState={props.saveState.saving} onSaveClick={props.saveVideo} onResetClick={props.resetVideo} />
         </div>
       );
 };

--- a/public/video-ui/src/components/VideoEdit/formComponents/VideoPoster.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/VideoPoster.js
@@ -24,7 +24,12 @@ class VideoPosterImageEdit extends React.Component {
           <div className="form__row">
             <label className="form__label">Poster image</label>
             <div className="form__imageselect">
-              <GridImageSelect video={this.props.video} updateVideo={this.props.updateVideo} gridUrl={this.props.config.gridUrl} createMode={true}/>
+              <GridImageSelect
+                video={this.props.video}
+                updateVideo={this.props.updateVideo}
+                gridUrl={this.props.config.gridUrl}
+                createMode={true}
+              />
               {this.renderImage()}
             </div>
           </div>

--- a/public/video-ui/src/components/VideoEdit/formComponents/VideoTitle.js
+++ b/public/video-ui/src/components/VideoEdit/formComponents/VideoTitle.js
@@ -9,6 +9,7 @@ export default class VideoTitleEdit extends React.Component {
     const newData = Object.assign({}, this.props.video, {
       title: e.target.value
     });
+    this.props.input.onChange(e.target.value);
 
     this.props.updateVideo(newData);
   };

--- a/public/video-ui/src/components/VideoMetaData/VideoMetaData.js
+++ b/public/video-ui/src/components/VideoMetaData/VideoMetaData.js
@@ -8,7 +8,6 @@ import VideoCategorySelect from '../VideoEdit/formComponents/VideoCategory';
 import { Field, reduxForm } from 'redux-form';
 import {validate} from '../../constants/videoEditValidation';
 
-
 const VideoMetaData = (props) => {
 
     return (

--- a/public/video-ui/src/components/VideoMetaData/VideoMetaData.js
+++ b/public/video-ui/src/components/VideoMetaData/VideoMetaData.js
@@ -18,7 +18,7 @@ const VideoMetaData = (props) => {
             type="text"
             component={VideoTitleEdit}
             video={props.video}
-            updateVideo={props.saveAndUpdateVideo}
+            updateVideo={props.updateVideo}
             editable={props.editable} />
 
           <Field
@@ -26,7 +26,7 @@ const VideoMetaData = (props) => {
             type="text"
             component={VideoDescriptionEdit}
             video={props.video}
-            updateVideo={props.saveAndUpdateVideo}
+            updateVideo={props.updateVideo}
             editable={props.editable} />
 
           <Field
@@ -34,7 +34,7 @@ const VideoMetaData = (props) => {
             type="select"
             component={VideoCategorySelect}
             video={props.video}
-            updateVideo={props.saveAndUpdateVideo}
+            updateVideo={props.updateVideo}
             editable={props.editable} />
 
           <Field
@@ -42,7 +42,7 @@ const VideoMetaData = (props) => {
             type="number"
             component={VideoExpiryEdit}
             video={props.video}
-            updateVideo={props.saveAndUpdateVideo}
+            updateVideo={props.updateVideo}
             editable={props.editable} />
 
           <Field
@@ -56,7 +56,7 @@ const VideoMetaData = (props) => {
             name="contentFlags"
             component={ContentFlags}
             video={props.video}
-            updateVideo={props.saveAndUpdateVideo}
+            updateVideo={props.updateVideo}
             editable={props.editable} />
         </div>
     );

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -3,7 +3,7 @@ import {saveStateVals} from '../../constants/saveStateVals';
 import {isVideoPublished} from '../../util/isVideoPublished';
 import {hasUnpublishedChanges} from '../../util/hasUnpublishedChanges';
 
-export default class VideoPublishBar extends React.Component {
+class VideoPublishBar extends React.Component {
 
   videoIsCurrentlyPublishing() {
     return this.props.saveState.publishing === saveStateVals.inprogress;
@@ -15,6 +15,8 @@ export default class VideoPublishBar extends React.Component {
 
   isPublishingDisabled() {
     return this.videoIsCurrentlyPublishing() ||
+      this.props.editState.metadataEditable ||
+      this.props.editState.youtubeEditable ||
       !this.videoHasUnpublishedChanges();
   }
 
@@ -67,3 +69,13 @@ export default class VideoPublishBar extends React.Component {
     );
   }
 }
+
+//REDUX CONNECTIONS
+import { connect } from 'react-redux';
+
+function mapStateToProps(state) {
+  return {
+    editState: state.editState
+  };
+}
+export default connect(mapStateToProps)(VideoPublishBar);

--- a/public/video-ui/src/components/YoutubeMetaData/YoutubeMetaData.js
+++ b/public/video-ui/src/components/YoutubeMetaData/YoutubeMetaData.js
@@ -16,7 +16,7 @@ const YoutubeMetaData = (props) => {
           type="select"
           component={YoutubeCategorySelect}
           video={props.video}
-          updateVideo={props.saveAndUpdateVideo}
+          updateVideo={props.updateVideo}
           editable={props.editable} />
 
         <Field
@@ -31,14 +31,14 @@ const YoutubeMetaData = (props) => {
           type="text"
           component={PrivacyStatusSelect}
           video={props.video}
-          updateVideo={props.saveAndUpdateVideo}
+          updateVideo={props.updateVideo}
           editable={!props.disableStatusEditing && props.editable} />
 
         <Field
           name="youtubeKeywords"
           component={YoutubeKeywordsSelect}
           video={props.video}
-          updateVideo={props.saveAndUpdateVideo}
+          updateVideo={props.updateVideo}
           editable={props.editable} />
       </div>
     );

--- a/public/video-ui/src/components/utils/GridImageSelect.js
+++ b/public/video-ui/src/components/utils/GridImageSelect.js
@@ -65,6 +65,9 @@ export default class GridEmbedder extends React.Component {
         this.onUpdatePosterImage(data.crop.data);
     }
 
+    pickerIsDisabled = () => {
+      return this.props.editState.metadataEditable || this.props.editState.youtubeEditable;
+    }
 
     render() {
       if(this.props.createMode && this.props.video.posterImage){
@@ -99,9 +102,9 @@ export default class GridEmbedder extends React.Component {
       } else {
         return (
             <div className="gridembedder">
-                <div onClick={this.toggleModal}>
-                  <Icon icon="add_to_photos" className="icon__edit"/>
-                </div>
+                <button disabled={this.pickerIsDisabled()} onClick={this.toggleModal}>
+                  <Icon icon="add_to_photos" className={"icon__edit " + (this.pickerIsDisabled() ? "disabled" : "")}/>
+                </button>
 
                 <Modal isOpen={this.state.modalOpen} dismiss={this.closeModal}>
                     <iframe className="gridembedder__modal" src={this.props.gridUrl}></iframe>

--- a/public/video-ui/src/components/utils/SaveButton.js
+++ b/public/video-ui/src/components/utils/SaveButton.js
@@ -1,7 +1,18 @@
 import React from 'react';
 import {saveStateVals} from '../../constants/saveStateVals';
+import {validate} from '../../constants/videoEditValidation';
 
 export default class SaveButton extends React.Component {
+
+  createDisabled = () => {
+    if (!this.props.video) {
+      return false;
+    }
+    return Object.keys(validate(Object.assign(this.props.video, {
+      youtubeCategory: this.props.video.youtubeCategoryId,
+      youtubeChannel: this.props.video.channelId
+    }))).length !== 0;
+  }
 
   renderButtons = () => {
     if (this.props.isHidden) {
@@ -21,8 +32,14 @@ export default class SaveButton extends React.Component {
       return false;
     }
 
+
     return (
-      <button type="button" className={(this.props.saveState.saving == saveStateVals.inprogress ? "btn--loading " : "") + "btn"} onClick={this.props.onSaveClick}>
+      <button
+        type="button"
+        disabled={this.createDisabled()}
+        className={(this.props.saveState.saving == saveStateVals.inprogress ? "btn--loading " : "") + "btn"}
+        onClick={this.props.onSaveClick}
+      >
         <i className="i-tick-green"/>Save
       </button>
     );

--- a/public/video-ui/src/constants/videoEditValidation.js
+++ b/public/video-ui/src/constants/videoEditValidation.js
@@ -15,9 +15,6 @@ export const validate = (values) => {
     errors.posterImage = 'Required';
   }
 
-  if (!values.duration) {
-    errors.duration = 'Required';
-  }
   if(!values.youtubeCategory) {
     errors.youtubeCategory = 'Required';
   }

--- a/public/video-ui/src/reducers/editStateReducer.js
+++ b/public/video-ui/src/reducers/editStateReducer.js
@@ -1,0 +1,11 @@
+export default function video(state = {
+    metadataEditable: false,
+    youtubeEditable: false
+  }, action) {
+  switch (action.type) {
+    case 'VIDEO_EDIT_STATE_REQUEST':
+      return Object.assign({}, action.editState) || state;
+    default:
+      return state;
+  }
+}

--- a/public/video-ui/src/reducers/rootReducer.js
+++ b/public/video-ui/src/reducers/rootReducer.js
@@ -12,6 +12,7 @@ import { reducer as form } from 'redux-form';
 import usage from './usageReducer';
 import pageCreate from './composerPageReducer';
 import upload from './uploadsReducer';
+import editState from './editStateReducer';
 
 export default combineReducers({
   audits,
@@ -26,5 +27,6 @@ export default combineReducers({
   usage,
   pageCreate,
   publishedVideo,
-  upload
+  upload,
+  editState
 });

--- a/public/video-ui/styles/abstracts/_mixins.scss
+++ b/public/video-ui/styles/abstracts/_mixins.scss
@@ -13,6 +13,7 @@
 
   &:disabled {
     background: $color500Grey;
+    cursor: default;
   }
 
   &:focus {

--- a/public/video-ui/styles/layout/_icons.scss
+++ b/public/video-ui/styles/layout/_icons.scss
@@ -52,5 +52,9 @@
   &:hover {
     background-color: darken($brandColor, 5%);
   }
+
+  &.disabled {
+    background-color: darken($brandColor, 15%);
+  }
 }
 

--- a/public/video-ui/styles/layout/_icons.scss
+++ b/public/video-ui/styles/layout/_icons.scss
@@ -45,6 +45,8 @@
     background-color: darken($color600Grey, 10%);
   }
   &.disabled {
+    opacity: 0.4;
+    cursor: default;
     background-color: darken($color600Grey, 10%);
   }
 }
@@ -57,7 +59,8 @@
   }
 
   &.disabled {
-    background-color: darken($brandColor, 15%);
+    cursor: default;
+    opacity: 0.4;
   }
 }
 

--- a/public/video-ui/styles/layout/_icons.scss
+++ b/public/video-ui/styles/layout/_icons.scss
@@ -44,6 +44,9 @@
   &:hover {
     background-color: darken($color600Grey, 10%);
   }
+  &.disabled {
+    background-color: darken($color600Grey, 10%);
+  }
 }
 
 .icon__done {


### PR DESCRIPTION
- Saves the metadata and youtube metadata forms only when the form is closed so that we can validate form fields. 

- Using the form validate function in `VideoDisplay.js` to determine when the buttons that close the forms are disabled is not ideal but checking the form validity to determine this would require writing multiple validate functions instead of having one that checks all video fields. If we have time, we should probably spend some time thinking about how we do form validation and perhaps get rid of redux forms.

- The 'create button is disabled in the create form if the atom is not valid

- Only one form can be edited at a time. If edit metadata or edit youtube forms are open, other atom data, including the poster image, cannot be updated: 
<img width="1064" alt="screen shot 2017-02-24 at 09 45 21" src="https://cloud.githubusercontent.com/assets/3066534/23298622/54422e0a-fa76-11e6-87ed-7833caa5be0b.png">


@mbarton @akash1810 @jennysivapalan 