### PR TITLE
endpoints to get, create and update pluto projects

### DIFF
--- a/app/controllers/PlutoController.scala
+++ b/app/controllers/PlutoController.scala
@@ -1,0 +1,42 @@
+package controllers
+
+import com.gu.media.pluto.PlutoProject
+import com.gu.pandahmac.HMACAuthActions
+import data.{DataStores, UnpackedDataStores}
+import play.api.libs.json.Json
+import play.api.mvc.Controller
+
+class PlutoController (val authActions: HMACAuthActions, override val stores: DataStores) extends Controller
+  with UnpackedDataStores
+  with JsonRequestParsing {
+
+  import authActions.APIHMACAuthAction
+
+  def listProjects() = APIHMACAuthAction {
+    val plutoProjects = stores.plutoProjectStore.list()
+    Ok(Json.toJson(plutoProjects))
+  }
+
+  def createProject() = APIHMACAuthAction { implicit req =>
+    parse[PlutoProject](req) { data: PlutoProject => {
+      stores.plutoProjectStore.put(data)
+      Ok(Json.toJson(data))
+    }}
+  }
+
+  def getProject(id: String) = APIHMACAuthAction {
+    stores.plutoProjectStore.get(id) match {
+      case Some(p) => Ok(Json.toJson(p))
+      case _ => NotFound
+    }
+  }
+
+  def updateProject(id: String) = APIHMACAuthAction { implicit req =>
+    parse[PlutoProject](req) { data: PlutoProject => {
+      stores.plutoProjectStore.update(id, data) match {
+        case Some(_) => Ok(Json.toJson(data))
+        case None => NotFound
+      }
+    }}
+  }
+}

--- a/app/controllers/PlutoProjectController.scala
+++ b/app/controllers/PlutoProjectController.scala
@@ -6,7 +6,7 @@ import data.{DataStores, UnpackedDataStores}
 import play.api.libs.json.Json
 import play.api.mvc.Controller
 
-class PlutoController (val authActions: HMACAuthActions, override val stores: DataStores) extends Controller
+class PlutoProjectController(val authActions: HMACAuthActions, override val stores: DataStores) extends Controller
   with UnpackedDataStores
   with JsonRequestParsing {
 

--- a/app/data/DataStores.scala
+++ b/app/data/DataStores.scala
@@ -4,6 +4,7 @@ import com.gu.atom.data._
 import com.gu.atom.publish._
 import com.gu.contentatom.thrift.{Atom, AtomData}
 import com.gu.contentatom.thrift.atom.media.MediaAtom
+import com.gu.media.pluto.PlutoProjectDataStore
 import com.gu.media.upload.UploadsDataStore
 import com.gu.media.PlutoDataStore
 import com.gu.scanamo.DynamoFormat
@@ -40,6 +41,8 @@ class DataStores(aws: AWSConfig) extends MediaAtomImplicits {
     new PublishedKinesisAtomReindexer(aws.publishedKinesisReindexStreamName, aws.crossAccountKinesisClient)
 
   val uploadStore: UploadsDataStore = new UploadsDataStore(aws)
+
+  val plutoProjectStore: PlutoProjectDataStore = new PlutoProjectDataStore(aws)
 
   private def getPreview[T: ClassTag: DynamoFormat](dynamoFormats: AtomDynamoFormats[T]): PreviewDynamoDataStore[T] = {
     new PreviewDynamoDataStore[T](aws.dynamoDB, aws.dynamoTableName) {

--- a/app/di.scala
+++ b/app/di.scala
@@ -54,7 +54,7 @@ class MediaAtomMaker(context: Context)
   private val support = new Support(hmacAuthActions, capi)
   private val youTubeController = new controllers.Youtube(hmacAuthActions, youTube, defaultCacheApi)
 
-  private val pluto = new PlutoController(hmacAuthActions, stores)
+  private val pluto = new PlutoProjectController(hmacAuthActions, stores)
 
   private val transcoder = new util.Transcoder(aws, defaultCacheApi)
   private val transcoderController = new controllers.Transcoder(hmacAuthActions, transcoder)

--- a/app/di.scala
+++ b/app/di.scala
@@ -54,6 +54,8 @@ class MediaAtomMaker(context: Context)
   private val support = new Support(hmacAuthActions, capi)
   private val youTubeController = new controllers.Youtube(hmacAuthActions, youTube, defaultCacheApi)
 
+  private val pluto = new PlutoController(hmacAuthActions, stores)
+
   private val transcoder = new util.Transcoder(aws, defaultCacheApi)
   private val transcoderController = new controllers.Transcoder(hmacAuthActions, transcoder)
 
@@ -62,9 +64,20 @@ class MediaAtomMaker(context: Context)
 
   private val assets = new controllers.Assets(httpErrorHandler)
 
-  override val router =
-    new Routes(httpErrorHandler, mainApp, api, api2, uploads, youTubeController, transcoderController, reindexer,
-      assets, videoApp, support)
+  override val router = new Routes(
+    httpErrorHandler,
+    mainApp,
+    api,
+    api2,
+    pluto,
+    uploads,
+    youTubeController,
+    transcoderController,
+    reindexer,
+    assets,
+    videoApp,
+    support
+  )
 
   private def buildReindexer() = {
     // pass the parameters manually since the reindexer is part of the atom-maker lib

--- a/cloudformation/media-atom-maker-dev.yml
+++ b/cloudformation/media-atom-maker-dev.yml
@@ -82,6 +82,9 @@ Resources:
                   - !Sub
                     - "arn:aws:dynamodb:${Region}:${Account}:table/${Table}"
                     - { Region: !Ref "AWS::Region", Account: !Ref "AWS::AccountId", Table: !Ref "ManualPlutoMediaAtomsDynamoTable" }
+                  - !Sub
+                    - "arn:aws:dynamodb:${Region}:${Account}:table/${Table}"
+                    - { Region: !Ref "AWS::Region", Account: !Ref "AWS::AccountId", Table: !Ref "PlutoProjectDynamoTable" }
   MediaAtomUser:
     Type: "AWS::IAM::User"
     Properties:
@@ -175,6 +178,19 @@ Resources:
             WriteCapacityUnits: "5"
 
   UploadTrackingDynamoTable:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: "id"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "id"
+          KeyType: "HASH"
+      ProvisionedThroughput:
+        ReadCapacityUnits: "5"
+        WriteCapacityUnits: "5"
+
+  PlutoProjectDynamoTable:
     Type: "AWS::DynamoDB::Table"
     Properties:
       AttributeDefinitions:

--- a/cloudformation/media-atom-maker-dev.yml
+++ b/cloudformation/media-atom-maker-dev.yml
@@ -10,6 +10,10 @@ Parameters:
   ConfigBucket:
     Description: "The S3 bucket where configuration lives"
     Type: "String"
+  App:
+    Description: "App name"
+    Type: "String"
+    Default: "media-atom-maker"
   Stack:
     Description: "Stack name"
     Type: "String"
@@ -193,6 +197,8 @@ Resources:
   PlutoProjectDynamoTable:
     Type: "AWS::DynamoDB::Table"
     Properties:
+      TableName: !Join ["-", [Ref: App, Ref: Stage, "pluto-projects-table"]]
+
       AttributeDefinitions:
         - AttributeName: "id"
           AttributeType: "S"

--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -155,6 +155,30 @@
         }
     },
     "Resources": {
+
+      "PlutoProjectDynamoTable": {
+        "Type": "AWS::DynamoDB::Table",
+        "Properties": {
+          "TableName": {"Fn::Join": ["-", [
+            {"Ref": "App"},
+            {"Ref": "Stage"},
+            "pluto-projects-table"
+          ]]},
+          "AttributeDefinitions": [{
+              "AttributeName": "id",
+              "AttributeType": "S"
+          }],
+          "KeySchema": [{
+              "AttributeName": "id",
+              "KeyType": "HASH"
+          }],
+          "ProvisionedThroughput": {
+            "ReadCapacityUnits": "5",
+            "WriteCapacityUnits": "5"
+          }
+        }
+      },
+
       "UploadsToPlutoStream": {
         "Type" : "AWS::Kinesis::Stream",
         "Properties": {
@@ -1027,6 +1051,13 @@
                             "Resource": {
                                 "Fn::Join": ["", ["arn:aws:dynamodb:", {"Ref": "AWS::Region"}, ":", {"Ref": "AWS::AccountId"}, ":table/", {"Ref": "ManualPlutoTable"} ] ]
                             }
+                        },
+                        {
+                          "Action": [ "dynamodb:*" ],
+                          "Effect": "Allow",
+                          "Resource": {
+                            "Fn::Join": ["", ["arn:aws:dynamodb:", {"Ref": "AWS::Region"}, ":", {"Ref": "AWS::AccountId"}, ":table/", {"Ref": "PlutoProjectDynamoTable"} ] ]
+                          }
                         }
                     ]
                 },

--- a/common/src/main/scala/com/gu/media/aws/AwsAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/AwsAccess.scala
@@ -20,6 +20,6 @@ trait AwsAccess { this: Settings =>
 
   // These are injected as environment variables when running in a Lambda (unfortunately they cannot be tagged)
   final val stack: Option[String] = readTag("Stack")
-  final val app: Option[String] = readTag("App")
+  final val app: String = readTag("App").getOrElse("media-atom-maker")
   final val stage: String = readTag("Stage").getOrElse("DEV")
 }

--- a/common/src/main/scala/com/gu/media/aws/DynamoAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/DynamoAccess.scala
@@ -12,6 +12,8 @@ trait DynamoAccess { this: Settings with AwsAccess =>
   )
   val manualPlutoDynamo = getMandatoryString("aws.dynamo.plutoTableName")
 
+  lazy val plutoProjectTableName: String = getMandatoryString("aws.dynamo.plutoProjectTableName")
+
   lazy val dynamoDB: AmazonDynamoDBClient = region.createClient(
     classOf[AmazonDynamoDBClient],
     credsProvider,

--- a/common/src/main/scala/com/gu/media/aws/DynamoAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/DynamoAccess.scala
@@ -12,7 +12,9 @@ trait DynamoAccess { this: Settings with AwsAccess =>
   )
   val manualPlutoDynamo = getMandatoryString("aws.dynamo.plutoTableName")
 
-  lazy val plutoProjectTableName: String = getMandatoryString("aws.dynamo.plutoProjectTableName")
+  private def getTableName(name: String): String = s"$app-$stage-$name-table"
+
+  lazy val plutoProjectTableName: String = getTableName("pluto-projects")
 
   lazy val dynamoDB: AmazonDynamoDBClient = region.createClient(
     classOf[AmazonDynamoDBClient],

--- a/common/src/main/scala/com/gu/media/logging/KinesisLogging.scala
+++ b/common/src/main/scala/com/gu/media/logging/KinesisLogging.scala
@@ -17,7 +17,6 @@ trait KinesisLogging { this: Settings with AwsAccess with CrossAccountAccess =>
 
     for {
       _stack <- stack
-      _app <- app
       stream <- getString("aws.kinesis.logging")
     } yield {
       rootLogger.info(s"bootstrapping kinesis appender with $stack -> $app -> $stage")
@@ -29,7 +28,7 @@ trait KinesisLogging { this: Settings with AwsAccess with CrossAccountAccess =>
       appender.setRegion(region.getName)
       appender.setStreamName(stream)
       appender.setContext(context)
-      appender.setLayout(Logging.layout(context, _stack, _app, stage))
+      appender.setLayout(Logging.layout(context, _stack, app, stage))
       appender.setCredentialsProvider(credentials)
       appender.start()
 

--- a/common/src/main/scala/com/gu/media/pluto/PlutoProject.scala
+++ b/common/src/main/scala/com/gu/media/pluto/PlutoProject.scala
@@ -3,7 +3,6 @@ package com.gu.media.pluto
 import org.cvogt.play.json.Jsonx
 import org.joda.time.DateTime
 import play.api.libs.json._
-import play.api.libs.functional.syntax._
 import com.gu.media.util.JsonDate._
 
 case class PlutoProject (
@@ -16,24 +15,5 @@ case class PlutoProject (
 )
 
 object PlutoProject {
-  implicit val plutoProjectReads: Reads[PlutoProject] = (
-    (JsPath \ "id").read[String] and
-    (JsPath \ "collectionId").read[String] and
-    (JsPath \ "headline").read[String] and
-    (JsPath \ "productionOffice").read[String] and
-    (JsPath \ "status").read[String] and
-    (JsPath \ "created").read[String].map(DateTime.parse)
-  )(PlutoProject.apply _)
-
-  implicit val plutoProjectWrites: Writes[PlutoProject] = (
-    (JsPath \ "id").write[String] and
-    (JsPath \ "collectionId").write[String] and
-    (JsPath \ "headline").write[String] and
-    (JsPath \ "productionOffice").write[String] and
-    (JsPath \ "status").write[String] and
-    (JsPath \ "created").write[String].contramap((_: DateTime).toString)
-  )(unlift(PlutoProject.unapply))
-
-
   implicit val format: Format[PlutoProject] = Jsonx.formatCaseClass[PlutoProject]
 }

--- a/common/src/main/scala/com/gu/media/pluto/PlutoProject.scala
+++ b/common/src/main/scala/com/gu/media/pluto/PlutoProject.scala
@@ -1,0 +1,39 @@
+package com.gu.media.pluto
+
+import org.cvogt.play.json.Jsonx
+import org.joda.time.DateTime
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import com.gu.media.util.JsonDate._
+
+case class PlutoProject (
+  id: String,
+  collectionId: String,
+  headline: String,
+  productionOffice: String,
+  status: String,
+  created: DateTime
+)
+
+object PlutoProject {
+  implicit val plutoProjectReads: Reads[PlutoProject] = (
+    (JsPath \ "id").read[String] and
+    (JsPath \ "collectionId").read[String] and
+    (JsPath \ "headline").read[String] and
+    (JsPath \ "productionOffice").read[String] and
+    (JsPath \ "status").read[String] and
+    (JsPath \ "created").read[String].map(DateTime.parse)
+  )(PlutoProject.apply _)
+
+  implicit val plutoProjectWrites: Writes[PlutoProject] = (
+    (JsPath \ "id").write[String] and
+    (JsPath \ "collectionId").write[String] and
+    (JsPath \ "headline").write[String] and
+    (JsPath \ "productionOffice").write[String] and
+    (JsPath \ "status").write[String] and
+    (JsPath \ "created").write[String].contramap((_: DateTime).toString)
+  )(unlift(PlutoProject.unapply))
+
+
+  implicit val format: Format[PlutoProject] = Jsonx.formatCaseClass[PlutoProject]
+}

--- a/common/src/main/scala/com/gu/media/pluto/PlutoProjectDataStore.scala
+++ b/common/src/main/scala/com/gu/media/pluto/PlutoProjectDataStore.scala
@@ -2,13 +2,16 @@ package com.gu.media.pluto
 
 import com.amazonaws.services.dynamodbv2.model.PutItemResult
 import com.gu.media.aws.DynamoAccess
+import com.gu.media.logging.Logging
 import com.gu.scanamo.syntax._
 import com.gu.scanamo.{Scanamo, Table}
 import com.gu.scanamo.DynamoFormat._
 import com.gu.scanamo.DynamoFormat
 import org.joda.time.{DateTime, DateTimeZone}
 
-class PlutoProjectDataStore(aws: DynamoAccess) {
+case class PlutoProjectDataStoreException(err: String) extends Exception(err)
+
+class PlutoProjectDataStore(aws: DynamoAccess) extends Logging {
   implicit val dateTimeFormat = DynamoFormat.coercedXmap[DateTime, String, IllegalArgumentException](
     DateTime.parse(_).withZone(DateTimeZone.UTC)
   )(_.toString)
@@ -30,6 +33,7 @@ class PlutoProjectDataStore(aws: DynamoAccess) {
   }
 
   def put(plutoProject: PlutoProject): PutItemResult = {
+    log.info(s"saving pluto project ${plutoProject.id}")
     val op = table.put(plutoProject)
     Scanamo.exec(aws.dynamoDB)(op)
   }
@@ -41,15 +45,22 @@ class PlutoProjectDataStore(aws: DynamoAccess) {
     result.map {
       case Right(project) => project
       case Left(err) => {
-        throw new Exception(err.toString)
+        log.info(s"pluto project $id not found")
+        throw PlutoProjectDataStoreException(err.toString)
       }
     }
   }
 
   def update(id: String, plutoProject: PlutoProject): Option[PutItemResult] = {
     get(id) match {
-      case Some(_) => Some(put(plutoProject))
-      case None => None
+      case Some(_) => {
+        log.info(s"updating pluto project $id")
+        Some(put(plutoProject))
+      }
+      case None => {
+        log.error(s"failed to update pluto project $id as it does not exist")
+        None
+      }
     }
   }
 }

--- a/common/src/main/scala/com/gu/media/pluto/PlutoProjectDataStore.scala
+++ b/common/src/main/scala/com/gu/media/pluto/PlutoProjectDataStore.scala
@@ -1,0 +1,55 @@
+package com.gu.media.pluto
+
+import com.amazonaws.services.dynamodbv2.model.PutItemResult
+import com.gu.media.aws.DynamoAccess
+import com.gu.scanamo.syntax._
+import com.gu.scanamo.{Scanamo, Table}
+import com.gu.scanamo.DynamoFormat._
+import com.gu.scanamo.DynamoFormat
+import org.joda.time.{DateTime, DateTimeZone}
+
+class PlutoProjectDataStore(aws: DynamoAccess) {
+  implicit val dateTimeFormat = DynamoFormat.coercedXmap[DateTime, String, IllegalArgumentException](
+    DateTime.parse(_).withZone(DateTimeZone.UTC)
+  )(_.toString)
+
+  private val table = Table[PlutoProject](aws.plutoProjectTableName)
+
+  def list(): List[PlutoProject] = {
+    val op = table.scan()
+    val results = Scanamo.exec(aws.dynamoDB)(op)
+
+    results.collect {
+      case Left(error) => {
+        throw new Exception(error.toString)
+      }
+      case Right(plutoProject) => {
+        plutoProject
+      }
+    }
+  }
+
+  def put(plutoProject: PlutoProject): PutItemResult = {
+    val op = table.put(plutoProject)
+    Scanamo.exec(aws.dynamoDB)(op)
+  }
+
+  def get(id: String): Option[PlutoProject] = {
+    val op = table.get('id -> id)
+    val result = Scanamo.exec(aws.dynamoDB)(op)
+
+    result.map {
+      case Right(project) => project
+      case Left(err) => {
+        throw new Exception(err.toString)
+      }
+    }
+  }
+
+  def update(id: String, plutoProject: PlutoProject): Option[PutItemResult] = {
+    get(id) match {
+      case Some(_) => Some(put(plutoProject))
+      case None => None
+    }
+  }
+}

--- a/common/src/main/scala/com/gu/media/pluto/PlutoProjectDataStore.scala
+++ b/common/src/main/scala/com/gu/media/pluto/PlutoProjectDataStore.scala
@@ -24,7 +24,8 @@ class PlutoProjectDataStore(aws: DynamoAccess) extends Logging {
 
     results.collect {
       case Left(error) => {
-        throw new Exception(error.toString)
+        log.error("failed to list pluto projects")
+        throw PlutoProjectDataStoreException(error.toString)
       }
       case Right(plutoProject) => {
         plutoProject

--- a/common/src/main/scala/com/gu/media/util/JsonDate.scala
+++ b/common/src/main/scala/com/gu/media/util/JsonDate.scala
@@ -1,0 +1,19 @@
+package com.gu.media.util
+
+import org.joda.time.format.ISODateTimeFormat
+import play.api.libs.json._
+import org.joda.time.DateTime
+
+object JsonDate {
+  implicit object DefaultJodaDateWrites extends Writes[org.joda.time.DateTime] {
+    def writes(d: org.joda.time.DateTime): JsValue = JsString(ISODateTimeFormat.dateTime.print(d))
+  }
+  implicit object DefaultJodaDateReads extends Reads[org.joda.time.DateTime] {
+    def reads(json: JsValue): JsResult[DateTime] = {
+      json match {
+        case JsString(dateTime) => JsSuccess(ISODateTimeFormat.dateTime.parseDateTime(dateTime))
+        case _ => JsError("DateTime can only be extracted from a JsString")
+      }
+    }
+  }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -30,10 +30,10 @@ GET     /api2/pluto                     controllers.Api2.getPlutoAtoms()
 
 DELETE  /api2/atom/:id                  controllers.Api2.deleteAtom(id)
 
-GET     /api2/pluto/projects            controllers.PlutoController.listProjects()
-GET     /api2/pluto/projects:id         controllers.PlutoController.getProject(id)
-POST    /api2/pluto/projects            controllers.PlutoController.createProject()
-PUT     /api2/pluto/projects/:id        controllers.PlutoController.updateProject(id)
+GET     /api2/pluto/projects            controllers.PlutoProjectController.listProjects()
+GET     /api2/pluto/projects:id         controllers.PlutoProjectController.getProject(id)
+POST    /api2/pluto/projects            controllers.PlutoProjectController.createProject()
+PUT     /api2/pluto/projects/:id        controllers.PlutoProjectController.updateProject(id)
 
 # user uploaded videos
 GET     /api2/uploads                   controllers.UploadController.list(atomId)

--- a/conf/routes
+++ b/conf/routes
@@ -28,8 +28,12 @@ PUT     /api2/atom/:id/pluto-id         controllers.Api2.setPlutoId(id)
 PUT     /api2/pluto/:id                 controllers.Api2.sendToPluto(id)
 GET     /api2/pluto                     controllers.Api2.getPlutoAtoms()
 
-
 DELETE  /api2/atom/:id                  controllers.Api2.deleteAtom(id)
+
+GET     /api2/pluto/projects            controllers.PlutoController.listProjects()
+GET     /api2/pluto/projects:id         controllers.PlutoController.getProject(id)
+POST    /api2/pluto/projects            controllers.PlutoController.createProject()
+PUT     /api2/pluto/projects/:id        controllers.PlutoController.updateProject(id)
 
 # user uploaded videos
 GET     /api2/uploads                   controllers.UploadController.list(atomId)
@@ -44,8 +48,6 @@ GET     /api/youtube/categories         controllers.Youtube.listCategories()
 GET     /api/youtube/channels           controllers.Youtube.listChannels()
 
 GET     /api/transcoder/jobStatus       controllers.Transcoder.jobStatus
-
-
 
 # reindex
 

--- a/conf/routes
+++ b/conf/routes
@@ -31,7 +31,7 @@ GET     /api2/pluto                     controllers.Api2.getPlutoAtoms()
 DELETE  /api2/atom/:id                  controllers.Api2.deleteAtom(id)
 
 GET     /api2/pluto/projects            controllers.PlutoProjectController.listProjects()
-GET     /api2/pluto/projects:id         controllers.PlutoProjectController.getProject(id)
+GET     /api2/pluto/projects/:id         controllers.PlutoProjectController.getProject(id)
 POST    /api2/pluto/projects            controllers.PlutoProjectController.createProject()
 PUT     /api2/pluto/projects/:id        controllers.PlutoProjectController.updateProject(id)
 

--- a/scripts/hmac/make-hmac-request.js
+++ b/scripts/hmac/make-hmac-request.js
@@ -60,6 +60,11 @@ function getData() {
       }
     }
 
+    if (! args.data && ! args.dataFile) {
+      // no data
+      resolve();
+    }
+
     if (args.data) {
       tryParse(args.data);
     }
@@ -73,8 +78,6 @@ function getData() {
         tryParse(rawData);
       });
     }
-
-    resolve({});
   });
 }
 


### PR DESCRIPTION
This PR is also a start of removing the extra dynamo stacks. The new table is defined in the main template and not `cat`ed to the config file in LaunchConfig. Instead, we look up instance tags and [craft the table name in code](https://github.com/guardian/media-atom-maker/pull/349/files#diff-939dbba1b8854def696be19ce74e7717R12) as its deterministic.