### PR TITLE
remove redundant file

### DIFF
--- a/cloudformation/README
+++ b/cloudformation/README
@@ -1,8 +1,0 @@
-# Cloud formation for Media Atom Maker
-
-# Dev
-You can convert the the YAML for the dev stack by using [a Yaml converter](https://github.com/guardian/yaml-to-json).
-
-    > ./create-dev-stack.sh <USERNAME> [AWS_PROFILE]
-
-If you don't have IAM / CreateStack permissions on your local AWS account, you will have to upload the JSON manually.


### PR DESCRIPTION
AWS supports yml templates now, so don't need to instruct how to convert