### PR TITLE
Fix name of lambda function in riff-raff

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -14,7 +14,7 @@ deployments:
       fileName: media-atom-uploader.zip
       functions:
         CODE:
-          name: media-atom-maker-CODE-UploaderLambda-88U8JB1YYG4J
+          name: media-atom-maker-CODE-UploaderLambda-QFNJ4Y06QLZ
           filename: media-atom-uploader.zip
         PROD:
           name: media-atom-maker-PROD-UploaderLambda-MXQD3DV3H1VL


### PR DESCRIPTION
Quick fix to the failing deploys on CODE due to the old CloudFormation name for the uploader lambda being hard-coded in riff-raff.yaml.

NB: a full fix for this is in #298, which sets the names directly.