### PR TITLE
Fix uploading to YouTube in CODE and PROD

### DIFF
--- a/app/data/DataStores.scala
+++ b/app/data/DataStores.scala
@@ -25,16 +25,16 @@ class DataStores(aws: AWSConfig) extends MediaAtomImplicits {
   val audit: AuditDataStore = new AuditDataStore(aws.dynamoDB, aws.auditDynamoTableName)
 
   val livePublisher: LiveKinesisAtomPublisher =
-    new LiveKinesisAtomPublisher(aws.liveKinesisStreamName, aws.kinesisClient)
+    new LiveKinesisAtomPublisher(aws.liveKinesisStreamName, aws.crossAccountKinesisClient)
 
   val previewPublisher: PreviewKinesisAtomPublisher =
-    new PreviewKinesisAtomPublisher(aws.previewKinesisStreamName, aws.kinesisClient)
+    new PreviewKinesisAtomPublisher(aws.previewKinesisStreamName, aws.crossAccountKinesisClient)
 
   val reindexPreview: PreviewAtomReindexer =
-    new PreviewKinesisAtomReindexer(aws.previewKinesisReindexStreamName, aws.kinesisClient)
+    new PreviewKinesisAtomReindexer(aws.previewKinesisReindexStreamName, aws.crossAccountKinesisClient)
 
   val reindexPublished: PublishedKinesisAtomReindexer =
-    new PublishedKinesisAtomReindexer(aws.publishedKinesisReindexStreamName, aws.kinesisClient)
+    new PublishedKinesisAtomReindexer(aws.publishedKinesisReindexStreamName, aws.crossAccountKinesisClient)
 
   private def getPreview[T: ClassTag: DynamoFormat](dynamoFormats: AtomDynamoFormats[T]): PreviewDynamoDataStore[T] = {
     new PreviewDynamoDataStore[T](aws.dynamoDB, aws.dynamoTableName) {

--- a/build.sbt
+++ b/build.sbt
@@ -104,9 +104,7 @@ lazy val root = (project in file("root"))
     riffRaffManifestProjectName := "media-service:media-atom-maker",
     riffRaffArtifactResources := Seq(
       (packageBin in Debian in app).value -> s"${(name in app).value}/${(name in app).value}.deb",
-      // we have an entry here for each lambda that uses this code (see the cloud formation)
-      (packageBin in Universal in uploader).value -> s"media-atom-uploader-s3-events/${(packageBin in Universal in uploader).value.getName}",
-      (packageBin in Universal in uploader).value -> s"media-atom-uploader-dynamo-events/${(packageBin in Universal in uploader).value.getName}",
+      (packageBin in Universal in uploader).value -> s"media-atom-upload-actions/${(packageBin in Universal in uploader).value.getName}",
       (packageBin in Universal in transcoder).value -> s"${(name in transcoder).value}/${(packageBin in Universal in transcoder).value.getName}",
       (packageBin in Universal in expirer).value -> s"${(name in expirer).value}/${(packageBin in Universal in expirer).value.getName}",
       (baseDirectory in Global in app).value / "conf/riff-raff.yaml" -> "riff-raff.yaml"

--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -260,6 +260,22 @@
                                   "Resource": [
                                     "arn:aws:elastictranscoder:*"
                                   ]
+                                },
+                                {
+                                  "Effect": "Allow",
+                                  "Action": [
+                                    "s3:PutObject",
+                                    "s3:PutObjectAcl",
+                                    "s3:ListBucketMultipartUploads",
+                                    "s3:ListMultipartUploadParts",
+                                    "s3:AbortMultipartUpload"
+                                  ],
+                                  "Resource": {
+                                    "Fn::Sub": [
+                                      "arn:aws:s3:::${Bucket}/uploads/*",
+                                      { "Bucket": { "Ref": "UserUploadBucket" }}
+                                    ]
+                                  }
                                 }
                             ]
                         }
@@ -445,7 +461,7 @@
                           },
                           {
                             "Effect": "Allow",
-                            "Action": ["s3:GetObject"],
+                            "Action": ["s3:GetObject", "s3:DeleteObject"],
                             "Resource": [
                               { "Fn::Sub": [
                                 "arn:aws:s3:::${Bucket}/*",

--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -263,16 +263,10 @@
                                 },
                                 {
                                   "Effect": "Allow",
-                                  "Action": [
-                                    "s3:PutObject",
-                                    "s3:PutObjectAcl",
-                                    "s3:ListBucketMultipartUploads",
-                                    "s3:ListMultipartUploadParts",
-                                    "s3:AbortMultipartUpload"
-                                  ],
+                                  "Action": ["s3:*"],
                                   "Resource": {
                                     "Fn::Sub": [
-                                      "arn:aws:s3:::${Bucket}/uploads/*",
+                                      "arn:aws:s3:::${Bucket}/*",
                                       { "Bucket": { "Ref": "UserUploadBucket" }}
                                     ]
                                   }
@@ -504,7 +498,8 @@
                 "APP": "media-atom-uploader",
                 "STAGE": { "Ref": "Stage" },
                 "CONFIG_BUCKET": { "Ref": "ConfigBucket" },
-                "CONFIG_KEY": { "Fn::FindInMap": [ "LambdaConfig", "Uploader", { "Ref": "Stage" }] }
+                "CONFIG_KEY": { "Fn::FindInMap": [ "LambdaConfig", "Uploader", { "Ref": "Stage" }] },
+                "UPLOAD_TRACKING_TABLE_NAME": { "Ref": "UploadTrackingTable" }
               }
             },
             "MemorySize": 256,

--- a/common/src/main/scala/com/gu/media/aws/DynamoAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/DynamoAccess.scala
@@ -4,10 +4,12 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
 import com.gu.media.Settings
 
 trait DynamoAccess { this: Settings with AwsAccess =>
-  val dynamoTableName: String = getMandatoryString("aws.dynamo.tableName")
-  val publishedDynamoTableName: String = getMandatoryString("aws.dynamo.publishedTableName")
-  val auditDynamoTableName: String = getMandatoryString("aws.dynamo.auditTableName")
-  val uploadTrackingTableName: String = getMandatoryString("aws.dynamo.uploadTrackingTableName")
+  lazy val dynamoTableName: String = getMandatoryString("aws.dynamo.tableName")
+  lazy val publishedDynamoTableName: String = getMandatoryString("aws.dynamo.publishedTableName")
+  lazy val auditDynamoTableName: String = getMandatoryString("aws.dynamo.auditTableName")
+  lazy val uploadTrackingTableName: String = sys.env.getOrElse("UPLOAD_TRACKING_TABLE_NAME",
+    getMandatoryString("aws.dynamo.uploadTrackingTableName")
+  )
 
   lazy val dynamoDB: AmazonDynamoDBClient = region.createClient(
     classOf[AmazonDynamoDBClient],

--- a/common/src/main/scala/com/gu/media/aws/KinesisAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/KinesisAccess.scala
@@ -20,11 +20,13 @@ trait KinesisAccess { this: Settings with AwsAccess with CrossAccountAccess =>
 
   val uploadActionsStreamName: String = getMandatoryString("aws.kinesis.uploadActionsStreamName")
 
-  lazy val kinesisClient = if (stage != "DEV" || readFromComposerAccount) {
+  lazy val crossAccountKinesisClient = if (stage != "DEV" || readFromComposerAccount) {
     region.createClient(classOf[AmazonKinesisClient], atomEventsProvider, null)
   } else {
     region.createClient(classOf[AmazonKinesisClient], credsProvider, null)
   }
+
+  lazy val kinesisClient = region.createClient(classOf[AmazonKinesisClient], credsProvider, null)
 
   def sendOnKinesis[T: Writes](streamName: String, partitionKey: String, value: T): Unit = {
     val json = Json.stringify(Json.toJson(value))

--- a/uploader/src/main/scala/com/gu/media/UploadActionsLambda.scala
+++ b/uploader/src/main/scala/com/gu/media/UploadActionsLambda.scala
@@ -24,7 +24,7 @@ class UploadActionsLambda extends RequestHandler[KinesisEvent, Unit]
   with Logging {
 
   private val table = new UploadsDataStore(this)
-  private val domain = getString("host").getOrElse("https://video.local.dev-gutools.co.uk")
+  private val domain = getString("host").getOrElse("video.local.dev-gutools.co.uk")
 
   private val http = new OkHttpClient()
   private val appJson = MediaType.parse("application/json")
@@ -71,8 +71,8 @@ class UploadActionsLambda extends RequestHandler[KinesisEvent, Unit]
 
   private def addAsset(atomId: String, videoId: String): Unit = {
     val actuallyPerformRequest = stage != "DEV" && domain.nonEmpty
-    
-    val uri = s"$domain/api2/atoms/:id/assets"
+
+    val uri = s"https://$domain/api2/atoms/:id/assets"
     val hmacHeaders = generateHmacHeaders(uri)
 
     val videoUri = s"https://www.youtube.com/watch?v=$videoId"

--- a/uploader/src/main/scala/com/gu/media/UploadActionsLambda.scala
+++ b/uploader/src/main/scala/com/gu/media/UploadActionsLambda.scala
@@ -72,7 +72,7 @@ class UploadActionsLambda extends RequestHandler[KinesisEvent, Unit]
   private def addAsset(atomId: String, videoId: String): Unit = {
     val actuallyPerformRequest = stage != "DEV" && domain.nonEmpty
 
-    val uri = s"https://$domain/api2/atoms/:id/assets"
+    val uri = s"https://$domain/api2/atoms/$atomId/assets"
     val hmacHeaders = generateHmacHeaders(uri)
 
     val videoUri = s"https://www.youtube.com/watch?v=$videoId"


### PR DESCRIPTION
Follow up fixes to #325/#326 that make it work correctly in CODE and PROD.

- Do not use the cross-account credentials when posting to the stream of upload actions
- Fix the name of the lambda in `riffRaffArtifactResources` in build.sbt
- Give permission to the main MAM app to access the upload bucket (to do multipart copies)
- Pass in the upload table name to lambdas via an environment variable
   - Unfortunately required since the table names are injected into configuration files
   - Also make the table names lazy vals so the mandatory setting error only happens on access
- Fix the URI for add asset