### PR TITLE
Fix upload lambda error on pluto table setting

### DIFF
--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -616,7 +616,8 @@
                 "STAGE": { "Ref": "Stage" },
                 "CONFIG_BUCKET": { "Ref": "ConfigBucket" },
                 "CONFIG_KEY": { "Fn::FindInMap": [ "LambdaConfig", "Uploader", { "Ref": "Stage" }] },
-                "UPLOAD_TRACKING_TABLE_NAME": { "Ref": "UploadTrackingTable" }
+                "UPLOAD_TRACKING_TABLE_NAME": { "Ref": "UploadTrackingTable" },
+                "PLUTO_TABLE_NAME": { "Ref": "ManualPlutoTable" }
               }
             },
             "MemorySize": 512,

--- a/common/src/main/scala/com/gu/media/aws/DynamoAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/DynamoAccess.scala
@@ -7,10 +7,14 @@ trait DynamoAccess { this: Settings with AwsAccess =>
   lazy val dynamoTableName: String = getMandatoryString("aws.dynamo.tableName")
   lazy val publishedDynamoTableName: String = getMandatoryString("aws.dynamo.publishedTableName")
   lazy val auditDynamoTableName: String = getMandatoryString("aws.dynamo.auditTableName")
+
   lazy val uploadTrackingTableName: String = sys.env.getOrElse("UPLOAD_TRACKING_TABLE_NAME",
     getMandatoryString("aws.dynamo.uploadTrackingTableName")
   )
-  lazy val manualPlutoDynamo = getMandatoryString("aws.dynamo.plutoTableName")
+
+  lazy val manualPlutoDynamo: String = sys.env.getOrElse("PLUTO_TABLE_NAME",
+    getMandatoryString("aws.dynamo.plutoTableName")
+  )
 
   private def getTableName(name: String): String = s"$app-$stage-$name-table"
 

--- a/common/src/main/scala/com/gu/media/aws/DynamoAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/DynamoAccess.scala
@@ -10,7 +10,7 @@ trait DynamoAccess { this: Settings with AwsAccess =>
   lazy val uploadTrackingTableName: String = sys.env.getOrElse("UPLOAD_TRACKING_TABLE_NAME",
     getMandatoryString("aws.dynamo.uploadTrackingTableName")
   )
-  val manualPlutoDynamo = getMandatoryString("aws.dynamo.plutoTableName")
+  lazy val manualPlutoDynamo = getMandatoryString("aws.dynamo.plutoTableName")
 
   private def getTableName(name: String): String = s"$app-$stage-$name-table"
 

--- a/common/src/main/scala/com/gu/media/upload/actions/UploadActionHandler.scala
+++ b/common/src/main/scala/com/gu/media/upload/actions/UploadActionHandler.scala
@@ -1,6 +1,6 @@
 package com.gu.media.upload.actions
 
-import com.amazonaws.services.s3.model.{CompleteMultipartUploadRequest, CopyPartRequest, InitiateMultipartUploadRequest, PartETag}
+import com.amazonaws.services.s3.model._
 import com.gu.media.PlutoDataStore
 import com.gu.media.logging.Logging
 import com.gu.media.ses.Mailer
@@ -43,7 +43,7 @@ abstract class UploadActionHandler(store: UploadsDataStore, plutoStore: PlutoDat
     val UploadPart(key, start, end) = part
     val total = upload.parts.last.end
 
-    if(s3.doesObjectExist(bucket, key.toString)) {
+    if(objectExists(key.toString)) {
       val input = s3.getObject(bucket, key.toString).getObjectContent
 
       youTube.uploadPart(uploadUri, input, start, end, total) match {
@@ -128,5 +128,13 @@ abstract class UploadActionHandler(store: UploadsDataStore, plutoStore: PlutoDat
           log.warn(s"Unable to delete part $part: $err")
       }
     }
+  }
+
+  private def objectExists(key: String) = try {
+    s3.doesObjectExist(bucket, key)
+  } catch {
+    case e: AmazonS3Exception =>
+      log.error(s"Error checking $key", e)
+      false
   }
 }

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeUploader.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeUploader.scala
@@ -49,11 +49,6 @@ class YouTubeUploader(aws: UploaderAccess, youTube: YouTubeAccess) {
     response.header("Location")
   }
 
-  def uploadPart(uri: String, key: String, start: Long, end: Long, total: Long): Option[String] = {
-    val input = aws.s3Client.getObject(aws.userUploadBucket, key.toString).getObjectContent
-    uploadPart(uri, input, start, end, total)
-  }
-
   def uploadPart(uri: String, input: InputStream, start: Long, end: Long, total: Long): Option[String] = {
     val size = end - start
     // end index is inclusive in direct contradiction to programming history (and my end variable)

--- a/public/video-ui/styles/layout/_upload.scss
+++ b/public/video-ui/styles/layout/_upload.scss
@@ -68,6 +68,7 @@
 
     &__running {
       background-color: $color900Grey;
+      height: 140px;
 
       span {
         position: absolute;


### PR DESCRIPTION
The direct upload lambdas in CODE and PROD are failing with:

```
Missing aws.dynamo.plutoTableName : java.lang.IllegalArgumentException
```

This is because the setting is not present in the config file but is injected into the main app as part of the start script in cloud formation.

There is an upcoming PR from @akash1810 to fix this and put the settings into the file. This is just a stop gap PR to get the uploads back up and running.