### PR TITLE
Add expirer to riff-raff.yaml

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -140,7 +140,7 @@ case class PublishAtomCommand(id: String, fromExpiryPoller: Boolean, override va
 
     MediaAtom.getActiveYouTubeAsset(atom).foreach { activeAsset =>
       val youTubeAssets = atom.assets.filter(_.platform == Youtube)
-      val toMakePrivate = if(expired) { youTubeAssets } else { youTubeAssets.filter(_.id == activeAsset.id) }
+      val toMakePrivate = if(expired) { youTubeAssets } else { youTubeAssets.filterNot(_.id == activeAsset.id) }
 
       toMakePrivate.foreach { asset =>
         log.info(s"Marking asset=${asset.id} atom=${atom.id} as private")

--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -28,6 +28,13 @@ deployments:
       functionNames: [media-atom-maker-transcoder-]
       fileName: media-atom-transcoder.zip
       prefixStack: false
+  media-atom-expirer:
+    type: aws-lambda
+    parameters:
+      bucket: atom-maker-dist
+      functionNames: [media-atom-maker-expirer-]
+      fileName: media-atom-expirer.zip
+      prefixStack: false
   media-atom-maker-ami-update:
       type: ami-cloudformation-parameter
       app: media-atom-maker


### PR DESCRIPTION
Follow up to #300 because I forgot to add the new lambda to the riff raff deploy.

Deploys still work at the moment, they just wont update the expirer lambda probably.

Also fixes a bug that would have made the active video private, rather than the inactive ones