### PR TITLE
Add function name to expirer lambda

### DIFF
--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -590,6 +590,7 @@
           "Type": "AWS::Lambda::Function",
           "Properties": {
             "Description": "Expires atoms",
+            "FunctionName":  {"Fn::Join": ["-", ["media-atom-maker-expirer", {"Ref": "Stage"} ] ] },
             "Handler": "com.gu.media.expirer.ExpirerLambda::handleRequest",
             "Code": {
               "S3Bucket": { "Ref": "BuildBucket" },


### PR DESCRIPTION
The function name needs to be hard-coded (albeit with stage as a parameter) in order for riff-raff to deploy it.