### PR TITLE
Add upload table to start script

### DIFF
--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -641,6 +641,7 @@
                                 "aws.dynamo.tableName=", { "Ref": "AtomMakerTable" }, "\n",
                                 "aws.dynamo.publishedTableName=", { "Ref": "PublishedAtomMakerTable" }, "\n",
                                 "aws.dynamo.auditTableName=", { "Ref": "AuditTable" }, "\n",
+                                "aws.dynamo.uploadTrackingTableName=", { "Ref": "UploadTrackingTable" }, "\n",
                                 "EOF\n",
 
                                 "mkdir /etc/gu\n",


### PR DESCRIPTION
The upload table was missing from the start script - which would cause deploys to fail due to it being a mandatory setting.