### PR TITLE
use smaller image in the select bar

### DIFF
--- a/public/video-ui/src/components/VideoSelectBar/VideoSelectBar.js
+++ b/public/video-ui/src/components/VideoSelectBar/VideoSelectBar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {isVideoPublished} from '../../util/isVideoPublished';
+import {findSmallestAssetAboveWidth} from '../../util/imageHelpers';
 
 export default class VideoSelectBar extends React.Component {
 
@@ -9,7 +10,8 @@ export default class VideoSelectBar extends React.Component {
     }
 
     if (this.props.video.posterImage) {
-      return  <img src={this.props.video.posterImage.master.file} alt={this.props.video.title}/>;
+      const image = findSmallestAssetAboveWidth(this.props.video.posterImage.assets);
+      return  <img src={image.file} alt={this.props.video.title}/>;
     }
 
     return <div className="bar__image-placeholder">No Image</div>;


### PR DESCRIPTION
Previously we were using the master crop which is massive!
Now we use the same image used elsewhere; the 500px wide one.