### PR TITLE
Use latest atom-publisher-lib

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -34,15 +34,15 @@ class Api (override val stores: DataStores,
 
   def getMediaAtom(id: String) = APIAuthAction { implicit req =>
     previewDataStore.getAtom(id) match {
-      case Some(atom) => Ok(Json.toJson(atom))
-      case None => NotFound(jsonError(s"no atom with id $id found"))
+      case Right(atom) => Ok(Json.toJson(atom))
+      case _ => NotFound(jsonError(s"no atom with id $id found"))
     }
   }
 
   def getPublishedMediaAtom(id: String) = APIAuthAction { implicit req =>
     publishedDataStore.getAtom(id) match {
-      case Some(atom) => Ok(Json.toJson(atom))
-      case None => Ok("not published")
+      case Right(atom) => Ok(Json.toJson(atom))
+      case _ => Ok("not published")
     }
   }
 
@@ -70,7 +70,7 @@ class Api (override val stores: DataStores,
   def updateMediaAtom(atomId: String) = thriftResultAction(atomBodyParser) { implicit req =>
     val updatedData = req.body.tdata
     previewDataStore.getAtom(atomId) match {
-      case Some(atom) =>
+      case Right(atom) =>
         val activeVersion = atom.tdata.activeVersion getOrElse {
           val versions = atom.tdata.assets.map(_.version)
           if (versions.isEmpty) 1 else versions.max
@@ -100,7 +100,7 @@ class Api (override val stores: DataStores,
             Ok(Json.toJson(atom))
           }
         )
-      case None => NotFound(s"atom not found $atomId")
+      case _ => NotFound(s"atom not found $atomId")
     }
   }
 
@@ -108,7 +108,7 @@ class Api (override val stores: DataStores,
     val newAsset = req.body
 
     previewDataStore.getAtom(atomId) match {
-      case Some(atom) =>
+      case Right(atom) =>
         val ma = atom.tdata
         val assets = ma.assets
 
@@ -139,7 +139,7 @@ class Api (override val stores: DataStores,
             }
           )
         }
-      case None => NotFound(s"atom not found $atomId")
+      case _ => NotFound(s"atom not found $atomId")
     }
   }
 
@@ -147,7 +147,7 @@ class Api (override val stores: DataStores,
 
   def revertAtom(atomId: String, version: Long) = APIAuthAction { implicit req =>
     previewDataStore.getAtom(atomId) match {
-      case Some(atom) =>
+      case Right(atom) =>
         if(!atom.tdata.assets.exists(_.version == version)) {
           InternalServerError(jsonError(s"no asset is listed for version $version"))
         } else {
@@ -158,7 +158,7 @@ class Api (override val stores: DataStores,
           previewDataStore.updateAtom(newAtom)
           Ok(Json.toJson(newAtom))
         }
-      case None => NotFound(s"atom not found $atomId")
+      case _ => NotFound(s"atom not found $atomId")
     }
   }
 

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -5,7 +5,7 @@ import java.util.Date
 import com.gu.atom.data._
 import com.gu.atom.play._
 import com.gu.contentatom.thrift.atom.media.Category.Hosted
-import com.gu.contentatom.thrift.{ContentAtomEvent, EventType}
+import com.gu.contentatom.thrift.{Atom, ContentAtomEvent, EventType}
 import com.gu.pandahmac.HMACAuthActions
 import data.DataStores
 import data.JsonConversions._
@@ -15,6 +15,7 @@ import util.AWSConfig
 import util.ThriftUtil._
 import util.atom.MediaAtomImplicits
 import play.api.libs.json._
+import play.api.mvc.Result
 
 import scala.util.{Failure, Success}
 
@@ -33,16 +34,14 @@ class Api (override val stores: DataStores,
   // takes a configured URL object and shows how it would look as a content atom
 
   def getMediaAtom(id: String) = APIAuthAction { implicit req =>
-    previewDataStore.getAtom(id) match {
-      case Right(atom) => Ok(Json.toJson(atom))
-      case _ => NotFound(jsonError(s"no atom with id $id found"))
+    getAtom(id, previewDataStore) { atom =>
+      Ok(Json.toJson(atom))
     }
   }
 
   def getPublishedMediaAtom(id: String) = APIAuthAction { implicit req =>
-    publishedDataStore.getAtom(id) match {
-      case Right(atom) => Ok(Json.toJson(atom))
-      case _ => Ok("not published")
+    getAtom(id, publishedDataStore) { atom =>
+      Ok(Json.toJson(atom))
     }
   }
 
@@ -69,27 +68,63 @@ class Api (override val stores: DataStores,
 
   def updateMediaAtom(atomId: String) = thriftResultAction(atomBodyParser) { implicit req =>
     val updatedData = req.body.tdata
-    previewDataStore.getAtom(atomId) match {
-      case Right(atom) =>
-        val activeVersion = atom.tdata.activeVersion getOrElse {
-          val versions = atom.tdata.assets.map(_.version)
-          if (versions.isEmpty) 1 else versions.max
-        }
 
+    getAtom(atomId, previewDataStore) { atom =>
+      val activeVersion = atom.tdata.activeVersion getOrElse {
+        val versions = atom.tdata.assets.map(_.version)
+        if (versions.isEmpty) 1 else versions.max
+      }
+
+      val newAtom = atom
+        .withRevision(_ + 1)
+        .updateData { media =>
+          media.copy(
+            activeVersion = Some(activeVersion),
+            title = updatedData.title,
+            category = updatedData.category,
+            duration = updatedData.duration,
+            posterUrl = updatedData.posterUrl
+          )
+        }
+      previewDataStore.updateAtom(newAtom).fold(
+        err => InternalServerError(err.msg),
+        _ => {
+          val event = ContentAtomEvent(newAtom, EventType.Update, now())
+
+          previewPublisher.publishAtomEvent(event) match {
+            case Success(_) => NoContent
+            case Failure(err) => InternalServerError(jsonError(s"could not publish: ${err.toString}"))
+          }
+
+          Ok(Json.toJson(atom))
+        }
+      )
+    }
+  }
+
+  def addAsset(atomId: String) = thriftResultAction(assetBodyParser) { implicit req =>
+    val newAsset = req.body
+
+    getAtom(atomId, previewDataStore) { atom =>
+      val ma = atom.tdata
+      val assets = ma.assets
+
+      if (assets.exists(asset => {
+        asset.version == newAsset.version && asset.mimeType == newAsset.mimeType
+      })) {
+        InternalServerError("could not add asset to atom: version conflict")
+      } else {
         val newAtom = atom
-                      .withRevision(_ + 1)
-                      .updateData { media =>
-                        media.copy(
-                          activeVersion = Some(activeVersion),
-                          title = updatedData.title,
-                          category = updatedData.category,
-                          duration = updatedData.duration,
-                          posterUrl = updatedData.posterUrl
-                        )
-                      }
+          .withData(ma.copy(
+            activeVersion = Some(newAsset.version),
+            assets = newAsset +: assets
+          ))
+          .withRevision(_ + 1)
+
         previewDataStore.updateAtom(newAtom).fold(
           err => InternalServerError(err.msg),
           _ => {
+
             val event = ContentAtomEvent(newAtom, EventType.Update, now())
 
             previewPublisher.publishAtomEvent(event) match {
@@ -97,68 +132,27 @@ class Api (override val stores: DataStores,
               case Failure(err) => InternalServerError(jsonError(s"could not publish: ${err.toString}"))
             }
 
-            Ok(Json.toJson(atom))
+            Ok(Json.toJson(newAtom))
           }
         )
-      case _ => NotFound(s"atom not found $atomId")
-    }
-  }
-
-  def addAsset(atomId: String) = thriftResultAction(assetBodyParser) { implicit req =>
-    val newAsset = req.body
-
-    previewDataStore.getAtom(atomId) match {
-      case Right(atom) =>
-        val ma = atom.tdata
-        val assets = ma.assets
-
-        if (assets.exists(asset => {
-          asset.version == newAsset.version && asset.mimeType == newAsset.mimeType
-        })) {
-          InternalServerError("could not add asset to atom: version conflict")
-        } else {
-          val newAtom = atom
-            .withData(ma.copy(
-              activeVersion = Some(newAsset.version),
-              assets = newAsset +: assets
-            ))
-            .withRevision(_ + 1)
-
-          previewDataStore.updateAtom(newAtom).fold(
-            err => InternalServerError(err.msg),
-            _ => {
-
-              val event = ContentAtomEvent(newAtom, EventType.Update, now())
-
-              previewPublisher.publishAtomEvent(event) match {
-                case Success(_) => NoContent
-                case Failure(err) => InternalServerError(jsonError(s"could not publish: ${err.toString}"))
-              }
-
-              Ok(Json.toJson(newAtom))
-            }
-          )
-        }
-      case _ => NotFound(s"atom not found $atomId")
+      }
     }
   }
 
   def now() = new Date().getTime
 
   def revertAtom(atomId: String, version: Long) = APIAuthAction { implicit req =>
-    previewDataStore.getAtom(atomId) match {
-      case Right(atom) =>
-        if(!atom.tdata.assets.exists(_.version == version)) {
-          InternalServerError(jsonError(s"no asset is listed for version $version"))
-        } else {
-          val newAtom = atom
-            .withRevision(_ + 1)
-            .updateData { media => media.copy(activeVersion = Some(version)) }
+    getAtom(atomId, previewDataStore) { atom =>
+      if(!atom.tdata.assets.exists(_.version == version)) {
+        InternalServerError(jsonError(s"no asset is listed for version $version"))
+      } else {
+        val newAtom = atom
+          .withRevision(_ + 1)
+          .updateData { media => media.copy(activeVersion = Some(version)) }
 
-          previewDataStore.updateAtom(newAtom)
-          Ok(Json.toJson(newAtom))
-        }
-      case _ => NotFound(s"atom not found $atomId")
+        previewDataStore.updateAtom(newAtom)
+        Ok(Json.toJson(newAtom))
+      }
     }
   }
 
@@ -182,5 +176,13 @@ class Api (override val stores: DataStores,
 
     Ok(Json.toJson(Map("stage" -> stage)))
 
+  }
+
+  private def getAtom(atomId: String, store: DataStore)(fn: Atom => Result): Result = {
+    store.getAtom(atomId) match {
+      case Right(atom) => fn(atom)
+      case Left(IDNotFound) => NotFound(s"atom not found $atomId")
+      case Left(err) => InternalServerError(err.msg)
+    }
   }
 }

--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -46,17 +46,13 @@ class Api2 (override val stores: DataStores, conf: Configuration, val authAction
   }
 
   def getMediaAtom(id: String) = APIHMACAuthAction {
-    previewDataStore.getAtom(id) match {
-      case Some(atom) => Ok(Json.toJson(MediaAtom.fromThrift(atom)))
-      case None => NotFound(jsonError(s"no atom with id $id found"))
-    }
+    val atom = getPreviewAtom(id)
+    Ok(Json.toJson(MediaAtom.fromThrift(atom)))
   }
 
   def getPublishedMediaAtom(id: String) = APIHMACAuthAction {
-    publishedDataStore.getAtom(id) match {
-      case Some(atom) => Ok(Json.toJson(MediaAtom.fromThrift(atom)))
-      case None => Ok(Json.obj())
-    }
+    val atom = getPublishedAtom(id)
+    Ok(Json.toJson(MediaAtom.fromThrift(atom)))
   }
 
   def publishMediaAtom(id: String) = APIHMACAuthAction { implicit req =>

--- a/app/data/DataStores.scala
+++ b/app/data/DataStores.scala
@@ -1,11 +1,12 @@
 package data
 
-import com.gu.atom.data.{PreviewDataStore, PreviewDynamoDataStore, PublishedDataStore, PublishedDynamoDataStore}
+import com.gu.atom.data._
 import com.gu.atom.publish._
-import com.gu.contentatom.thrift.AtomData
+import com.gu.contentatom.thrift.{Atom, AtomData}
 import com.gu.contentatom.thrift.atom.media.MediaAtom
 import util.atom.MediaAtomImplicits
 import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
+import model.commands.CommandExceptions._
 import util.AWSConfig
 
 class DataStores(aws: AWSConfig) extends MediaAtomImplicits {
@@ -50,4 +51,16 @@ trait UnpackedDataStores {
 
   val previewPublisher: PreviewAtomPublisher = stores.previewPublisher
   val livePublisher: LiveAtomPublisher = stores.livePublisher
+
+  def getPreviewAtom(atomId: String): Atom  = previewDataStore.getAtom(atomId) match {
+    case Right(atom) => atom
+    case Left(IDNotFound) => AtomNotFound
+    case Left(err) => AtomDataStoreError(err.msg)
+  }
+
+  def getPublishedAtom(atomId: String): Atom  = previewDataStore.getAtom(atomId) match {
+    case Right(atom) => atom
+    case Left(IDNotFound) => AtomNotFound
+    case Left(err) => AtomDataStoreError(err.msg)
+  }
 }

--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -9,6 +9,7 @@ object CommandExceptions extends Results {
   def UnknownFailure = throw new CommandException("Unknown internal server error", 500)
   def AtomNotFound = throw new CommandException("Atom not found", 404)
   def AtomIdConflict = throw new CommandException("Atom ID conflict", 400)
+  def AtomDataStoreError(err: String) = throw new CommandException(err, 500)
   def YouTubeConnectionIssue = throw new CommandException("Could not connect to YouTube", 500)
   def NotYoutubeAsset = throw new CommandException("Asset is not a youtube video", 400)
   def AssetVersionConflict = throw new CommandException("Asset version conflict", 400)

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -3,7 +3,6 @@ package model.commands
 import java.net.URL
 import java.util.Date
 
-import cats.data.Xor
 import com.gu.atom.play.AtomAPIActions
 import com.gu.contentatom.thrift.{Atom, ContentAtomEvent, EventType}
 import com.gu.media.logging.Logging
@@ -11,8 +10,8 @@ import com.gu.media.youtube.{YouTube, YouTubeMetadataUpdate}
 import com.gu.pandomainauth.model.{User => PandaUser}
 import data.DataStores
 import model.Platform.Youtube
-import model.commands.CommandExceptions._
 import model._
+import model.commands.CommandExceptions._
 
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
@@ -25,77 +24,71 @@ case class PublishAtomCommand(id: String, fromExpiryPoller: Boolean, override va
   def process(): T = {
     log.info(s"Request to publish atom $id")
 
-    previewDataStore.getAtom(id) match {
-      case None =>
-        log.info(s"Unable to publish atom $id. No atom has that id")
-        AtomNotFound
+    val thriftAtom = getPreviewAtom(id)
 
-      case Some(thriftAtom) => {
-        val atom = MediaAtom.fromThrift(thriftAtom)
+    val atom = MediaAtom.fromThrift(thriftAtom)
 
-        (atom.privacyStatus, !fromExpiryPoller) match {
-          case (Some(PrivacyStatus.Private), false) =>
-            log.error(s"Unable to publish atom ${atom.id}, privacy status is set to private")
-            AtomPublishFailed("Atom status set to private")
+    (atom.privacyStatus, !fromExpiryPoller) match {
+      case (Some(PrivacyStatus.Private), false) =>
+        log.error(s"Unable to publish atom ${atom.id}, privacy status is set to private")
+        AtomPublishFailed("Atom status set to private")
 
-          case _ => {
+      case _ => {
 
-            MediaAtom.getActiveYouTubeAsset(atom) match {
-              case Some(asset) => {
-                try {
-                  updateThumbnail(atom)
-                } catch {
-                  case NonFatal(e) => {
-                    log.error(s"Unable to update thumbnail for asset=${asset.id} atom={$id}", e)
-                    PosterImageUploadFailed(e.getMessage)
-                  }
-                }
+        MediaAtom.getActiveYouTubeAsset(atom) match {
+          case Some(asset) => {
+            try {
+              updateThumbnail(atom)
+            } catch {
+              case NonFatal(e) => {
+                log.error(s"Unable to update thumbnail for asset=${asset.id} atom={$id}", e)
+                PosterImageUploadFailed(e.getMessage)
               }
-              case None =>
-                log.info(s"Unable to update thumbnail for $id. There is no active YouTube asset")
             }
+          }
+          case None =>
+            log.info(s"Unable to update thumbnail for $id. There is no active YouTube asset")
+        }
 
-            atom.activeVersion match {
-              case Some(atomVersion) => {
+        atom.activeVersion match {
+          case Some(atomVersion) => {
 
-                val activeAssetId = atom.assets.find(asset => {
-                  asset.version == atomVersion
-                }).get.id
+            val activeAssetId = atom.assets.find(asset => {
+              asset.version == atomVersion
+            }).get.id
 
-                val metadata = YouTubeMetadataUpdate(
-                  title = Some(atom.title),
-                  categoryId = atom.youtubeCategoryId,
-                  description = atom.description,
-                  tags = atom.tags,
-                  license = atom.license,
-                  privacyStatus = atom.privacyStatus.map(_.name)
-                )
-
-                youTube.updateMetadata(activeAssetId, metadata)
-              }
-              case None =>
-                log.info(s"Not updating YouTube metadata for atom $id as it has no active asset")
-            }
-
-            val changeRecord = Some(ChangeRecord.now(user).asThrift)
-
-            val updatedAtom = thriftAtom.copy(
-              contentChangeDetails = thriftAtom.contentChangeDetails.copy(
-                published = changeRecord,
-                lastModified = changeRecord,
-                revision = thriftAtom.contentChangeDetails.revision + 1
-              )
+            val metadata = YouTubeMetadataUpdate(
+              title = Some(atom.title),
+              categoryId = atom.youtubeCategoryId,
+              description = atom.description,
+              tags = atom.tags,
+              license = atom.license,
+              privacyStatus = atom.privacyStatus.map(_.name)
             )
 
-            log.info(s"Publishing atom $id")
-
-            auditDataStore.auditPublish(id, user)
-            UpdateAtomCommand(id, MediaAtom.fromThrift(updatedAtom), stores, user).process()
-
-            setOldAssetsToPrivate(atom)
-            publishAtomToLive(updatedAtom)
+            youTube.updateMetadata(activeAssetId, metadata)
           }
+          case None =>
+            log.info(s"Not updating YouTube metadata for atom $id as it has no active asset")
         }
+
+        val changeRecord = Some(ChangeRecord.now(user).asThrift)
+
+        val updatedAtom = thriftAtom.copy(
+          contentChangeDetails = thriftAtom.contentChangeDetails.copy(
+            published = changeRecord,
+            lastModified = changeRecord,
+            revision = thriftAtom.contentChangeDetails.revision + 1
+          )
+        )
+
+        log.info(s"Publishing atom $id")
+
+        auditDataStore.auditPublish(id, user)
+        UpdateAtomCommand(id, MediaAtom.fromThrift(updatedAtom), stores, user).process()
+
+        setOldAssetsToPrivate(atom)
+        publishAtomToLive(updatedAtom)
       }
     }
   }
@@ -106,11 +99,11 @@ case class PublishAtomCommand(id: String, fromExpiryPoller: Boolean, override va
     livePublisher.publishAtomEvent(event) match {
       case Success(_) =>
         publishedDataStore.updateAtom(atom) match {
-          case Xor.Right(_) => {
+          case Right(_) => {
             log.info(s"Successfully published atom: ${id}")
             MediaAtom.fromThrift(atom)
           }
-          case Xor.Left(err) =>
+          case Left(err) =>
             log.error("Unable to update datastore after publish", err)
             AtomPublishFailed(s"Could not update published datastore after publish: ${err.toString}")
         }

--- a/app/model/commands/SetPlutoIdCommand.scala
+++ b/app/model/commands/SetPlutoIdCommand.scala
@@ -4,7 +4,6 @@ import com.gu.media.logging.Logging
 import com.gu.pandomainauth.model.{User => PandaUser}
 import data.DataStores
 import model.MediaAtom
-import model.commands.CommandExceptions.AtomNotFound
 import util.atom.MediaAtomImplicits
 
 class SetPlutoIdCommand(atomId: String, plutoId: String, override val stores: DataStores, user: PandaUser)
@@ -16,17 +15,12 @@ class SetPlutoIdCommand(atomId: String, plutoId: String, override val stores: Da
   override def process(): MediaAtom = {
     log.info(s"Request received to set pluto id $plutoId for atom $atomId")
 
-    previewDataStore.getAtom(atomId) match {
-      case Some(before) =>
-        val after = before.updateData { data =>
-          data.copy(plutoProjectId = Some(plutoId))
-        }
+    val before = getPreviewAtom(atomId)
 
-        UpdateAtomCommand(atomId, MediaAtom.fromThrift(after), stores, user).process()
-
-      case None =>
-        log.info(s"Cannot set pluto id $plutoId for atom $atomId. No atom has that id")
-        AtomNotFound
+    val after = before.updateData { data =>
+      data.copy(plutoProjectId = Some(plutoId))
     }
+
+    UpdateAtomCommand(atomId, MediaAtom.fromThrift(after), stores, user).process()
   }
 }

--- a/app/model/commands/UpdateAtomCommand.scala
+++ b/app/model/commands/UpdateAtomCommand.scala
@@ -26,14 +26,7 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom, override val stores: D
       AtomIdConflict
     }
 
-    val oldAtom = previewDataStore.getAtom(atom.id)
-
-    if (oldAtom.isEmpty) {
-      log.info(s"Unable to update atom ${atom.id}. Atom does not exist")
-      AtomNotFound
-    }
-
-    val existingAtom = oldAtom.get
+    val existingAtom = getPreviewAtom(atom.id)
 
     val diffString = auditDataStore.createDiffString(MediaAtom.fromThrift(existingAtom), atom)
     log.info(s"Update atom changes ${atom.id}: $diffString")

--- a/app/util/ExpiryPoller.scala
+++ b/app/util/ExpiryPoller.scala
@@ -38,7 +38,7 @@ case class ExpiryPoller(override val stores: DataStores, youTube: YouTube, awsCo
               val atomId = expiredAtom.id
 
               publishedDataStore.getAtom(atomId) match {
-                case Right(atom) =>
+                case Right(_) =>
                   PublishAtomCommand(atomId, fromExpiryPoller = true, stores, youTube, user).process()
 
                 case _ =>
@@ -48,6 +48,9 @@ case class ExpiryPoller(override val stores: DataStores, youTube: YouTube, awsCo
             case _ =>
           }
         })
+
+      case Left(err) =>
+        log.error(s"Unable to list atoms for expiry: ${err.msg}")
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,19 +6,20 @@ object Dependencies {
   val awsVersion = "1.11.48"
   val pandaVersion = "0.4.0"
   val mockitoVersion = "2.0.97-beta"
-  val atomMakerVersion = "0.1.7"
+  val atomMakerVersion = "0.2.0"
   val slf4jVersion = "1.7.21"
   val typesafeConfigVersion = "1.3.0" // to match what we get from Play transitively
+  val scanamoVersion = "0.9.1" // to match what we get from atom-publisher-lib transitively
 
   val thrift = "org.apache.thrift" % "libthrift" % "0.9.3"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0"
-  val cats = "org.typelevel" %% "cats-core" % "0.7.0" // for interacting with scanamo
   val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.0"
   val playJsonExtensions = "org.cvogt" %% "play-json-extensions" % "0.8.0"
   val okHttp = "com.squareup.okhttp" % "okhttp" % "2.4.0"
   val diff = "ai.x" %% "diff" % "1.2.0"
   val typesafeConfig = "com.typesafe" % "config" % "1.3.1"
 
+  val scanamo = "com.gu" %% "scanamo" % scanamoVersion
   val contentAtomModel = "com.gu" %% "content-atom-model" %  "2.4.17"
 
   val scalaTestPlusPlay = "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.0" % "test"
@@ -43,16 +44,6 @@ object Dependencies {
     PlayImport.ws
   )
 
-  val scanamo = Seq(
-    "com.gu" %% "scanamo" % "0.7.0",
-    "com.gu" %% "scanamo-scrooge" % "0.1.3"
-  )
-
-  val scrooge = Seq(
-    "com.twitter" %% "scrooge-core" % scroogeVersion,
-    "com.twitter" %% "scrooge-serializer" % scroogeVersion
-  )
-
   val atomMaker = Seq(
     "com.gu" %% "atom-publisher-lib" % atomMakerVersion,
     "com.gu" %% "atom-publisher-lib" % atomMakerVersion % "test" classifier "tests",
@@ -71,11 +62,12 @@ object Dependencies {
   )
 
   val commonDependencies = googleApi ++ Seq(
-    typesafeConfig, awsLambdaCore, awsS3, awsDynamo, playJsonExtensions, logstashLogbackEncoder, kinesisLogbackAppender, awsTranscoder
+    typesafeConfig, awsLambdaCore, awsS3, awsDynamo, playJsonExtensions, logstashLogbackEncoder, kinesisLogbackAppender,
+    awsTranscoder, scanamo
   )
 
-  val appDependencies = panda ++ scanamo ++ scrooge ++ atomMaker ++ slf4j ++ Seq(
-    PlayImport.cache, thrift, scalaLogging, cats, jacksonDatabind, okHttp, contentAtomModel, diff,
+  val appDependencies = panda ++ atomMaker ++ slf4j ++ Seq(
+    PlayImport.cache, thrift, scalaLogging, jacksonDatabind, okHttp, contentAtomModel, diff,
     awsSts, awsEc2, scalaTestPlusPlay, mockito, scalaXml, awsTranscoder
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,6 @@ object Dependencies {
   val typesafeConfigVersion = "1.3.0" // to match what we get from Play transitively
   val scanamoVersion = "0.9.1" // to match what we get from atom-publisher-lib transitively
 
-  val thrift = "org.apache.thrift" % "libthrift" % "0.9.3"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0"
   val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.0"
   val playJsonExtensions = "org.cvogt" %% "play-json-extensions" % "0.8.0"
@@ -67,7 +66,7 @@ object Dependencies {
   )
 
   val appDependencies = panda ++ atomMaker ++ slf4j ++ Seq(
-    PlayImport.cache, thrift, scalaLogging, jacksonDatabind, okHttp, contentAtomModel, diff,
+    PlayImport.cache, scalaLogging, jacksonDatabind, okHttp, contentAtomModel, diff,
     awsSts, awsEc2, scalaTestPlusPlay, mockito, scalaXml, awsTranscoder
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val awsVersion = "1.11.48"
   val pandaVersion = "0.4.0"
   val mockitoVersion = "2.0.97-beta"
-  val atomMakerVersion = "0.2.0"
+  val atomMakerVersion = "0.2.1"
   val slf4jVersion = "1.7.21"
   val typesafeConfigVersion = "1.3.0" // to match what we get from Play transitively
   val scanamoVersion = "0.9.1" // to match what we get from atom-publisher-lib transitively

--- a/test/ThriftUtilSpec.scala
+++ b/test/ThriftUtilSpec.scala
@@ -53,9 +53,9 @@ class ThriftUtilSpec extends FunSpec
       inside(parseRequest(makeParams("uri" -> youtubeUrl))) {
         case Right(atom) =>
           inside(atom) {
-            case Atom(_, AtomType.Media, Nil, defaultHtml, _, changeDetails, None) =>
+            case Atom(_, AtomType.Media, Nil, defaultHtml, _, changeDetails, None, _) =>
               changeDetails should matchPattern {
-                case ContentChangeDetails(None, None, None, 1L) =>
+                case ContentChangeDetails(None, None, None, 1L, None) =>
               }
               XML.loadString(defaultHtml) should matchPattern {
                 case <iframe>{_}</iframe> =>


### PR DESCRIPTION
Upgrade to use the latest `atom-publisher-lib`. This is so we can also use the latest `scanamo` which supports consistent reads/writes.

Sorry for the diff spam. The actual code in each action should not have changed, only the access to the datastores. The exception is `AddAssetCommand`, where I have refactored the main body of the code into a method.

- ~~When updating the `Api` controller, I have swallowed all errors as `AtomNotFound`. Is there a better way?~~
- I've added helper methods to avoid repeating `this atom does not exist` code in controllers and commands