### PR TITLE
Fix name of lambda function in riff-raff conf

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -14,7 +14,7 @@ deployments:
       fileName: media-atom-uploader.zip
       functions:
         CODE:
-          name: media-atom-maker-CODE-UploaderLambda-QFNJ4Y06QLZ
+          name: media-atom-maker-CODE-UploaderLambda-2YYI5KOIPSK9
           filename: media-atom-uploader.zip
         PROD:
           name: media-atom-maker-PROD-UploaderLambda-MXQD3DV3H1VL


### PR DESCRIPTION
Quick fix to the failing deploys on CODE due to the old CloudFormation name for the uploader 
lambda being hard-coded in riff-raff.yaml... again (See #299)

NB: a full fix for this is in #298, which sets the names directly.