### PR TITLE
Revert "remove gulp from CI"

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,9 @@ machine:
 
 dependencies:
   pre:
+    - npm install -g gulp
     - npm install
+    - gulp js
     - wget -q https://dl.bintray.com/sbt/debian/sbt-0.13.13.deb
     - sudo dpkg -i sbt-0.13.13.deb
   cache_directories:


### PR DESCRIPTION
This reverts commit 69516043cfca07c0e100ba2aadddbeae04b04b07 because the old UI used by Labs is 404ing on `assets/dist/javascripts.js ` 😱 