### PR TITLE
Missing kinesis permission for uploads

### DIFF
--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -598,6 +598,26 @@
           }
         },
 
+        "UploadActionsStreamPolicy": {
+          "Type": "AWS::IAM::Policy",
+          "Properties": {
+            "PolicyName": "UploadActionsStreamPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "kinesis:PutRecord",
+                    "kinesis:PutRecords"
+                  ],
+                  "Resource": {"Fn::GetAtt": ["UploadActionsStream", "Arn"]}
+                }
+              ]
+            },
+            "Roles": [{"Ref": "DistributionRole"}]
+          }
+        },
+
         "UploadActionsLambda": {
           "Type": "AWS::Lambda::Function",
           "Properties": {


### PR DESCRIPTION
I had added this permission manually in CODE and forgotten about it, so the uploads then didn't work when deployed to PROD.

I have updated both cloud formations already, this is just to get it in the repo.