### PR TITLE
respond with more detail when YT is still processing

### DIFF
--- a/app/model/commands/ActiveAssetCommand.scala
+++ b/app/model/commands/ActiveAssetCommand.scala
@@ -80,7 +80,7 @@ case class ActiveAssetCommand(atomId: String, youtubeId: String, stores: DataSto
 
           case Some(other) =>
             log.info(s"Cannot mark $youtubeId as the active asset in $atomId. Unexpected processing state $other")
-            AssetEncodingInProcess
+            AssetEncodingInProgress(other)
 
           case None =>
             log.info(s"Cannot mark $youtubeId as the active asset in $atomId. No youtube video has that id")

--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -13,7 +13,7 @@ object CommandExceptions extends Results {
   def NotYoutubeAsset = throw new CommandException("Asset is not a youtube video", 400)
   def AssetVersionConflict = throw new CommandException("Asset version conflict", 400)
   def AssetParseFailed = throw new CommandException("Failed to parse asset", 400)
-  def AssetEncodingInProcess = throw new CommandException("Asset encoding in progress", 400)
+  def AssetEncodingInProgress(state: String) = throw CommandException(s"Asset encoding in progress. Current state $state", 400)
   def AssetNotFound = throw new CommandException("Asset not found", 404)
 
   def AssetNotFound(assetId: String) = throw new CommandException(s"Asset with id $assetId not found", 404)


### PR DESCRIPTION
provides more detail to the client

In Friday's demo, we came across an issue where YT was returning `failed` for the processing status of a video (even though playback was possible on yt.com). Returning more information in the response will help surface this problem earlier, instead of looking through the logs to see what was happening.