### PR TITLE
Set duration on publish

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -68,7 +68,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, val authAction
 
   def publishMediaAtom(id: String) = APIHMACAuthAction { implicit req =>
     try {
-      val command = PublishAtomCommand(id, fromExpiryPoller = false, stores, youTube, req.user)
+      val command = PublishAtomCommand(id, stores, youTube, req.user)
 
       val updatedAtom = command.process()
       Ok(Json.toJson(updatedAtom))

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -35,11 +35,11 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youTu
 
     getActiveAsset(atom) match {
       case Some(asset) if asset.platform == Youtube =>
-        val withDuration = atom.copy(duration = youTube.getDuration(asset.id))
+        val atomWithDuration = atom.copy(duration = youTube.getDuration(asset.id))
 
-        updateThumbnail(withDuration, asset)
-        updateYouTube(withDuration, asset)
-        publish(withDuration, user)
+        updateThumbnail(atomWithDuration, asset)
+        updateYouTube(atomWithDuration, asset)
+        publish(atomWithDuration, user)
 
       case _ =>
         publish(atom, user)

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -33,7 +33,7 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youTu
       AtomPublishFailed("Atom status set to private")
     }
 
-    val updatedAtom = getActiveAsset(atom) match {
+    getActiveAsset(atom) match {
       case Some(asset) if asset.platform == Youtube =>
         val withDuration = atom.copy(duration = youTube.getDuration(asset.id))
 
@@ -44,9 +44,6 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youTu
       case _ =>
         publish(atom, user)
     }
-
-    setAssetsToPrivate(updatedAtom)
-    updatedAtom
   }
 
   private def publish(atom: MediaAtom, user: PandaUser): MediaAtom = {
@@ -65,7 +62,10 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youTu
     auditDataStore.auditPublish(id, user)
     UpdateAtomCommand(id, updatedAtom, stores, user).process()
 
-    publishAtomToLive(updatedAtom)
+    val publishedAtom = publishAtomToLive(updatedAtom)
+    setAssetsToPrivate(publishedAtom)
+
+    publishedAtom
   }
 
   private def publishAtomToLive(mediaAtom: MediaAtom): MediaAtom = {

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -5,7 +5,7 @@ import java.time.Instant
 import java.util.Date
 
 import com.gu.atom.play.AtomAPIActions
-import com.gu.contentatom.thrift.{Atom, ContentAtomEvent, EventType}
+import com.gu.contentatom.thrift.{ContentAtomEvent, EventType}
 import com.gu.media.logging.Logging
 import com.gu.media.youtube.{YouTube, YouTubeMetadataUpdate}
 import com.gu.pandomainauth.model.{User => PandaUser}
@@ -17,7 +17,7 @@ import model.commands.CommandExceptions._
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 
-case class PublishAtomCommand(id: String, fromExpiryPoller: Boolean, override val stores: DataStores, youTube: YouTube, user: PandaUser)
+case class PublishAtomCommand(id: String, override val stores: DataStores, youTube: YouTube, user: PandaUser)
   extends Command with AtomAPIActions with Logging {
 
   type T = MediaAtom
@@ -26,75 +26,50 @@ case class PublishAtomCommand(id: String, fromExpiryPoller: Boolean, override va
     log.info(s"Request to publish atom $id")
 
     val thriftAtom = getPreviewAtom(id)
-
     val atom = MediaAtom.fromThrift(thriftAtom)
 
-    (atom.privacyStatus, !fromExpiryPoller) match {
-      case (Some(PrivacyStatus.Private), false) =>
-        log.error(s"Unable to publish atom ${atom.id}, privacy status is set to private")
-        AtomPublishFailed("Atom status set to private")
-
-      case _ => {
-
-        MediaAtom.getActiveYouTubeAsset(atom) match {
-          case Some(asset) => {
-            try {
-              updateThumbnail(atom)
-            } catch {
-              case NonFatal(e) => {
-                log.error(s"Unable to update thumbnail for asset=${asset.id} atom={$id}", e)
-                PosterImageUploadFailed(e.getMessage)
-              }
-            }
-          }
-          case None =>
-            log.info(s"Unable to update thumbnail for $id. There is no active YouTube asset")
-        }
-
-        atom.activeVersion match {
-          case Some(atomVersion) => {
-
-            val activeAssetId = atom.assets.find(asset => {
-              asset.version == atomVersion
-            }).get.id
-
-            val metadata = YouTubeMetadataUpdate(
-              title = Some(atom.title),
-              categoryId = atom.youtubeCategoryId,
-              description = atom.description,
-              tags = atom.tags,
-              license = atom.license,
-              privacyStatus = atom.privacyStatus.map(_.name)
-            )
-
-            youTube.updateMetadata(activeAssetId, metadata)
-          }
-          case None =>
-            log.info(s"Not updating YouTube metadata for atom $id as it has no active asset")
-        }
-
-        val changeRecord = Some(ChangeRecord.now(user).asThrift)
-
-        val updatedAtom = thriftAtom.copy(
-          contentChangeDetails = thriftAtom.contentChangeDetails.copy(
-            published = changeRecord,
-            lastModified = changeRecord,
-            revision = thriftAtom.contentChangeDetails.revision + 1
-          )
-        )
-
-        log.info(s"Publishing atom $id")
-
-        auditDataStore.auditPublish(id, user)
-        UpdateAtomCommand(id, MediaAtom.fromThrift(updatedAtom), stores, user).process()
-
-        setAssetsToPrivate(atom)
-        publishAtomToLive(updatedAtom)
-      }
+    if(atom.privacyStatus.contains(PrivacyStatus.Private)) {
+      log.error(s"Unable to publish atom ${atom.id}, privacy status is set to private")
+      AtomPublishFailed("Atom status set to private")
     }
+
+    val updatedAtom = getActiveAsset(atom) match {
+      case Some(asset) if asset.platform == Youtube =>
+        val withDuration = atom.copy(duration = youTube.getDuration(asset.id))
+
+        updateThumbnail(withDuration, asset)
+        updateYouTube(withDuration, asset)
+        publish(withDuration, user)
+
+      case _ =>
+        publish(atom, user)
+    }
+
+    setAssetsToPrivate(updatedAtom)
+    updatedAtom
   }
 
-  private def publishAtomToLive(atom: Atom): MediaAtom = {
+  private def publish(atom: MediaAtom, user: PandaUser): MediaAtom = {
+    log.info(s"Publishing atom $id")
+
+    val changeRecord = Some(ChangeRecord.now(user))
+
+    val updatedAtom = atom.copy(
+      contentChangeDetails = atom.contentChangeDetails.copy(
+        published = changeRecord,
+        lastModified = changeRecord,
+        revision = atom.contentChangeDetails.revision + 1
+      )
+    )
+
+    auditDataStore.auditPublish(id, user)
+    UpdateAtomCommand(id, updatedAtom, stores, user).process()
+
+    publishAtomToLive(updatedAtom)
+  }
+
+  private def publishAtomToLive(mediaAtom: MediaAtom): MediaAtom = {
+    val atom = mediaAtom.asThrift
     val event = ContentAtomEvent(atom, EventType.Update, (new Date()).getTime())
 
     livePublisher.publishAtomEvent(event) match {
@@ -114,24 +89,41 @@ case class PublishAtomCommand(id: String, fromExpiryPoller: Boolean, override va
     }
   }
 
-  private def updateThumbnail(atom: MediaAtom): Unit = {
-    val asset = atom.getActiveAsset.get
+  private def updateYouTube(atom: MediaAtom, asset: Asset): Unit = {
+    val metadata = YouTubeMetadataUpdate(
+      title = Some(atom.title),
+      categoryId = atom.youtubeCategoryId,
+      description = atom.description,
+      tags = atom.tags,
+      license = atom.license,
+      privacyStatus = atom.privacyStatus.map(_.name)
+    )
 
-    val master = atom.posterImage.flatMap(_.master).get
-    val MAX_SIZE = 2000000
-    val img: ImageAsset = if (master.size.get < MAX_SIZE) {
-      master
-    } else {
-      // Get the biggest crop which is still less than MAX_SIZE
-      atom.posterImage.map(
-        _.assets
-          .filter(a => a.size.nonEmpty && a.size.get < MAX_SIZE)
-          .sortBy(_.size.get)
-          .last
-      ).get
+    youTube.updateMetadata(asset.id, metadata)
+  }
+
+  private def updateThumbnail(atom: MediaAtom, asset: Asset): Unit = {
+    try {
+      val master = atom.posterImage.flatMap(_.master).get
+      val MAX_SIZE = 2000000
+      val img: ImageAsset = if (master.size.get < MAX_SIZE) {
+        master
+      } else {
+        // Get the biggest crop which is still less than MAX_SIZE
+        atom.posterImage.map(
+          _.assets
+            .filter(a => a.size.nonEmpty && a.size.get < MAX_SIZE)
+            .sortBy(_.size.get)
+            .last
+        ).get
+      }
+
+      youTube.updateThumbnail(asset.id, new URL(img.file), img.mimeType.get)
+    } catch {
+      case NonFatal(e) =>
+        log.error(s"Unable to update thumbnail for asset=${asset.id} atom={$id}", e)
+        PosterImageUploadFailed(e.getMessage)
     }
-
-    youTube.updateThumbnail(asset.id, new URL(img.file), img.mimeType.get)
   }
 
   private def setAssetsToPrivate(atom: MediaAtom): Unit = {
@@ -148,4 +140,9 @@ case class PublishAtomCommand(id: String, fromExpiryPoller: Boolean, override va
       }
     }
   }
+
+  private def getActiveAsset(atom: MediaAtom): Option[Asset] = for {
+    version <- atom.activeVersion
+    asset <- atom.assets.find(_.version == version)
+  } yield asset
 }


### PR DESCRIPTION
Fixes #336.

Previously we only set the duration when an asset was activated. Now we set it again when the atom is published as a double check.

I've also taken the opportunity to refactor PublishAtomCommand to hopefully be easier to read. As such, it may be easier to look at the file itself rather than the diff when reviewing.