### PR TITLE
tiny optimisations in CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,9 +6,7 @@ machine:
 
 dependencies:
   pre:
-    - npm install -g gulp
     - npm install
-    - gulp js
     - wget -q https://dl.bintray.com/sbt/debian/sbt-0.13.13.deb
     - sudo dpkg -i sbt-0.13.13.deb
   cache_directories:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "gulp-uglify": "^2.0.0",
     "jsonlint": "^1.6.2",
     "lodash": "^4.17.4",
-    "moment": "^2.10.6",
     "node-sass": "^3.10.1",
     "properties-reader": "0.0.15",
     "react-hot-loader": "^3.0.0-beta.5",


### PR DESCRIPTION
gulp is used for the angular app. As we're no longer developing that app, there's no point running the steps in CI.

Also, remove `moment` from devDependencies as it exists (at a later version) in dependencies