### PR TITLE
Fix initial publishing

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -46,13 +46,25 @@ class Api2 (override val stores: DataStores, conf: Configuration, val authAction
   }
 
   def getMediaAtom(id: String) = APIHMACAuthAction {
-    val atom = getPreviewAtom(id)
-    Ok(Json.toJson(MediaAtom.fromThrift(atom)))
+    try {
+      val atom = getPreviewAtom(id)
+      Ok(Json.toJson(MediaAtom.fromThrift(atom)))
+    } catch {
+      commandExceptionAsResult
+    }
   }
 
   def getPublishedMediaAtom(id: String) = APIHMACAuthAction {
-    val atom = getPublishedAtom(id)
-    Ok(Json.toJson(MediaAtom.fromThrift(atom)))
+    try {
+      val atom = getPublishedAtom(id)
+      Ok(Json.toJson(MediaAtom.fromThrift(atom)))
+    } catch {
+      case CommandException(_, 404) =>
+        Ok(Json.obj())
+
+      case err: CommandException =>
+        commandExceptionAsResult(err)
+    }
   }
 
   def publishMediaAtom(id: String) = APIHMACAuthAction { implicit req =>

--- a/app/data/DataStores.scala
+++ b/app/data/DataStores.scala
@@ -44,7 +44,7 @@ class DataStores(aws: AWSConfig) extends MediaAtomImplicits {
   }
 
   private def getPublished[T: ClassTag: DynamoFormat](dynamoFormats: AtomDynamoFormats[T]): PublishedDynamoDataStore[T] = {
-    new PublishedDynamoDataStore[T](aws.dynamoDB, aws.dynamoTableName) {
+    new PublishedDynamoDataStore[T](aws.dynamoDB, aws.publishedDynamoTableName) {
       def fromAtomData = dynamoFormats.fromAtomData
       def toAtomData(data: T) = dynamoFormats.toAtomData(data)
     }
@@ -68,7 +68,7 @@ trait UnpackedDataStores {
     case Left(err) => AtomDataStoreError(err.msg)
   }
 
-  def getPublishedAtom(atomId: String): Atom  = previewDataStore.getAtom(atomId) match {
+  def getPublishedAtom(atomId: String): Atom  = publishedDataStore.getAtom(atomId) match {
     case Right(atom) => atom
     case Left(IDNotFound) => AtomNotFound
     case Left(err) => AtomDataStoreError(err.msg)


### PR DESCRIPTION
**Headline**: PR #282 broke the 'publish' button in the UI

This lead to atoms appearing as published in the UI, enabling the 'Create Video Page' button. This in turn created pages that referenced atoms that were only in CAPI preview, because the atom had not been published.

This PR fixes the references to the published table (I'd pointed both preview and published end-points at the preview data-store 😱) and also brings back the previous behaviour of returning an empty object if the atom is not in the published store.