### PR TITLE
remove redirect on google auth error

### DIFF
--- a/app/controllers/MainApp.scala
+++ b/app/controllers/MainApp.scala
@@ -24,15 +24,7 @@ class MainApp (override val stores: DataStores,
   }
 
   def oauthCallback = Action.async { implicit req =>
-    try {
-      processGoogleCallback()
-    } catch {
-      case e: GoogleAuthException => {
-        val redirectTo = "https://" + conf.getString("host").get
-        Logger.info(s"Authentication failure. ${e.message}. Redirecting to $redirectTo")
-        Future(Redirect(redirectTo, MOVED_PERMANENTLY))
-      }
-    }
+    processGoogleCallback()
   }
 
   def listAtoms = AuthAction { implicit req =>


### PR DESCRIPTION
This was put in place for graceful fallback when users went to `media-atom-maker.` rather than `video.`.
I tried using a Filter to do this redirection earlier in #269 but it broke the healthcheck.

Let's just delete the redirection entirely and remove the old domain from DNS as no-one is using it anymore anyway.

Before Deploy
- [ ] Ask CP to send comms