### PR TITLE
Frontpage grid updates

### DIFF
--- a/public/video-ui/src/components/Videos/VideoItem.js
+++ b/public/video-ui/src/components/Videos/VideoItem.js
@@ -14,7 +14,7 @@ export default class VideoItem extends React.Component {
       const assets = this.props.video.assets.filter((asset) => asset.version === activeVersion);
 
       if(assets.length && assets[0] && assets[0].platform) {
-        return ;
+        return;
       } else {
         return <span className="publish__label label__frontpage__novideo label__frontpage__overlay">No Video</span>;
       }
@@ -39,6 +39,8 @@ export default class VideoItem extends React.Component {
             <div className="grid__info">
               <div className="grid__image">
                 {this.renderItemImage()}
+              </div>
+              <div className="grid__status__overlay">
                 {this.renderActiveAssetName()}
               </div>
               <div className="grid__item__footer">

--- a/public/video-ui/src/components/Videos/VideoItem.js
+++ b/public/video-ui/src/components/Videos/VideoItem.js
@@ -14,9 +14,9 @@ export default class VideoItem extends React.Component {
       const assets = this.props.video.assets.filter((asset) => asset.version === activeVersion);
 
       if(assets.length && assets[0] && assets[0].platform) {
-        return <span className="success">Active {assets[0].platform} video</span>;
+        return <span className="publish__label label__live label__overlay">Live</span>;
       } else {
-        return <span className="error">No Active Assets</span>;
+        return <span className="publish__label label__draft label__overlay">Draft</span>;
       }
     }
   }
@@ -39,10 +39,10 @@ export default class VideoItem extends React.Component {
             <div className="grid__info">
               <div className="grid__image">
                 {this.renderItemImage()}
+                {this.renderActiveAssetName()}
               </div>
               <div className="grid__item__footer">
                 <span className="grid__item__title">{this.props.video.title}</span>
-                {this.renderActiveAssetName()}
               </div>
             </div>
           </Link>

--- a/public/video-ui/src/components/Videos/VideoItem.js
+++ b/public/video-ui/src/components/Videos/VideoItem.js
@@ -14,9 +14,9 @@ export default class VideoItem extends React.Component {
       const assets = this.props.video.assets.filter((asset) => asset.version === activeVersion);
 
       if(assets.length && assets[0] && assets[0].platform) {
-        return <span className="publish__label label__live label__overlay">Live</span>;
+        return <span className="publish__label label__live label__frontpage__overlay">Live</span>;
       } else {
-        return <span className="publish__label label__draft label__overlay">No Video</span>;
+        return <span className="publish__label label__alert label__frontpage__overlay">No Video</span>;
       }
     }
   }

--- a/public/video-ui/src/components/Videos/VideoItem.js
+++ b/public/video-ui/src/components/Videos/VideoItem.js
@@ -14,9 +14,9 @@ export default class VideoItem extends React.Component {
       const assets = this.props.video.assets.filter((asset) => asset.version === activeVersion);
 
       if(assets.length && assets[0] && assets[0].platform) {
-        return <span className="publish__label label__live label__frontpage__overlay">Live</span>;
+        return 
       } else {
-        return <span className="publish__label label__alert label__frontpage__overlay">No Video</span>;
+        return <span className="publish__label label__frontpage__novideo label__frontpage__overlay">No Video</span>;
       }
     }
   }

--- a/public/video-ui/src/components/Videos/VideoItem.js
+++ b/public/video-ui/src/components/Videos/VideoItem.js
@@ -16,7 +16,7 @@ export default class VideoItem extends React.Component {
       if(assets.length && assets[0] && assets[0].platform) {
         return <span className="publish__label label__live label__overlay">Live</span>;
       } else {
-        return <span className="publish__label label__draft label__overlay">Draft</span>;
+        return <span className="publish__label label__draft label__overlay">No Video</span>;
       }
     }
   }

--- a/public/video-ui/src/components/Videos/VideoItem.js
+++ b/public/video-ui/src/components/Videos/VideoItem.js
@@ -14,7 +14,7 @@ export default class VideoItem extends React.Component {
       const assets = this.props.video.assets.filter((asset) => asset.version === activeVersion);
 
       if(assets.length && assets[0] && assets[0].platform) {
-        return;
+        return <span className="publish__label label__live label__frontpage__overlay">Active</span>;
       } else {
         return <span className="publish__label label__frontpage__novideo label__frontpage__overlay">No Video</span>;
       }

--- a/public/video-ui/src/components/Videos/VideoItem.js
+++ b/public/video-ui/src/components/Videos/VideoItem.js
@@ -14,7 +14,7 @@ export default class VideoItem extends React.Component {
       const assets = this.props.video.assets.filter((asset) => asset.version === activeVersion);
 
       if(assets.length && assets[0] && assets[0].platform) {
-        return 
+        return ;
       } else {
         return <span className="publish__label label__frontpage__novideo label__frontpage__overlay">No Video</span>;
       }

--- a/public/video-ui/styles/components/_header.scss
+++ b/public/video-ui/styles/components/_header.scss
@@ -25,7 +25,7 @@
   color: $cWhite;
 }
 
-.label__alert {
+.label__frontpage__novideo {
   color: $color300Grey;
   background-color: rgba(51,51,51,0.9);
 }

--- a/public/video-ui/styles/components/_header.scss
+++ b/public/video-ui/styles/components/_header.scss
@@ -29,4 +29,5 @@
   position: absolute;
   left: 5px;
   bottom: 55px;
+  width: 80px;
 }

--- a/public/video-ui/styles/components/_header.scss
+++ b/public/video-ui/styles/components/_header.scss
@@ -31,8 +31,5 @@
 }
 
 .label__frontpage__overlay {
-  position: absolute;
-  left: 5px;
-  bottom: 65px;
   width: 70px;
 }

--- a/public/video-ui/styles/components/_header.scss
+++ b/public/video-ui/styles/components/_header.scss
@@ -24,3 +24,9 @@
   background-color: $cRedE3;
   color: $cWhite;
 }
+
+.label__overlay {
+  position: absolute;
+  left: 5px;
+  bottom: 55px;
+}

--- a/public/video-ui/styles/components/_header.scss
+++ b/public/video-ui/styles/components/_header.scss
@@ -25,9 +25,14 @@
   color: $cWhite;
 }
 
-.label__overlay {
+.label__alert {
+  color: $color300Grey;
+  background-color: rgba(51,51,51,0.9);
+}
+
+.label__frontpage__overlay {
   position: absolute;
   left: 5px;
-  bottom: 55px;
-  width: 80px;
+  bottom: 65px;
+  width: 70px;
 }

--- a/public/video-ui/styles/layout/_grid.scss
+++ b/public/video-ui/styles/layout/_grid.scss
@@ -22,12 +22,12 @@
   position: relative;
   border-top: 1px solid $brandColor;
 
-  width: 250px;
-  height: auto;
+  width: 300px;
+  height: 220px;
 
   margin: 8px;
 
-  white-space: nowrap;
+  white-space: wrap;
   overflow: hidden;
 }
 
@@ -58,9 +58,11 @@
 
 .grid__image__placeholder {
   width: 100%;
-  height: 200px;
+  height: 180px;
   display: block;
-  padding-top: 40px;
+  text-align: center;
+  padding-top: 60px;
+  background-color: $color800Grey;
 
 }
 
@@ -69,15 +71,19 @@
   bottom: 0;
   left: 0;
   width: 100%;
-  background-color: $color800Grey;
+  background-color: $color700Grey;
   height: 50px;
 }
 
 .grid__item__title {
   font-family: "Guardian Agate Sans";
-  display: block;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 14px;
-  padding-top: 10px;
+  font-size: 15px;
+  line-height: 17px;
+  padding: 5px 10px;
+  height: 40px;
 }

--- a/public/video-ui/styles/layout/_grid.scss
+++ b/public/video-ui/styles/layout/_grid.scss
@@ -20,12 +20,12 @@
   display: inline-block;
 
   position: relative;
-  border: 3px solid $color625Grey;
+  border-top: 1px solid $brandColor;
 
-  width: 300px;
-  height: 230px;
+  width: 250px;
+  height: auto;
 
-  margin: 5px;
+  margin: 8px;
 
   white-space: nowrap;
   overflow: hidden;
@@ -60,46 +60,24 @@
   width: 100%;
   height: 200px;
   display: block;
-
-  text-decoration: none;
-
-  color: #666;
-
-  font-size: 40px;
-
-  text-align: center;
   padding-top: 40px;
 
 }
 
 .grid__item__footer {
-
   position: absolute;
   bottom: 0;
   left: 0;
-
   width: 100%;
-  background-color: #222;
-  height: 70px;
-  padding: 5px 10px;
-
-  &:before {
-    content: " ";
-    position: absolute;
-    top: -6px;
-    left: 0;
-
-    height: 6px;
-    width: 100%;
-
-    background: linear-gradient(0deg, #111, transparent);
-  }
+  background-color: $color800Grey;
+  height: 50px;
 }
 
 .grid__item__title {
+  font-family: "Guardian Agate Sans";
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 17px;
+  font-size: 14px;
   padding-top: 10px;
 }

--- a/public/video-ui/styles/layout/_grid.scss
+++ b/public/video-ui/styles/layout/_grid.scss
@@ -81,7 +81,14 @@
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   font-size: 15px;
-  line-height: 18px;
-  padding: 5px 10px;
+  line-height: 19px;
+  padding: 8px 10px;
+  height: 50px;
   overflow: hidden;
+}
+
+.grid__status__overlay {
+  position: absolute;
+  left: 5px;
+  bottom: 70px;
 }

--- a/public/video-ui/styles/layout/_grid.scss
+++ b/public/video-ui/styles/layout/_grid.scss
@@ -72,7 +72,7 @@
   left: 0;
   width: 100%;
   background-color: $color700Grey;
-  height: 50px;
+  height: 60px;
 }
 
 .grid__item__title {
@@ -80,10 +80,8 @@
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-overflow: ellipsis;
   font-size: 15px;
-  line-height: 17px;
+  line-height: 18px;
   padding: 5px 10px;
-  height: 40px;
+  overflow: hidden;
 }

--- a/public/video-ui/styles/layout/_topbar.scss
+++ b/public/video-ui/styles/layout/_topbar.scss
@@ -6,7 +6,7 @@ $topbarHeight: 50px;
 }
 
 .topbar__search {
-  border: 1px solid #999;
+  border-bottom: 1px solid #999;
   box-sizing: border-box;
   min-width: 250px;
   input {


### PR DESCRIPTION
Small design tweaks to the frontpage, preparing for shortcut links (edit and select video).

Once an atom has a video added to it's asset list, the 'no video' lozenge is removed. There might be cases to add different lozenges in (unpublished changes, but for now it's cleaner to show nothing if everything is green with the atom in question.

![image](https://cloud.githubusercontent.com/assets/2067172/23471732/3c7317aa-fea2-11e6-9a1f-0529fb6a35bb.png)


![image](https://cloud.githubusercontent.com/assets/2067172/23471711/28132142-fea2-11e6-89c6-ac84c1d2da3b.png)
