### PR TITLE
Grid tweaks and Usages

### DIFF
--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -7,6 +7,8 @@ import VideoMetaData from '../VideoMetaData/VideoMetaData';
 import YoutubeMetaData from '../YoutubeMetaData/YoutubeMetaData';
 import VideoPoster from '../VideoPoster/VideoPoster';
 import GridImageSelect from '../utils/GridImageSelect';
+import {getVideoBlock} from '../../util/getVideoBlock';
+import {getStore} from '../../util/storeAccessor';
 import Icon from '../Icon';
 
 class VideoDisplay extends React.Component {
@@ -18,6 +20,7 @@ class VideoDisplay extends React.Component {
 
   componentWillMount() {
     this.props.videoActions.getVideo(this.props.params.id);
+    this.props.videoActions.getUsages(this.props.params.id);
   }
 
   saveVideo = () => {
@@ -61,6 +64,33 @@ class VideoDisplay extends React.Component {
   cannotEditStatus = () => {
     return this.props.video.expiryDate <= Date.now();
   };
+
+    pageCreate = () => {
+
+    this.setState({
+      pageCreated: true
+    });
+
+    const metadata = {
+      title: this.props.video.title,
+      standfirst: this.props.video.description
+    };
+
+    const videoBlock = getVideoBlock(this.props.video.id, metadata);
+
+    return this.props.videoActions.createVideoPage(this.props.video.id, metadata, this.getComposerUrl(), videoBlock);
+  }
+
+  getComposerUrl = () => {
+    return getStore().getState().config.composerUrl;
+  }
+
+  renderUsagesButton = () => {
+    return (
+      <button className="button__secondary" onClick={this.pageCreate}><Icon icon="add_to_queue"></Icon> Create Video Page</button>
+    )
+  }
+
 
   renderEditButton = (editable, property) => {
 
@@ -135,13 +165,12 @@ class VideoDisplay extends React.Component {
               <div className="video__detailbox">
                 <div className="video__detailbox__header__container">
                   <header className="video__detailbox__header">Usages</header>
+                  {this.renderUsagesButton()}
                 </div>
                 <VideoUsages
                   video={this.props.video || {}}
                   publishedVideo={this.props.publishedVideo || {}}
-                  fetchUsages={this.props.videoActions.getUsages}
                   usages={this.props.usages || []}
-                  createComposerPage={this.props.videoActions.createVideoPage}
                 />
               </div>
               <div className="video__detailbox">

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -86,7 +86,7 @@ class VideoDisplay extends React.Component {
     return getStore().getState().config.composerUrl;
   }
 
-  renderCreateButton = () => {
+  videoPageUsages = () => {
       const filterUsageType = this.props.usages.filter(value => value.type === 'video');
 
       if(filterUsageType.length === 0){
@@ -170,7 +170,7 @@ class VideoDisplay extends React.Component {
               <div className="video__detailbox">
                 <div className="video__detailbox__header__container">
                   <header className="video__detailbox__header">Usages</header>
-                  {this.renderCreateButton()}
+                  {this.videoPageUsages()}
                 </div>
                 <VideoUsages
                   video={this.props.video || {}}

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -85,7 +85,6 @@ class VideoDisplay extends React.Component {
     return getStore().getState().config.composerUrl;
   }
 
-
   renderCreateButton = () => {
     const filterUsageType = this.props.usages.filter(value => value.type === 'video');
 

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -9,7 +9,6 @@ import VideoPoster from '../VideoPoster/VideoPoster';
 import GridImageSelect from '../utils/GridImageSelect';
 import {getVideoBlock} from '../../util/getVideoBlock';
 import {getStore} from '../../util/storeAccessor';
-import {saveStateVals} from '../../constants/saveStateVals';
 import Icon from '../Icon';
 import {validate} from '../../constants/videoEditValidation';
 
@@ -77,7 +76,7 @@ class VideoDisplay extends React.Component {
       if(filterUsageType.length === 0){
         return (
           <button className="button__secondary" onClick={this.pageCreate}><Icon icon="add_to_queue"></Icon> Create Video Page</button>
-        )
+        );
       }
   }
 

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -85,10 +85,15 @@ class VideoDisplay extends React.Component {
     return getStore().getState().config.composerUrl;
   }
 
-  renderUsagesButton = () => {
-    return (
-      <button className="button__secondary" onClick={this.pageCreate}><Icon icon="add_to_queue"></Icon> Create Video Page</button>
-    )
+
+  renderCreateButton = () => {
+    const filterUsageType = this.props.usages.filter(value => value.type === 'video');
+
+    if(filterUsageType.length === 0){
+      return (
+        <button className="button__secondary" onClick={this.pageCreate}><Icon icon="add_to_queue"></Icon> Create Video Page</button>
+      )
+    }
   }
 
 
@@ -165,7 +170,7 @@ class VideoDisplay extends React.Component {
               <div className="video__detailbox">
                 <div className="video__detailbox__header__container">
                   <header className="video__detailbox__header">Usages</header>
-                  {this.renderUsagesButton()}
+                  {this.renderCreateButton()}
                 </div>
                 <VideoUsages
                   video={this.props.video || {}}

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -9,6 +9,7 @@ import VideoPoster from '../VideoPoster/VideoPoster';
 import GridImageSelect from '../utils/GridImageSelect';
 import {getVideoBlock} from '../../util/getVideoBlock';
 import {getStore} from '../../util/storeAccessor';
+import {saveStateVals} from '../../constants/saveStateVals';
 import Icon from '../Icon';
 
 class VideoDisplay extends React.Component {
@@ -86,13 +87,13 @@ class VideoDisplay extends React.Component {
   }
 
   renderCreateButton = () => {
-    const filterUsageType = this.props.usages.filter(value => value.type === 'video');
+      const filterUsageType = this.props.usages.filter(value => value.type === 'video');
 
-    if(filterUsageType.length === 0){
-      return (
-        <button className="button__secondary" onClick={this.pageCreate}><Icon icon="add_to_queue"></Icon> Create Video Page</button>
-      )
-    }
+      if(filterUsageType.length === 0){
+        return (
+          <button className="button__secondary" onClick={this.pageCreate}><Icon icon="add_to_queue"></Icon> Create Video Page</button>
+        )
+      }
   }
 
 

--- a/public/video-ui/src/components/VideoAssets/VideoAssets.js
+++ b/public/video-ui/src/components/VideoAssets/VideoAssets.js
@@ -117,7 +117,7 @@ class VideoAssets extends React.Component {
       </Link>
     </div>;
 
-    return <div className="section-header">
+    return <div className="video__detailbox__header__container">
       <span className="video__detailbox__header">Assets</span>
       {this.state.showAssetForm ? false : buttons }
     </div>;
@@ -133,7 +133,7 @@ class VideoAssets extends React.Component {
           {this.renderHeader()}
           {this.renderAssetEdit()}
           {this.renderList()}
-          {!this.props.video.assets.length ? <span>No assets found</span> : false}
+          {!this.props.video.assets.length ? <span className="baseline-margin">No assets found</span> : false}
           {this.shouldShowAssetExpander() ? <button className="video-assets__show-btn" type="button" onClick={this.showAssetList}>Show all assets</button> : false}
         </div>
     );

--- a/public/video-ui/src/components/VideoAssets/VideoAssets.js
+++ b/public/video-ui/src/components/VideoAssets/VideoAssets.js
@@ -110,7 +110,7 @@ class VideoAssets extends React.Component {
   renderHeader() {
     const buttons = <div className="video-assets__buttons">
       <a className="button" onClick={this.showAssetForm}>
-        <Icon className="icon__edit" icon="add"/>
+        <Icon className="icon__edit icon__spacing" icon="add"/>
       </a>
       <Link className="button" to={`/videos/${this.props.video.id}/upload`}>
         <Icon className="icon__edit" icon="backup"/>

--- a/public/video-ui/src/components/VideoPreview/VideoPreview.js
+++ b/public/video-ui/src/components/VideoPreview/VideoPreview.js
@@ -26,16 +26,16 @@ export default class VideoPreview extends React.Component {
 
     if (!activeAsset) {
       return (
-        <div className="video-preview__video">No Active Video</div>
+        <div className="baseline-margin">No Active Video</div>
       );
     }
 
     if (activeAsset.platform !== "Youtube") {
-      <div className="video-preview__video">Unable to Preview</div>;
+      <div className="baseline-margin">Unable to Preview</div>;
     }
 
     return  (
-      <iframe className="video-preview__video" src={this.youtubeEmbedUrl() + activeAsset.id} allowFullScreen></iframe>
+      <iframe className="baseline-margin" src={this.youtubeEmbedUrl() + activeAsset.id} allowFullScreen></iframe>
     );
   }
 

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -2,7 +2,6 @@ import React from 'react';
 import moment from 'moment';
 import {getVideoBlock} from '../../util/getVideoBlock';
 import {getStore} from '../../util/storeAccessor';
-import {isVideoPublished} from '../../util/isVideoPublished';
 import {hasUnpublishedChanges} from '../../util/hasUnpublishedChanges';
 import {FrontendIcon, ComposerIcon, ViewerIcon} from '../Icon';
 
@@ -85,7 +84,7 @@ export default class VideoUsages extends React.Component {
         <div>
           <div className="baseline-margin">No usages found</div>
         </div>
-      )
+      );
     } else {
       return (
         <div>

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -69,7 +69,7 @@ export default class VideoUsages extends React.Component {
       );
     }
 
-    return (<div>Publish this atom to enable the creation of composer pages</div>);
+    return (<div className="baseline-margin">Publish this atom to enable the creation of composer pages</div>);
   };
 
   renderUsage = (usage) => {

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -40,22 +40,6 @@ export default class VideoUsages extends React.Component {
     return hasUnpublishedChanges(this.props.video, this.props.publishedVideo);
   }
 
-  // renderCreateButton = () => {
-  //   if (this.props.video && isVideoPublished(this.props.publishedVideo) && !this.videoHasUnpublishedChanges()) {
-  //     return (
-  //       <button
-  //         type="button"
-  //         className="btn page__add__button"
-  //         disabled={this.state.pageCreated}
-  //         onClick={this.pageCreate}>
-  //         Create video page
-  //       </button>
-  //     );
-  //   }
-
-    // return (<div className="baseline-margin">Publish this atom to enable the creation of composer pages</div>);
-  // };
-
   renderUsage = (usage) => {
     const composerLink = `${this.getComposerUrl()}/content/${usage.fields.internalComposerCode}`;
     const viewerLink = `${this.getViewerUrl()}/preview/${usage.id}`;

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -12,22 +12,6 @@ export default class VideoUsages extends React.Component {
     pageCreated: false
   };
 
-  componentDidMount() {
-    if (this.props.video) {
-      this.props.fetchUsages(this.props.video.id);
-    }
-  }
-
-  componentWillReceiveProps(newProps) {
-    const oldVideoId = this.props.video && this.props.video.id;
-    const newVideoId = newProps.video && newProps.video.id;
-
-    if (oldVideoId !== newVideoId) {
-
-      this.props.fetchUsages(newVideoId);
-    }
-  }
-
   getComposerUrl = () => {
     return getStore().getState().config.composerUrl;
   };
@@ -56,21 +40,21 @@ export default class VideoUsages extends React.Component {
     return hasUnpublishedChanges(this.props.video, this.props.publishedVideo);
   }
 
-  renderCreateButton = () => {
-    if (this.props.video && isVideoPublished(this.props.publishedVideo) && !this.videoHasUnpublishedChanges()) {
-      return (
-        <button
-          type="button"
-          className="btn page__add__button"
-          disabled={this.state.pageCreated}
-          onClick={this.pageCreate}>
-          Create video page
-        </button>
-      );
-    }
+  // renderCreateButton = () => {
+  //   if (this.props.video && isVideoPublished(this.props.publishedVideo) && !this.videoHasUnpublishedChanges()) {
+  //     return (
+  //       <button
+  //         type="button"
+  //         className="btn page__add__button"
+  //         disabled={this.state.pageCreated}
+  //         onClick={this.pageCreate}>
+  //         Create video page
+  //       </button>
+  //     );
+  //   }
 
-    return (<div className="baseline-margin">Publish this atom to enable the creation of composer pages</div>);
-  };
+    // return (<div className="baseline-margin">Publish this atom to enable the creation of composer pages</div>);
+  // };
 
   renderUsage = (usage) => {
     const composerLink = `${this.getComposerUrl()}/content/${usage.fields.internalComposerCode}`;
@@ -108,23 +92,28 @@ export default class VideoUsages extends React.Component {
   }
 
   render() {
-    if (! this.props.usages) {
+    if (!this.props.usages) {
       return (<div className="baseline-margin">Fetching Usages...</div>);
     }
 
-    return (
-      <div>
-        {this.renderCreateButton()}
-        {this.renderUsages()}
-      </div>
-    );
+    if(this.props.usages.length === 0){
+      return (
+        <div>
+          <div className="baseline-margin">No usages found</div>
+        </div>
+      )
+    } else {
+      return (
+        <div>
+          {this.renderUsages()}
+        </div>
+      );
+    }
   }
 }
 
 VideoUsages.propTypes = {
   usages: React.PropTypes.array.isRequired,
   video: React.PropTypes.object.isRequired,
-  publishedVideo: React.PropTypes.object.isRequired,
-  createComposerPage: React.PropTypes.func.isRequired,
-  fetchUsages: React.PropTypes.func.isRequired
+  publishedVideo: React.PropTypes.object.isRequired
 };

--- a/public/video-ui/src/reducers/saveStateReducer.js
+++ b/public/video-ui/src/reducers/saveStateReducer.js
@@ -75,6 +75,16 @@ export default function saveState(state = {
         addingAsset: false
       });
 
+      // Checkign usages state
+      case 'VIDEO_USAGE_GET_REQUEST':
+        return Object.assign({}, state, {
+          fetchingUsages: true
+        });
+      case 'VIDEO_USAGE_GET_RECEIVE':
+        return Object.assign({}, state, {
+          fetchingUsages: false
+        });
+
 
     case 'SHOW_ERROR':
       return Object.assign({}, state, {

--- a/public/video-ui/styles/base/_helpers.scss
+++ b/public/video-ui/styles/base/_helpers.scss
@@ -66,5 +66,12 @@
 $baselineMargin: 20px;
 
 .baseline-margin {
+  background-color: $color700Grey;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  text-align: center;
   margin: 10px;
+  height: 170px;
+  border-style: none;
 }

--- a/public/video-ui/styles/components/_buttons.scss
+++ b/public/video-ui/styles/components/_buttons.scss
@@ -40,7 +40,6 @@ button {
 }
 
 .page__add__button {
-  padding: 5px 10px;
-  margin: 0px 5px;
-  font-family: $text-font-stack;
+  display: flex;
+  justify-content: flex-end;
 }

--- a/public/video-ui/styles/layout/_icons.scss
+++ b/public/video-ui/styles/layout/_icons.scss
@@ -46,6 +46,10 @@
   }
 }
 
+.icon__spacing {
+  margin-right: 5px;
+}
+
 .icon__done {
   background-color: $brandColor;
   color: $color800Grey;

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -18,18 +18,8 @@
 }
 
 .video-preview {
-
-  margin: 0 10px 10px;
-  vertical-align: top;
-
-  position: relative;
-  align-content: center;
-
-  &__video {
-    height: 200px;
-    border-style: none;
-    display: block;
-  }
+  text-align: center;
+  border-style: none;
 
   &__header {
     display: block;


### PR DESCRIPTION
Mostly the zero states of each of the blocks, also includes a clean up of the usages header and button

Zero state on preview, usages and assets
![image](https://cloud.githubusercontent.com/assets/2067172/23306723/a2e0f336-fa9c-11e6-9733-229ec1520f76.png)

Usage button updated to secondary button and lives in the block header
![image](https://cloud.githubusercontent.com/assets/2067172/23306717/9c17c67e-fa9c-11e6-8339-a268feb8e70c.png)
