### PR TITLE
New navigation states

### DIFF
--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -43,6 +43,14 @@ export default class Header extends React.Component {
     );
   }
 
+  renderVideoTitle() {
+    return (
+      <div className="flex-container">
+        <span className="header__video__title">{this.props.video.title}</span>
+      </div>
+    )
+  }
+
   renderFeedback() {
     return (
       <nav className="topbar__nav-link">
@@ -122,6 +130,10 @@ export default class Header extends React.Component {
           {this.renderProgress()}
           {this.renderHome()}
 
+          <div>
+            {this.renderVideoTitle()}
+          </div>
+
           <VideoPublishBar className="flex-grow"
             video={this.props.video}
             publishedVideo={this.props.publishedVideo}
@@ -130,8 +142,6 @@ export default class Header extends React.Component {
 
           <div className="flex-container">
             {this.renderAuditLink()}
-            {this.renderFeedback()}
-            {this.renderHowTo()}
           </div>
 
         </header>

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -18,10 +18,17 @@ export default class Header extends React.Component {
     }
   }
 
-  renderHomeAndSearch() {
+  renderHome() {
     return (
       <div className="flex-container topbar__global">
         <Link to="/" className="topbar__home-link" title="Home"></Link>
+      </div>
+    );
+  }
+
+  renderSearch() {
+    return (
+      <div className="flex-container topbar__global">
         <VideoSearch {...this.props}/>
       </div>
     );
@@ -74,7 +81,7 @@ export default class Header extends React.Component {
   renderCreateVideo() {
     return (
       <nav className="topbar__nav-link">
-        <Link className="button__secondary" to="/videos/create">
+        <Link className="btn" to="/videos/create">
           <Icon icon="add">Create new video</Icon>
         </Link>
       </nav>
@@ -93,14 +100,18 @@ export default class Header extends React.Component {
         <header className="topbar flex-container">
           {this.renderProgress()}
 
-          {this.renderHomeAndSearch()}
+          {this.renderHome()}
+          {this.renderSearch()}
 
           <div className="flex-spacer"></div>
+
+        <div className="flex-container">
+            {this.renderCreateVideo()}
+          </div>
 
           <div className="flex-container">
             {this.renderFeedback()}
             {this.renderHowTo()}
-            {this.renderCreateVideo()}
           </div>
 
         </header>
@@ -109,7 +120,7 @@ export default class Header extends React.Component {
       return (
         <header className="topbar flex-container">
           {this.renderProgress()}
-          {this.renderHomeAndSearch()}
+          {this.renderHome()}
 
           <VideoPublishBar className="flex-grow"
             video={this.props.video}
@@ -121,7 +132,6 @@ export default class Header extends React.Component {
             {this.renderAuditLink()}
             {this.renderFeedback()}
             {this.renderHowTo()}
-            {this.renderCreateVideo()}
           </div>
 
         </header>

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {Link} from 'react-router';
 import VideoSearch from './VideoSearch/VideoSearch';
 import VideoPublishBar from './VideoPublishBar/VideoPublishBar';
+import VideoUpload from './VideoUpload/VideoUpload';
 import Icon from './Icon';
 
 export default class Header extends React.Component {
@@ -25,6 +26,15 @@ export default class Header extends React.Component {
         <VideoSearch {...this.props}/>
       </div>
     );
+  }
+
+  renderHeaderBack() {
+    return (
+      <div className="flex-container topbar__global">
+        <Link to={`/videos/${this.props.video.id}`} className="button" title="Back"><Icon className="icon icon__back" icon="keyboard_arrow_left"></Icon></Link>
+        <span>Edit Videos</span>
+      </div>
+    )
   }
 
   renderFeedback() {
@@ -73,8 +83,13 @@ export default class Header extends React.Component {
   }
 
   render () {
-
-    if (!this.props.showPublishedState) {
+    if (this.props.currentPath.endsWith("/upload")){
+      return (
+        <header className="topbar flex-container">
+          {this.renderHeaderBack()}
+        </header>
+      )
+    } if (!this.props.showPublishedState) {
       return (
         <header className="topbar flex-container">
           {this.renderProgress()}

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -38,7 +38,7 @@ export default class Header extends React.Component {
     return (
       <div className="flex-container topbar__global">
         <Link to={`/videos/${this.props.video.id}`} className="button" title="Back"><Icon className="icon icon__back" icon="keyboard_arrow_left"></Icon></Link>
-        <span>Edit Videos</span>
+        <span className="header__video__title">{this.props.video.title}</span>
       </div>
     );
   }

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -100,6 +100,7 @@ export default class Header extends React.Component {
     if (this.props.currentPath.endsWith("/upload")){
       return (
         <header className="topbar flex-container">
+          {this.renderProgress()}
           {this.renderHeaderBack()}
         </header>
       );

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {Link} from 'react-router';
 import VideoSearch from './VideoSearch/VideoSearch';
 import VideoPublishBar from './VideoPublishBar/VideoPublishBar';
-import VideoUpload from './VideoUpload/VideoUpload';
 import Icon from './Icon';
 
 export default class Header extends React.Component {
@@ -34,7 +33,7 @@ export default class Header extends React.Component {
         <Link to={`/videos/${this.props.video.id}`} className="button" title="Back"><Icon className="icon icon__back" icon="keyboard_arrow_left"></Icon></Link>
         <span>Edit Videos</span>
       </div>
-    )
+    );
   }
 
   renderFeedback() {
@@ -88,7 +87,7 @@ export default class Header extends React.Component {
         <header className="topbar flex-container">
           {this.renderHeaderBack()}
         </header>
-      )
+      );
     } if (!this.props.showPublishedState) {
       return (
         <header className="topbar flex-container">

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -48,7 +48,7 @@ export default class Header extends React.Component {
       <div className="flex-container">
         <span className="header__video__title">{this.props.video.title}</span>
       </div>
-    )
+    );
   }
 
   renderFeedback() {

--- a/public/video-ui/src/components/ReactApp.js
+++ b/public/video-ui/src/components/ReactApp.js
@@ -43,6 +43,7 @@ class ReactApp extends React.Component {
           <Header
             updateSearchTerm={this.updateSearchTerm}
             searchTerm={this.props.searchTerm}
+            currentPath={this.props.location.pathname}
             video={this.props.video || {}}
             publishedVideo={this.props.publishedVideo || {}}
             showPublishedState={this.props.params.id ? true : false}

--- a/public/video-ui/styles/components/_buttons.scss
+++ b/public/video-ui/styles/components/_buttons.scss
@@ -9,6 +9,9 @@ button {
   border: 0;
   background: transparent;
   padding: 0;
+  a {
+    text-decoration: none;
+  }
 }
 
 .button__secondary {

--- a/public/video-ui/styles/components/_header.scss
+++ b/public/video-ui/styles/components/_header.scss
@@ -33,3 +33,11 @@
 .label__frontpage__overlay {
   width: 70px;
 }
+
+.header__video__title {
+  width: 300px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-right: 10px;
+}

--- a/public/video-ui/styles/components/_header.scss
+++ b/public/video-ui/styles/components/_header.scss
@@ -35,7 +35,7 @@
 }
 
 .header__video__title {
-  width: 300px;
+  width: 250px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/public/video-ui/styles/layout/_icons.scss
+++ b/public/video-ui/styles/layout/_icons.scss
@@ -10,6 +10,7 @@
     text-transform: none;
     letter-spacing: normal;
     word-wrap: normal;
+    text-decoration: none;
 
     /* Support for all WebKit browsers. */
     -webkit-font-smoothing: antialiased;
@@ -24,6 +25,10 @@
 
   &--text {
     margin-left: 5px;
+  }
+
+  &:link {
+    text-decoration: none;
   }
 }
 
@@ -61,6 +66,24 @@
 
 .icon__spacing {
   margin-right: 5px;
+}
+
+.icon__back {
+  background-color: $brandColor;
+  color: $color800Grey;
+  border-radius: 50%;
+  width: 30px;
+  height: 30px;
+  font-size: 26px;
+  cursor: pointer;
+  display:flex;
+  justify-content:center;
+  align-items: center;
+  margin: 10px;
+
+  &:hover {
+    background-color: darken($brandColor, 10%);
+  }
 }
 
 .icon__done {

--- a/public/video-ui/styles/layout/_icons.scss
+++ b/public/video-ui/styles/layout/_icons.scss
@@ -1,8 +1,6 @@
 .icon {
     font-family: 'Material Icons';
-    font-weight: normal;
     font-style: normal;
-    font-size: $iconSize;
     display: inline-block;
     width: 1em;
     height: 1em;
@@ -38,6 +36,7 @@
   background-color: $color600Grey;
   width: 33px;
   height: 33px;
+  font-size: $iconSize;
   cursor: pointer;
   display:flex;
   justify-content:center;
@@ -74,12 +73,12 @@
   border-radius: 50%;
   width: 30px;
   height: 30px;
-  font-size: 26px;
+  font-size: 24px;
   cursor: pointer;
   display:flex;
   justify-content:center;
   align-items: center;
-  margin: 10px;
+  margin: 10px 20px 10px 10px;
 
   &:hover {
     background-color: darken($brandColor, 10%);
@@ -88,6 +87,7 @@
 
 .icon__done {
   background-color: $brandColor;
+  font-size: $iconSize;
   color: $color800Grey;
   &:hover {
     background-color: darken($brandColor, 5%);

--- a/public/video-ui/styles/layout/_topbar.scss
+++ b/public/video-ui/styles/layout/_topbar.scss
@@ -26,10 +26,6 @@ $topbarHeight: 50px;
   text-decoration: none;
 }
 
-.topbar__global {
-  margin-right: 20px;
-}
-
 .topbar__functional {
   margin-left: 20px;
 }

--- a/public/video-ui/styles/layout/_topbar.scss
+++ b/public/video-ui/styles/layout/_topbar.scss
@@ -55,3 +55,9 @@ $topbarHeight: 50px;
   height: 2px;
   top: 49px // covering 1px border, otherwise would be 50px :)
 }
+
+.topbar__back-link {
+  width: $topbarHeight;
+  height: $topbarHeight;
+  margin-right: 0;
+}

--- a/public/video-ui/styles/layout/_topbar.scss
+++ b/public/video-ui/styles/layout/_topbar.scss
@@ -26,6 +26,10 @@ $topbarHeight: 50px;
   text-decoration: none;
 }
 
+.topbar__global {
+  margin-right: 10px;
+}
+
 .topbar__functional {
   margin-left: 20px;
 }

--- a/public/video-ui/styles/layout/_upload.scss
+++ b/public/video-ui/styles/layout/_upload.scss
@@ -54,7 +54,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-
+      height: 180px;
       color: white;
 
       img {

--- a/public/video-ui/styles/layout/_upload.scss
+++ b/public/video-ui/styles/layout/_upload.scss
@@ -54,7 +54,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      height: 180px;
+      height: 150px;
       color: white;
 
       img {

--- a/public/video-ui/styles/vendor/_normalize.scss
+++ b/public/video-ui/styles/vendor/_normalize.scss
@@ -105,6 +105,7 @@ pre {
 a {
   background-color: transparent; /* 1 */
   -webkit-text-decoration-skip: objects; /* 2 */
+  text-decoration: none;
 }
 
 /**


### PR DESCRIPTION
PR now rebased with https://github.com/guardian/media-atom-maker/pull/339

So with the addition of the Upload assets page I wanted to address the state of the navigation, to make where the editor is clearer and avoid adding too much extra guff to the page.

I've split it into 3 layers:
Layer one is the homepage - 
![image](https://cloud.githubusercontent.com/assets/2067172/24542833/153758a8-15f5-11e7-9cec-97baca218704.png)

Layer two is the edit page
![image](https://cloud.githubusercontent.com/assets/2067172/24542849/222e08b8-15f5-11e7-8758-f908ff497fb3.png)

Layer three is the upload asset to the edit page
![image](https://cloud.githubusercontent.com/assets/2067172/24542857/2dc7c77c-15f5-11e7-957f-fbbefbd7c7d3.png)


Plus a gif 'cause I wanted to do one.
![vam_navigation](https://cloud.githubusercontent.com/assets/2067172/24542822/07a1c73c-15f5-11e7-873f-5f359acec844.gif)


Have a look and see what you think about the choices of what's visible. Not everything is visible on every state and that is by design.