### PR TITLE
Upload video parts to YouTube

### DIFF
--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -91,7 +91,7 @@ class UploadController(val authActions: HMACAuthActions, awsConfig: AWSConfig, o
     val youTube = YouTubeMetadata(
       title = atom.title,
       channel = channelId,
-      multipartUpload = None
+      upload = None
     )
 
     Upload(id, parts, metadata, youTube)

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -33,10 +33,16 @@ class UploadController(val authActions: HMACAuthActions, awsConfig: AWSConfig, o
       log.info(s"Request for upload under atom ${req.atomId}. filename=${req.filename}. size=${req.size}")
 
       val atom = MediaAtom.fromThrift(getPreviewAtom(req.atomId))
-      val upload = buildUpload(atom, raw.user, req.size)
+      atom.channelId match {
+        case Some(channel) =>
+          val upload = buildUpload(atom, channel, raw.user, req.size)
 
-      table.put(upload)
-      Ok(Json.toJson(upload))
+          table.put(upload)
+          Ok(Json.toJson(upload))
+
+        case None =>
+          BadRequest("Atom missing YouTube channel")
+      }
     }
   }
 
@@ -70,17 +76,25 @@ class UploadController(val authActions: HMACAuthActions, awsConfig: AWSConfig, o
     }
   }
 
-  private def buildUpload(atom: MediaAtom, user: User, size: Long) = {
+  private def buildUpload(atom: MediaAtom, channelId: String, user: User, size: Long) = {
     val id = UUID.randomUUID().toString
 
-    Upload(
-      id = id,
+    val parts = chunk(id, size)
+
+    val metadata = UploadMetadata(
       atomId = atom.id,
       user = user.email,
       bucket = awsConfig.userUploadBucket,
-      region = awsConfig.region.getName,
-      parts = chunk(id, size)
+      region = awsConfig.region.getName
     )
+
+    val youTube = YouTubeMetadata(
+      title = atom.title,
+      channel = channelId,
+      multipartUpload = None
+    )
+
+    Upload(id, parts, metadata, youTube)
   }
 }
 

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -85,11 +85,12 @@ class UploadController(val authActions: HMACAuthActions, awsConfig: AWSConfig, o
       atomId = atom.id,
       user = user.email,
       bucket = awsConfig.userUploadBucket,
-      region = awsConfig.region.getName
+      region = awsConfig.region.getName,
+      title = atom.title,
+      plutoProjectId = atom.plutoProjectId
     )
 
     val youTube = YouTubeMetadata(
-      title = atom.title,
       channel = channelId,
       upload = None
     )

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -52,7 +52,7 @@ class UploadController(val authActions: HMACAuthActions, awsConfig: AWSConfig, o
   }
 
   def credentials(id: String) = APIHMACAuthAction { implicit req =>
-    (table.get(id), req.headers.get(UPLOAD_KEY_HEADER)) match {
+    (table.consistentlyGet(id), req.headers.get(UPLOAD_KEY_HEADER)) match {
       case (Some(upload), Some(key)) =>
         val validKey = upload.parts.exists(_.key == key)
 

--- a/cloudformation/media-atom-maker-dev.yml
+++ b/cloudformation/media-atom-maker-dev.yml
@@ -266,6 +266,7 @@ Resources:
           STAGE: !Ref Stage
           CONFIG_BUCKET: !Ref ConfigBucket
           CONFIG_KEY: !FindInMap [LambdaConfig, Uploader, DEV]
+          DOMAIN: !Join [ "", [ "https://", { "Ref": "Domain"} ]]
       MemorySize: 256
       Role: !GetAtt UploaderRole.Arn
       Runtime: "java8"

--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -486,7 +486,8 @@
                 "APP": "media-atom-uploader",
                 "STAGE": { "Ref": "Stage" },
                 "CONFIG_BUCKET": { "Ref": "ConfigBucket" },
-                "CONFIG_KEY": { "Fn::FindInMap": [ "LambdaConfig", "Uploader", { "Ref": "Stage" }] }
+                "CONFIG_KEY": { "Fn::FindInMap": [ "LambdaConfig", "Uploader", { "Ref": "Stage" }] },
+                "DOMAIN": { "Fn::Join": ["", [ "https://", { "Ref": "DomainToMonitor" } ]] }
               }
             },
             "MemorySize": 256,

--- a/common/src/main/scala/com/gu/media/upload/Upload.scala
+++ b/common/src/main/scala/com/gu/media/upload/Upload.scala
@@ -4,10 +4,10 @@ import org.cvogt.play.json.Jsonx
 import play.api.libs.json.Format
 
 case class Upload(id: String, parts: List[UploadPart], metadata: UploadMetadata, youTube: YouTubeMetadata) {
-  def withPart(partIx: Int, fn: UploadPart => UploadPart): Upload = {
-    copy(parts = parts.zipWithIndex.map {
-      case (part, ix) if ix == partIx => fn(part)
-      case (part, _) => part
+  def withPart(key: String)(fn: UploadPart => UploadPart): Upload = {
+    copy(parts = parts.map {
+      case part if part.key == key => fn(part)
+      case part => part
     })
   }
 }

--- a/common/src/main/scala/com/gu/media/upload/Upload.scala
+++ b/common/src/main/scala/com/gu/media/upload/Upload.scala
@@ -3,7 +3,7 @@ package com.gu.media.upload
 import org.cvogt.play.json.Jsonx
 import play.api.libs.json.Format
 
-case class Upload(id: String, atomId: String, user: String, bucket: String, region: String, parts: List[UploadPart]) {
+case class Upload(id: String, parts: List[UploadPart], metadata: UploadMetadata, youTube: YouTubeMetadata) {
   def withPart(partIx: Int, fn: UploadPart => UploadPart): Upload = {
     copy(parts = parts.zipWithIndex.map {
       case (part, ix) if ix == partIx => fn(part)

--- a/common/src/main/scala/com/gu/media/upload/UploadMetadata.scala
+++ b/common/src/main/scala/com/gu/media/upload/UploadMetadata.scala
@@ -1,0 +1,10 @@
+package com.gu.media.upload
+
+import org.cvogt.play.json.Jsonx
+import play.api.libs.json.Format
+
+case class UploadMetadata(atomId: String, user: String, bucket: String, region: String)
+
+object UploadMetadata {
+  implicit val format: Format[UploadMetadata] = Jsonx.formatCaseClass[UploadMetadata]
+}

--- a/common/src/main/scala/com/gu/media/upload/UploadMetadata.scala
+++ b/common/src/main/scala/com/gu/media/upload/UploadMetadata.scala
@@ -3,7 +3,8 @@ package com.gu.media.upload
 import org.cvogt.play.json.Jsonx
 import play.api.libs.json.Format
 
-case class UploadMetadata(atomId: String, user: String, bucket: String, region: String)
+case class UploadMetadata(atomId: String, user: String, bucket: String, region: String, title: String,
+                          plutoProjectId: Option[String])
 
 object UploadMetadata {
   implicit val format: Format[UploadMetadata] = Jsonx.formatCaseClass[UploadMetadata]

--- a/common/src/main/scala/com/gu/media/upload/UploadPart.scala
+++ b/common/src/main/scala/com/gu/media/upload/UploadPart.scala
@@ -3,7 +3,7 @@ package com.gu.media.upload
 import org.cvogt.play.json.Jsonx
 import play.api.libs.json.Format
 
-case class UploadPart(key: String, start: Long, end: Long, uploadedToS3: Boolean = false, uploadedToYouTube: Long = 0)
+case class UploadPart(key: String, start: Long, end: Long, uploadedToS3: Boolean = false)
 
 object UploadPart {
   implicit val format: Format[UploadPart] = Jsonx.formatCaseClass[UploadPart]

--- a/common/src/main/scala/com/gu/media/upload/UploadsTable.scala
+++ b/common/src/main/scala/com/gu/media/upload/UploadsTable.scala
@@ -7,7 +7,6 @@ import com.gu.scanamo.{Scanamo, Table}
 trait UploadsTable {
   def list(atomId: String): List[Upload]
   def put(upload: Upload): Unit
-  def get(id: String): Option[Upload]
   def consistentlyGet(id: String): Option[Upload]
   def delete(id: String): Unit
 }
@@ -30,16 +29,6 @@ class DynamoUploadsTable(aws: DynamoAccess) extends UploadsTable {
   override def put(upload: Upload): Unit = {
     val operation = table.put(upload)
     Scanamo.exec(aws.dynamoDB)(operation)
-  }
-
-  override def get(id: String): Option[Upload] = {
-    val operation = table.get('id -> id)
-    val result = Scanamo.exec(aws.dynamoDB)(operation)
-
-    result.map {
-      case Right(upload) => upload
-      case Left(err) => throw DynamoUploadsTableException(err.toString)
-    }
   }
 
   override def consistentlyGet(id: String): Option[Upload] = {

--- a/common/src/main/scala/com/gu/media/upload/UploadsTable.scala
+++ b/common/src/main/scala/com/gu/media/upload/UploadsTable.scala
@@ -24,7 +24,7 @@ class DynamoUploadsTable(aws: DynamoAccess) extends UploadsTable {
       throw DynamoUploadsTableException(errors.mkString(","))
     }
 
-    allResults.collect { case Right(upload) if upload.atomId == atomId => upload }
+    allResults.collect { case Right(upload) if upload.metadata.atomId == atomId => upload }
   }
 
   override def put(upload: Upload): Unit = {

--- a/common/src/main/scala/com/gu/media/upload/YouTubeMetadata.scala
+++ b/common/src/main/scala/com/gu/media/upload/YouTubeMetadata.scala
@@ -1,0 +1,10 @@
+package com.gu.media.upload
+
+import org.cvogt.play.json.Jsonx
+import play.api.libs.json.Format
+
+case class YouTubeMetadata(title: String, channel: String, multipartUpload: Option[String])
+
+object YouTubeMetadata {
+  implicit val format: Format[YouTubeMetadata] = Jsonx.formatCaseClass[YouTubeMetadata]
+}

--- a/common/src/main/scala/com/gu/media/upload/YouTubeMetadata.scala
+++ b/common/src/main/scala/com/gu/media/upload/YouTubeMetadata.scala
@@ -3,7 +3,7 @@ package com.gu.media.upload
 import org.cvogt.play.json.Jsonx
 import play.api.libs.json.Format
 
-case class YouTubeMetadata(title: String, channel: String, multipartUpload: Option[String])
+case class YouTubeMetadata(title: String, channel: String, upload: Option[String])
 
 object YouTubeMetadata {
   implicit val format: Format[YouTubeMetadata] = Jsonx.formatCaseClass[YouTubeMetadata]

--- a/common/src/main/scala/com/gu/media/upload/YouTubeMetadata.scala
+++ b/common/src/main/scala/com/gu/media/upload/YouTubeMetadata.scala
@@ -3,7 +3,7 @@ package com.gu.media.upload
 import org.cvogt.play.json.Jsonx
 import play.api.libs.json.Format
 
-case class YouTubeMetadata(title: String, channel: String, upload: Option[String])
+case class YouTubeMetadata(channel: String, upload: Option[String])
 
 object YouTubeMetadata {
   implicit val format: Format[YouTubeMetadata] = Jsonx.formatCaseClass[YouTubeMetadata]

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
@@ -58,4 +58,9 @@ trait YouTubeAccess extends Settings {
       case allowedList => allChannels.filter(c => allowedList.contains(c.id))
     }
   }
+
+  def accessToken(): String = {
+    credentials.refreshToken()
+    credentials.getAccessToken
+  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,6 +38,8 @@ object Dependencies {
   val logstashLogbackEncoder = "net.logstash.logback" % "logstash-logback-encoder" % "4.8"
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.3.0"
 
+  val pandaHmacHeaders = "com.gu" %% "hmac-headers" % "1.1"
+
   val panda = Seq(
     "com.gu" %% "pan-domain-auth-play_2-5" % pandaVersion,
     "com.gu" %% "pan-domain-auth-verification" % pandaVersion,
@@ -74,7 +76,7 @@ object Dependencies {
   )
 
   val uploaderDependencies = Seq(
-    logstashLogbackEncoder, awsLambdaEvents, okHttp
+    logstashLogbackEncoder, awsLambdaEvents, okHttp, pandaHmacHeaders
   )
 
   val transcodeDependencies = Seq(awsLambdaCore, awsTranscoder, playJsonExtensions)

--- a/public/video-ui/src/services/UploadsApi.js
+++ b/public/video-ui/src/services/UploadsApi.js
@@ -30,7 +30,7 @@ class UploadFunctions {
       const s3 = this.getS3(upload.metadata.bucket, upload.metadata.region, credentials);
 
       const params = { Key: part.key, Body: slice, ACL: 'private', Metadata: { original: file.name } };
-      const request = s3.upload(params);
+      const request = s3.putObject(params);
 
       request.on('httpUploadProgress', (event) => {
         progressFn(part.start + event.loaded);

--- a/public/video-ui/src/services/UploadsApi.js
+++ b/public/video-ui/src/services/UploadsApi.js
@@ -27,15 +27,15 @@ class UploadFunctions {
     const slice = file.slice(part.start, part.end);
 
     return this.getCredentials(upload.id, part.key).then((credentials) => {
-      const s3 = this.getS3(upload.bucket, upload.region, credentials);
+      const s3 = this.getS3(upload.metadata.bucket, upload.metadata.region, credentials);
 
       const params = { Key: part.key, Body: slice, ACL: 'private', Metadata: { original: file.name } };
       const request = s3.upload(params);
-      
+
       request.on('httpUploadProgress', (event) => {
         progressFn(part.start + event.loaded);
       });
-      
+
       return request;
     });
   };

--- a/uploader/src/main/scala/com/gu/media/HmacRequestSupport.scala
+++ b/uploader/src/main/scala/com/gu/media/HmacRequestSupport.scala
@@ -1,0 +1,19 @@
+package com.gu.media
+
+import java.net.URI
+
+import com.gu.hmac.{HMACHeaderValues, HMACHeaders}
+
+trait HmacRequestSupport extends HMACHeaders { this: Settings =>
+  final override def secret = getMandatoryString("secret")
+
+  def generateHmacHeaders(uri: String): Map[String, String] = {
+    val HMACHeaderValues(date, token) = createHMACHeaderValues(new URI(uri))
+
+    Map(
+      "X-Gu-Tools-HMAC-Token" -> token,
+      "X-Gu-Tools-HMAC-Date" -> date,
+      "X-Gu-Tools-Service-Name" -> "media-atom-uploader"
+    )
+  }
+}

--- a/uploader/src/main/scala/com/gu/media/InputStreamRequestBody.scala
+++ b/uploader/src/main/scala/com/gu/media/InputStreamRequestBody.scala
@@ -1,0 +1,53 @@
+package com.gu.media
+
+import java.io.InputStream
+
+import com.squareup.okhttp.internal.Util
+import com.squareup.okhttp.{MediaType, RequestBody}
+import okio.{BufferedSink, Okio, Source}
+
+import scala.annotation.tailrec
+
+// http://stackoverflow.com/questions/25367888/upload-binary-file-with-okhttp-from-resources
+// http://stackoverflow.com/questions/25962595/tracking-progress-of-multipart-file-upload-using-okhttp
+class InputStreamRequestBody(override val contentType: MediaType, input: InputStream, size: Long, progress: Long => Unit) extends RequestBody {
+  private val SEGMENT_SIZE = 2048L // okio.Segment.SIZE
+  private val LOGGING_THROTTLE = 10000
+
+  override def contentLength(): Long = size
+
+  override def writeTo(sink: BufferedSink): Unit = {
+    var source: Source = null
+
+    try {
+      source = Okio.source(input)
+      write(source, sink, 0)
+    } finally {
+      Util.closeQuietly(source)
+    }
+  }
+
+  @tailrec
+  private def write(source: Source, sink: BufferedSink, uploaded: Long): Unit = {
+    if(uploaded % LOGGING_THROTTLE == 0)
+      progress(uploaded)
+
+    size - uploaded match {
+      case 0 =>
+      // terminate
+
+      case remaining =>
+        val amount = if(remaining > SEGMENT_SIZE) { SEGMENT_SIZE } else { remaining }
+        val written = source.read(sink.buffer(), amount)
+
+        // important otherwise we just make a massive buffer!
+        sink.flush()
+
+        if(written == -1) {
+          // terminate
+        } else {
+          write(source, sink, uploaded + written)
+        }
+    }
+  }
+}

--- a/uploader/src/main/scala/com/gu/media/S3EventsLambda.scala
+++ b/uploader/src/main/scala/com/gu/media/S3EventsLambda.scala
@@ -89,9 +89,9 @@ class S3EventsLambda extends RequestHandler[S3Event, Unit]
   }
 
   private def completePart(key: UploadPartKey, upload: Upload): Upload = {
-    upload.withPart(key.part, { part =>
+    upload.withPart(key.toString) { part =>
       part.copy(uploadedToS3 = true)
-    })
+    }
   }
 
   private def allPartsInS3(upload: Upload): Boolean = {

--- a/uploader/src/main/scala/com/gu/media/YouTubeUploadLambda.scala
+++ b/uploader/src/main/scala/com/gu/media/YouTubeUploadLambda.scala
@@ -2,19 +2,56 @@ package com.gu.media
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent
+import com.gu.media.aws.{DynamoAccess, S3Access, UploadAccess}
+import com.gu.media.lambda.LambdaBase
 import com.gu.media.logging.Logging
+import com.gu.media.upload.{DynamoUploadsTable, Upload, UploadPartKey}
+import com.gu.media.youtube.YouTubeAccess
 
-class YouTubeUploadLambda extends RequestHandler[KinesisEvent, Unit] with Logging {
+class YouTubeUploadLambda extends RequestHandler[KinesisEvent, Unit]
+  with LambdaBase
+  with S3Access
+  with UploadAccess
+  with DynamoAccess
+  with YouTubeAccess
+  with YouTubeVideoUpload
+  with Logging {
+
+  val table = new DynamoUploadsTable(this)
+
   override def handleRequest(input: KinesisEvent, context: Context): Unit = {
+    readKey(input).foreach { part =>
+      table.get(part.id) match {
+        case Some(upload) =>
+
+
+        case None =>
+          log.error(s"Unknown upload id ${part.id} [$part]")
+      }
+    }
+  }
+
+  private def getMultipartUrl(upload: Upload): String = upload.youTube.multipartUpload.getOrElse {
+    ???
+  }
+
+  private def readKey(input: KinesisEvent): Option[UploadPartKey] = {
     val records = input.getRecords
 
     if(records.size() > 1) {
       log.error(s"Expected 1 record in each batch, got ${records.size()}. The extra records will be discarded")
-    } else {
-      val record = input.getRecords.get(0)
-      val data = new String(record.getKinesis.getData.array(), "UTF-8")
+    }
 
-      log.info(s"Kinesis trigger: $data")
+    val record = input.getRecords.get(0)
+    val data = new String(record.getKinesis.getData.array(), "UTF-8")
+
+    data match {
+      case UploadPartKey(folder, id, part) =>
+        Some(UploadPartKey(folder, id, part))
+
+      case other =>
+        log.error(s"Unknown format for part key $other")
+        None
     }
   }
 }

--- a/uploader/src/main/scala/com/gu/media/YouTubeUploadLambda.scala
+++ b/uploader/src/main/scala/com/gu/media/YouTubeUploadLambda.scala
@@ -2,11 +2,15 @@ package com.gu.media
 
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
+import com.amazonaws.services.s3.model.DeleteObjectsRequest
 import com.gu.media.aws.{DynamoAccess, S3Access, UploadAccess}
 import com.gu.media.lambda.LambdaBase
 import com.gu.media.logging.Logging
 import com.gu.media.upload.{DynamoUploadsTable, Upload, UploadPart, UploadPartKey}
 import com.gu.media.youtube.YouTubeAccess
+import com.squareup.okhttp._
+
+import scala.collection.JavaConverters._
 
 class YouTubeUploadLambda extends RequestHandler[KinesisEvent, Unit]
   with LambdaBase
@@ -15,9 +19,14 @@ class YouTubeUploadLambda extends RequestHandler[KinesisEvent, Unit]
   with DynamoAccess
   with YouTubeAccess
   with YouTubeVideoUpload
+  with HmacRequestSupport
   with Logging {
 
-  val table = new DynamoUploadsTable(this)
+  private val table = new DynamoUploadsTable(this)
+  private val domain = sys.env.get("DOMAIN")
+
+  private val http = new OkHttpClient()
+  private val appJson = MediaType.parse("application/json")
 
   override def handleRequest(input: KinesisEvent, context: Context): Unit = {
     for {
@@ -31,6 +40,8 @@ class YouTubeUploadLambda extends RequestHandler[KinesisEvent, Unit]
 
       uploadPart(uploadUri, part.key, part.start, part.end, total, (_: Long) => {}).foreach { videoId =>
         log.info(s"Successful upload ${upload.id}. YouTube ID: $videoId")
+
+        addAsset(upload.metadata.atomId, videoId)
         table.delete(upload.id)
       }
     }
@@ -44,6 +55,34 @@ class YouTubeUploadLambda extends RequestHandler[KinesisEvent, Unit]
 
     table.put(updated)
     url
+  }
+
+  private def addAsset(atomId: String, videoId: String): Unit = {
+    val actuallyPerformRequest = stage != "DEV" && domain.nonEmpty
+
+    val origin = s"${domain.getOrElse("https://video.local.dev-gutools.co.uk")}"
+    val uri = s"$origin//api2/atoms/:id/assets"
+    val hmacHeaders = generateHmacHeaders(uri)
+
+    val videoUri = s"https://www.youtube.com/watch?v=$videoId"
+    val body = s"""{"uri": "$videoUri"}"""
+
+    if(actuallyPerformRequest) {
+      val request = new Request.Builder()
+        .url(uri)
+        .headers(Headers.of(hmacHeaders.asJava))
+        .post(RequestBody.create(appJson, body))
+        .build()
+
+      val response = http.newCall(request).execute()
+      if(response.code() != 200) {
+        log.error(s"Unexpected response adding asset ${response.code()}")
+        log.error(s"uri=$uri body=$body responseBody=${response.body().string()}")
+        log.error(s"atomId=$atomId youTubeId=$videoId")
+      }
+    } else {
+      log.info(s"Add asset: POST $uri $body $hmacHeaders")
+    }
   }
 
   private def readKey(input: KinesisEvent): Option[UploadPartKey] = {

--- a/uploader/src/main/scala/com/gu/media/YouTubeUploadLambda.scala
+++ b/uploader/src/main/scala/com/gu/media/YouTubeUploadLambda.scala
@@ -27,7 +27,7 @@ class YouTubeUploadLambda extends RequestHandler[KinesisEvent, Unit]
       total = upload.parts.last.end
       uploadUri = getYTUploadUrl(upload)
     } yield {
-      log.info(s"Uploading $uploadUri ${part.key} [${part.start} - ${part.end}]")
+      log.info(s"Uploading ${part.key} [${part.start} - ${part.end}]")
 
       uploadPart(uploadUri, part.key, part.start, part.end, total, (_: Long) => {}).foreach { videoId =>
         log.info(s"Successful upload ${upload.id}. YouTube ID: $videoId")
@@ -37,9 +37,9 @@ class YouTubeUploadLambda extends RequestHandler[KinesisEvent, Unit]
   }
 
   private def getYTUploadUrl(upload: Upload): String = upload.youTube.upload.getOrElse {
-    log.info(s"Starting YouTube upload for ${upload.id} [${upload.youTube.title} - ${upload.youTube.channel}]")
+    log.info(s"Starting YouTube upload for ${upload.id} [${upload.metadata.title} - ${upload.youTube.channel}]")
 
-    val url = startUpload(upload.youTube.title, upload.youTube.channel, upload.id, upload.parts.last.end)
+    val url = startUpload(upload.metadata.title, upload.youTube.channel, upload.id, upload.parts.last.end)
     val updated = upload.copy(youTube = upload.youTube.copy(upload = Some(url)))
 
     table.put(updated)

--- a/uploader/src/main/scala/com/gu/media/YouTubeUploadLambda.scala
+++ b/uploader/src/main/scala/com/gu/media/YouTubeUploadLambda.scala
@@ -1,11 +1,13 @@
 package com.gu.media
 
-import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
+import java.util.concurrent.atomic.AtomicLong
+
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent
+import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import com.gu.media.aws.{DynamoAccess, S3Access, UploadAccess}
 import com.gu.media.lambda.LambdaBase
 import com.gu.media.logging.Logging
-import com.gu.media.upload.{DynamoUploadsTable, Upload, UploadPartKey}
+import com.gu.media.upload.{DynamoUploadsTable, Upload, UploadPart, UploadPartKey}
 import com.gu.media.youtube.YouTubeAccess
 
 class YouTubeUploadLambda extends RequestHandler[KinesisEvent, Unit]
@@ -20,19 +22,42 @@ class YouTubeUploadLambda extends RequestHandler[KinesisEvent, Unit]
   val table = new DynamoUploadsTable(this)
 
   override def handleRequest(input: KinesisEvent, context: Context): Unit = {
-    readKey(input).foreach { part =>
-      table.get(part.id) match {
-        case Some(upload) =>
+    for {
+      key <- readKey(input)
+      (upload, part) <- readUploadAndPart(key)
 
+      uploadUri = getYTUploadUrl(upload)
+    } yield {
+      log.info(s"Uploading $uploadUri ${part.key} [${part.start} - ${part.end}]")
+      uploadPart(uploadUri, part.key, part.start, part.end, upload.parts.last.end, uploadProgress(upload, part))
+    }
+  }
 
-        case None =>
-          log.error(s"Unknown upload id ${part.id} [$part]")
+  private def uploadProgress(upload: Upload, part: UploadPart) = {
+    val lastUpdatedTime = new AtomicLong(System.currentTimeMillis())
+    val updatePeriod = 10 * 1000 // 10 seconds
+
+    (progress: Long) => {
+      val before = lastUpdatedTime.get()
+      val now = System.currentTimeMillis()
+
+      if(now - before > updatePeriod) {
+        val updated = upload.withPart(part.key)(_.copy(uploadedToYouTube = progress))
+        table.put(updated)
+
+        lastUpdatedTime.set(now)
       }
     }
   }
 
-  private def getMultipartUrl(upload: Upload): String = upload.youTube.multipartUpload.getOrElse {
-    ???
+  private def getYTUploadUrl(upload: Upload): String = upload.youTube.upload.getOrElse {
+    log.info(s"Starting YouTube upload for ${upload.id} [${upload.youTube.title} - ${upload.youTube.channel}]")
+
+    val url = startUpload(upload.youTube.title, upload.youTube.channel, upload.id, upload.parts.last.end)
+    val updated = upload.copy(youTube = upload.youTube.copy(upload = Some(url)))
+
+    table.put(updated)
+    url
   }
 
   private def readKey(input: KinesisEvent): Option[UploadPartKey] = {
@@ -50,8 +75,14 @@ class YouTubeUploadLambda extends RequestHandler[KinesisEvent, Unit]
         Some(UploadPartKey(folder, id, part))
 
       case other =>
-        log.error(s"Unknown format for part key $other")
         None
     }
+  }
+
+  private def readUploadAndPart(key: UploadPartKey): Option[(Upload, UploadPart)] = {
+    for {
+      upload <- table.consistentlyGet(key.id)
+      part <- upload.parts.find(_.key == key.toString)
+    } yield (upload, part)
   }
 }

--- a/uploader/src/main/scala/com/gu/media/YouTubeVideoUpload.scala
+++ b/uploader/src/main/scala/com/gu/media/YouTubeVideoUpload.scala
@@ -1,0 +1,82 @@
+package com.gu.media
+
+import java.io.InputStream
+
+import com.gu.media.aws.{S3Access, UploadAccess}
+import com.gu.media.youtube.YouTubeAccess
+import com.squareup.okhttp.{MediaType, OkHttpClient, Request, RequestBody}
+import play.api.libs.json.Json
+
+trait YouTubeVideoUpload { this: S3Access with UploadAccess with YouTubeAccess =>
+  private val JSON = MediaType.parse("application/json; charset=utf-8")
+  private val VIDEO = MediaType.parse("video/*")
+
+  private val http = new OkHttpClient()
+
+  def startUpload(title: String, channel: String, id: String, size: Long): String = {
+    val contentOwnerParams = s"onBehalfOfContentOwner=$contentOwner&onBehalfOfContentOwnerChannel=$channel"
+    val params = s"uploadType=resumable&part=snippet,statistics,status&$contentOwnerParams"
+    val endpoint = s"https://www.googleapis.com/upload/youtube/v3/videos?$params"
+
+    val videoTitle = s"$title-$id"
+    val description = s"Uploaded by the media-atom-maker. Pending publishing"
+
+    val json =
+      s"""
+         | {
+         |    "snippet": {
+         |      "title": "$videoTitle",
+         |      "description": "$description"
+         |    },
+         |    "status": {
+         |      "privacyStatus": "private"
+         |    },
+         |    "onBehalfOfContentOwner": "$contentOwner",
+         |    "onBehalfOfContentOwnerChannel": "$channel"
+         | }
+       """.stripMargin
+
+    val body = RequestBody.create(JSON, json)
+    val request = new Request.Builder()
+      .url(endpoint)
+      .addHeader("Authorization", "Bearer " + accessToken())
+      .addHeader("X-Upload-Content-Length", size.toString)
+      .addHeader("X-Upload-Content-Type", "video/*")
+      .post(body)
+      .build()
+
+    val response = http.newCall(request).execute()
+    response.header("Location")
+  }
+
+  def uploadPart(uri: String, key: String, start: Long, end: Long, total: Long, uploaded: Long => Unit): Option[String] = {
+    val input = s3Client.getObject(userUploadBucket, key.toString).getObjectContent
+    uploadPart(uri, input, start, end, total, uploaded)
+  }
+
+  def uploadPart(uri: String, input: InputStream, start: Long, end: Long, total: Long, uploaded: Long => Unit): Option[String] = {
+    val size = end - start
+    // end index is inclusive in direct contradiction to programming history (and my end variable)
+    val range = s"$start-${start + size - 1}"
+
+    val body = new InputStreamRequestBody(VIDEO, input, size, uploaded)
+
+    val request = new Request.Builder()
+      .url(uri)
+      .addHeader("Authorization", "Bearer " + accessToken())
+      .addHeader("Content-Length", size.toString)
+      .addHeader(s"Content-Range", s"bytes $range/$total")
+      .post(body)
+      .build()
+
+    val response = http.newCall(request).execute()
+    val str = response.body().string()
+
+    if(str.nonEmpty) {
+      Some((Json.parse(str) \ "id").as[String])
+    } else {
+      // next part
+      None
+    }
+  }
+}


### PR DESCRIPTION
**NB: This PR is dependent on #320**

This PR reacts to events on the kinesis stream introduced in #320 by uploading each part in turn to YouTube. Once all parts have been uploaded, the resulting YouTube video is added as an asset to the atom.

Other changes:

- Use Dynamo consistent reads to fix problem where part uploads would not see the YouTube resumable upload end-point in the DB
- Only use plain S3 PUT from the client rather than multipart uploads to avoid a really annoying race condition where the last part (small and therefore a PUT) would trigger the lambda before the preceding multipart upload
- Include `plutoProjectId` in the upload metadata (required for integration with Pluto sync)