### PR TITLE
Fix typo in cloudformation

### DIFF
--- a/cloudformation/media-atoms-dynamo-prod.json
+++ b/cloudformation/media-atoms-dynamo-prod.json
@@ -161,7 +161,7 @@
     "Outputs": {
       "UploadTrackingTableStream": {
         "Value": {
-          "Fn::GetAtt": ["UploadTrackingMediaAtomMakerCode", "StreamArn"]
+          "Fn::GetAtt": ["UploadTrackingMediaAtomMakerProd", "StreamArn"]
         }
       }
     }


### PR DESCRIPTION
The PROD cloudformation was incorrectly using the name of the resource from CODE.

I fixed manually and applied the fixed template to get #298 out of the door. This is a follow up PR to get the fix into master.