### PR TITLE
Add asset and delete atom permissions

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -6,6 +6,7 @@ import com.gu.atom.data._
 import com.gu.atom.play._
 import com.gu.contentatom.thrift.atom.media.Category.Hosted
 import com.gu.contentatom.thrift.{Atom, ContentAtomEvent, EventType}
+import com.gu.editorial.permissions.client.PermissionsProvider
 import com.gu.pandahmac.HMACAuthActions
 import data.DataStores
 import data.JsonConversions._
@@ -22,7 +23,8 @@ import scala.util.{Failure, Success}
 class Api (override val stores: DataStores,
            val conf: Configuration,
            val awsConfig: AWSConfig,
-           val authActions: HMACAuthActions)
+           val authActions: HMACAuthActions,
+           val permissions: PermissionsProvider)
     extends AtomController
     with MediaAtomImplicits
     with AtomAPIActions {

--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -2,9 +2,9 @@ package controllers
 
 import _root_.util.AWSConfig
 import com.gu.atom.play.AtomAPIActions
-import com.gu.media.upload.model.PlutoSyncMetadata
-import com.gu.media.Permissions
+import com.gu.media.MamPermissionsProvider
 import com.gu.media.logging.Logging
+import com.gu.media.upload.model.PlutoSyncMetadata
 import com.gu.media.youtube.YouTube
 import com.gu.pandahmac.HMACAuthActions
 import com.gu.pandomainauth.action.UserRequest
@@ -14,15 +14,15 @@ import model.MediaAtom
 import model.commands.CommandExceptions._
 import model.commands._
 import play.api.Configuration
+import play.api.libs.concurrent.Execution.Implicits._
 import util.atom.MediaAtomImplicits
 import play.api.libs.json._
 import play.api.mvc.{AnyContent, Result}
-import play.api.libs.concurrent.Execution.Implicits._
 
 import scala.concurrent.Future
 
-class Api2 (override val stores: DataStores, conf: Configuration, val authActions: HMACAuthActions,
-            youTube: YouTube, awsConfig: AWSConfig)
+class Api2 (override val stores: DataStores, conf: Configuration, val authActions: HMACAuthActions, youTube: YouTube,
+            awsConfig: AWSConfig, permissions: MamPermissionsProvider)
 
   extends MediaAtomImplicits
     with AtomAPIActions
@@ -136,7 +136,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, val authAction
   }
 
   def deleteAtom(id: String) = APIHMACAuthAction.async { implicit req =>
-    Permissions.canDeleteAtom(req.user.email).map {
+    permissions.canDeleteAtom(req.user.email).map {
       case true =>
         try {
           DeleteCommand(id, stores).process()
@@ -152,7 +152,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, val authAction
   }
 
   private def withAddAssetPermission(req: UserRequest[AnyContent])(fn: => Result): Future[Result] = {
-    Permissions.canAddAsset(req.user.email).map {
+    permissions.canAddAsset(req.user.email).map {
       case true =>
         fn
 

--- a/app/controllers/MainApp.scala
+++ b/app/controllers/MainApp.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import com.gu.editorial.permissions.client.PermissionsProvider
 import com.gu.pandahmac.HMACAuthActions
 import com.gu.pandomainauth.service.GoogleAuthException
 import data.DataStores
@@ -14,7 +15,8 @@ import scala.concurrent.Future
 class MainApp (override val stores: DataStores,
                wsClient: WSClient,
                conf: Configuration,
-               val authActions: HMACAuthActions)
+               val authActions: HMACAuthActions,
+               val permissions: PermissionsProvider)
     extends AtomController {
 
   import authActions.{AuthAction, processGoogleCallback}

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -161,8 +161,8 @@ class UploadController(val authActions: HMACAuthActions, awsConfig: AWSConfig, y
   }
 
   private def withPermission(req: UserRequest[AnyContent])(fn: => Result): Future[Result] = {
-    Permissions.forUser(req.user.email).map {
-      case perms if perms.directUpload =>
+    Permissions.canAddAsset(req.user.email).map {
+      case true =>
         fn
 
       case _ =>

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import java.util.UUID
 
-import com.gu.media.Permissions
+import com.gu.media.MamPermissionsProvider
 import com.gu.media.logging.Logging
 import com.gu.media.upload._
 import com.gu.media.upload.actions.{CopyParts, DeleteParts, UploadActionSender, UploadPartToYouTube}
@@ -16,15 +16,15 @@ import data.{DataStores, UnpackedDataStores}
 import _root_.model.MediaAtom
 import _root_.model.commands.CommandExceptions._
 import org.cvogt.play.json.Jsonx
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.{Format, Json}
 import play.api.mvc.{AnyContent, Controller, Result}
-import play.api.libs.concurrent.Execution.Implicits._
 import util.AWSConfig
 
 import scala.concurrent.Future
 
 class UploadController(val authActions: HMACAuthActions, awsConfig: AWSConfig, youTube: YouTubeAccess,
-                       uploadActions: UploadActionSender, override val stores: DataStores)
+                       uploadActions: UploadActionSender, permissions: MamPermissionsProvider, override val stores: DataStores)
 
   extends Controller with Logging with JsonRequestParsing with UnpackedDataStores {
 
@@ -161,7 +161,7 @@ class UploadController(val authActions: HMACAuthActions, awsConfig: AWSConfig, y
   }
 
   private def withPermission(req: UserRequest[AnyContent])(fn: => Result): Future[Result] = {
-    Permissions.canAddAsset(req.user.email).map {
+    permissions.canAddAsset(req.user.email).map {
       case true =>
         fn
 

--- a/app/controllers/VideoUIApp.scala
+++ b/app/controllers/VideoUIApp.scala
@@ -35,8 +35,7 @@ class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfi
         composerUrl = composerUrl,
         ravenUrl = conf.getString("raven.url").get,
         stage = conf.getString("stage").get,
-        viewerUrl = awsConfig.viewerUrl,
-        showAssetsPageButton = permissions.directUpload
+        viewerUrl = awsConfig.viewerUrl
       )
 
       Ok(views.html.VideoUIApp.app("Media Atom Maker", jsLocation, Json.toJson(clientConfig).toString()))

--- a/app/controllers/VideoUIApp.scala
+++ b/app/controllers/VideoUIApp.scala
@@ -24,7 +24,7 @@ class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfi
 
     val composerUrl = awsConfig.composerUrl
 
-    Permissions.forUser(req.user.email).map { permissions =>
+    Permissions.canDeleteAtom(req.user.email).map { canDeleteAtom =>
       val clientConfig = ClientConfig(
         username = req.user.email,
         youtubeEmbedUrl = "https://www.youtube.com/embed/",
@@ -35,7 +35,8 @@ class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfi
         composerUrl = composerUrl,
         ravenUrl = conf.getString("raven.url").get,
         stage = conf.getString("stage").get,
-        viewerUrl = awsConfig.viewerUrl
+        viewerUrl = awsConfig.viewerUrl,
+        canDeleteAtom = canDeleteAtom
       )
 
       Ok(views.html.VideoUIApp.app("Media Atom Maker", jsLocation, Json.toJson(clientConfig).toString()))

--- a/app/controllers/VideoUIApp.scala
+++ b/app/controllers/VideoUIApp.scala
@@ -24,7 +24,7 @@ class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfi
 
     val composerUrl = awsConfig.composerUrl
 
-    Permissions.canDeleteAtom(req.user.email).map { canDeleteAtom =>
+    Permissions.get(req.user.email).map { permissions =>
       val clientConfig = ClientConfig(
         username = req.user.email,
         youtubeEmbedUrl = "https://www.youtube.com/embed/",
@@ -36,7 +36,7 @@ class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfi
         ravenUrl = conf.getString("raven.url").get,
         stage = conf.getString("stage").get,
         viewerUrl = awsConfig.viewerUrl,
-        canDeleteAtom = canDeleteAtom
+        permissions
       )
 
       Ok(views.html.VideoUIApp.app("Media Atom Maker", jsLocation, Json.toJson(clientConfig).toString()))

--- a/app/controllers/VideoUIApp.scala
+++ b/app/controllers/VideoUIApp.scala
@@ -1,7 +1,7 @@
 package controllers
 
 
-import com.gu.media.MamPermissionsProvider
+import com.gu.media.MediaAtomMakerPermissionsProvider
 import com.gu.pandahmac.HMACAuthActions
 import model.ClientConfig
 import play.api.Configuration
@@ -11,7 +11,7 @@ import play.api.mvc.Controller
 import util.AWSConfig
 
 class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfig: AWSConfig,
-                 permissions: MamPermissionsProvider) extends Controller {
+                 permissions: MediaAtomMakerPermissionsProvider) extends Controller {
   import authActions.AuthAction
 
   def index(id: String = "") = AuthAction.async { req =>

--- a/app/controllers/VideoUIApp.scala
+++ b/app/controllers/VideoUIApp.scala
@@ -1,16 +1,17 @@
 package controllers
 
 
-import com.gu.media.Permissions
+import com.gu.media.MamPermissionsProvider
 import com.gu.pandahmac.HMACAuthActions
 import model.ClientConfig
 import play.api.Configuration
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
 import play.api.mvc.Controller
-import play.api.libs.concurrent.Execution.Implicits._
 import util.AWSConfig
 
-class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfig: AWSConfig) extends Controller {
+class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfig: AWSConfig,
+                 permissions: MamPermissionsProvider) extends Controller {
   import authActions.AuthAction
 
   def index(id: String = "") = AuthAction.async { req =>
@@ -24,7 +25,9 @@ class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfi
 
     val composerUrl = awsConfig.composerUrl
 
-    Permissions.get(req.user.email).map { permissions =>
+    permissions.getAll(req.user.email).map { permissions =>
+      println(permissions)
+
       val clientConfig = ClientConfig(
         username = req.user.email,
         youtubeEmbedUrl = "https://www.youtube.com/embed/",

--- a/app/controllers/VideoUIApp.scala
+++ b/app/controllers/VideoUIApp.scala
@@ -26,8 +26,6 @@ class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfi
     val composerUrl = awsConfig.composerUrl
 
     permissions.getAll(req.user.email).map { permissions =>
-      println(permissions)
-
       val clientConfig = ClientConfig(
         username = req.user.email,
         youtubeEmbedUrl = "https://www.youtube.com/embed/",

--- a/app/di.scala
+++ b/app/di.scala
@@ -1,8 +1,8 @@
 import com.gu.atom.play.ReindexController
-import com.gu.media.{CapiPreview, MamPermissionsProvider}
-import com.gu.media.upload.actions.KinesisActionSender
 import com.gu.media.ses.Mailer
+import com.gu.media.upload.actions.KinesisActionSender
 import com.gu.media.youtube.YouTube
+import com.gu.media.{CapiPreview, MediaAtomMakerPermissionsProvider}
 import controllers._
 import data._
 import play.api.ApplicationLoader.Context
@@ -11,7 +11,7 @@ import play.api.inject.DefaultApplicationLifecycle
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.{Application, ApplicationLoader, BuiltInComponentsFromContext, LoggerConfigurator}
 import router.Routes
-import util.{PlutoMessageConsumer, AWSConfig, DevUploadHandler, DevUploadSender}
+import util.{AWSConfig, DevUploadHandler, DevUploadSender, PlutoMessageConsumer}
 
 class MediaAtomMakerLoader extends ApplicationLoader {
   override def load(context: Context): Application = new MediaAtomMaker(context).application
@@ -35,7 +35,7 @@ class MediaAtomMaker(context: Context)
   private val capi = new CapiPreview(config)
 
   private val stores = new DataStores(aws, capi)
-  private val permissions = new MamPermissionsProvider(aws.stage, aws.credsProvider)
+  private val permissions = new MediaAtomMakerPermissionsProvider(aws.stage, aws.credsProvider)
 
   private val reindexer = buildReindexer()
 
@@ -46,12 +46,12 @@ class MediaAtomMaker(context: Context)
   private val uploaderMessageConsumer = PlutoMessageConsumer(stores, aws)
   uploaderMessageConsumer.start(actorSystem.scheduler)(actorSystem.dispatcher)
 
-  private val api = new Api(stores, configuration, aws, hmacAuthActions)
+  private val api = new Api(stores, configuration, aws, hmacAuthActions, permissions)
 
   private val api2 = new Api2(stores, configuration, hmacAuthActions, youTube, aws, permissions)
 
   private val uploadSender = buildUploadSender()
-  private val uploads = new UploadController(hmacAuthActions, aws, youTube, uploadSender, permissions, stores)
+  private val uploads = new UploadController(hmacAuthActions, aws, youTube, uploadSender, stores, permissions)
 
   private val support = new Support(hmacAuthActions, capi)
   private val youTubeController = new controllers.Youtube(hmacAuthActions, youTube, defaultCacheApi)
@@ -61,7 +61,7 @@ class MediaAtomMaker(context: Context)
   private val transcoder = new util.Transcoder(aws, defaultCacheApi)
   private val transcoderController = new controllers.Transcoder(hmacAuthActions, transcoder)
 
-  private val mainApp = new MainApp(stores, wsClient, configuration, hmacAuthActions)
+  private val mainApp = new MainApp(stores, wsClient, configuration, hmacAuthActions, permissions)
   private val videoApp = new VideoUIApp(hmacAuthActions, configuration, aws, permissions)
 
   private val assets = new controllers.Assets(httpErrorHandler)

--- a/app/di.scala
+++ b/app/di.scala
@@ -1,6 +1,5 @@
 import com.gu.atom.play.ReindexController
-import com.gu.media.CapiPreview
-import com.gu.media.upload.UploadsDataStore
+import com.gu.media.{CapiPreview, MamPermissionsProvider}
 import com.gu.media.upload.actions.KinesisActionSender
 import com.gu.media.ses.Mailer
 import com.gu.media.youtube.YouTube
@@ -36,6 +35,8 @@ class MediaAtomMaker(context: Context)
   private val capi = new CapiPreview(config)
 
   private val stores = new DataStores(aws, capi)
+  private val permissions = new MamPermissionsProvider(aws.stage, aws.credsProvider)
+
   private val reindexer = buildReindexer()
 
   private val youTube = new YouTube(config)
@@ -47,10 +48,10 @@ class MediaAtomMaker(context: Context)
 
   private val api = new Api(stores, configuration, aws, hmacAuthActions)
 
-  private val api2 = new Api2(stores, configuration, hmacAuthActions, youTube, aws)
+  private val api2 = new Api2(stores, configuration, hmacAuthActions, youTube, aws, permissions)
 
   private val uploadSender = buildUploadSender()
-  private val uploads = new UploadController(hmacAuthActions, aws, youTube, uploadSender, stores)
+  private val uploads = new UploadController(hmacAuthActions, aws, youTube, uploadSender, permissions, stores)
 
   private val support = new Support(hmacAuthActions, capi)
   private val youTubeController = new controllers.Youtube(hmacAuthActions, youTube, defaultCacheApi)
@@ -61,7 +62,7 @@ class MediaAtomMaker(context: Context)
   private val transcoderController = new controllers.Transcoder(hmacAuthActions, transcoder)
 
   private val mainApp = new MainApp(stores, wsClient, configuration, hmacAuthActions)
-  private val videoApp = new VideoUIApp(hmacAuthActions, configuration, aws)
+  private val videoApp = new VideoUIApp(hmacAuthActions, configuration, aws, permissions)
 
   private val assets = new controllers.Assets(httpErrorHandler)
 

--- a/app/model/ClientConfig.scala
+++ b/app/model/ClientConfig.scala
@@ -14,7 +14,8 @@ case class ClientConfig(username: String,
                         composerUrl: String,
                         ravenUrl: String,
                         stage: String,
-                        viewerUrl: String
+                        viewerUrl: String,
+                        showAssetsPageButton: Boolean
                        )
 
 object ClientConfig {

--- a/app/model/ClientConfig.scala
+++ b/app/model/ClientConfig.scala
@@ -14,7 +14,8 @@ case class ClientConfig(username: String,
                         composerUrl: String,
                         ravenUrl: String,
                         stage: String,
-                        viewerUrl: String
+                        viewerUrl: String,
+                        canDeleteAtom: Boolean // also validated server-side on every delete request
                        )
 
 object ClientConfig {

--- a/app/model/ClientConfig.scala
+++ b/app/model/ClientConfig.scala
@@ -1,9 +1,7 @@
 package model
 
+import com.gu.media.Permissions
 import org.cvogt.play.json.Jsonx
-import play.api.libs.functional.syntax._
-import play.api.libs.json.Json
-import scala.concurrent.{Future}
 
 case class ClientConfig(username: String,
                         youtubeEmbedUrl: String,
@@ -15,7 +13,8 @@ case class ClientConfig(username: String,
                         ravenUrl: String,
                         stage: String,
                         viewerUrl: String,
-                        canDeleteAtom: Boolean // also validated server-side on every delete request
+                        // permissions also validated server-side on every request
+                        permissions: Permissions
                        )
 
 object ClientConfig {

--- a/app/model/ClientConfig.scala
+++ b/app/model/ClientConfig.scala
@@ -14,8 +14,7 @@ case class ClientConfig(username: String,
                         composerUrl: String,
                         ravenUrl: String,
                         stage: String,
-                        viewerUrl: String,
-                        showAssetsPageButton: Boolean
+                        viewerUrl: String
                        )
 
 object ClientConfig {

--- a/common/src/main/scala/com/gu/media/Permissions.scala
+++ b/common/src/main/scala/com/gu/media/Permissions.scala
@@ -4,21 +4,29 @@ import com.gu.editorial.permissions.client._
 
 import scala.concurrent.Future
 
-case class Permissions(directUpload: Boolean)
+case class Permissions(addAsset: Boolean, deleteAtom: Boolean)
 
 object Permissions extends PermissionsProvider {
   val app = "media-atom-maker"
-  val directUpload = Permission("media_atom_direct_upload", app, defaultVal = PermissionDenied)
+  val addAsset = Permission("media_atom_add_asset", app, defaultVal = PermissionDenied)
+  val deleteAtom = Permission("media_atom_delete", app, defaultVal = PermissionDenied)
 
-  val all = Seq(directUpload)
-  val none = Permissions(false)
+  val all = Seq(addAsset, deleteAtom)
+  val none = Permissions(addAsset = false, deleteAtom = false)
 
   implicit def config = PermissionsConfig(app, all)
 
-  def forUser(email: String): Future[Permissions] = {
-    get(directUpload)(PermissionsUser(email)).map {
-      case PermissionGranted => Permissions(directUpload = true)
-      case _ => none
+  def canAddAsset(email: String): Future[Boolean] = {
+    get(addAsset)(PermissionsUser(email)).map {
+      case PermissionGranted => true
+      case _ => false
+    }
+  }
+
+  def canDeleteAtom(email: String): Future[Boolean] = {
+    get(deleteAtom)(PermissionsUser(email)).map {
+      case PermissionGranted => true
+      case _ => false
     }
   }
 }

--- a/common/src/main/scala/com/gu/media/Permissions.scala
+++ b/common/src/main/scala/com/gu/media/Permissions.scala
@@ -1,0 +1,24 @@
+package com.gu.media
+
+import com.gu.editorial.permissions.client._
+
+import scala.concurrent.Future
+
+case class Permissions(directUpload: Boolean)
+
+object Permissions extends PermissionsProvider {
+  val app = "media-atom-maker"
+  val directUpload = Permission("media_atom_direct_upload", app, defaultVal = PermissionDenied)
+
+  val all = Seq(directUpload)
+  val none = Permissions(false)
+
+  implicit def config = PermissionsConfig(app, all)
+
+  def forUser(email: String): Future[Permissions] = {
+    get(directUpload)(PermissionsUser(email)).map {
+      case PermissionGranted => Permissions(directUpload = true)
+      case _ => none
+    }
+  }
+}

--- a/common/src/main/scala/com/gu/media/Permissions.scala
+++ b/common/src/main/scala/com/gu/media/Permissions.scala
@@ -1,5 +1,6 @@
 package com.gu.media
 
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.gu.editorial.permissions.client._
 import org.cvogt.play.json.Jsonx
 import play.api.libs.json.Format
@@ -7,20 +8,26 @@ import play.api.libs.json.Format
 import scala.concurrent.Future
 
 case class Permissions(addAsset: Boolean, deleteAtom: Boolean)
-
-object Permissions extends PermissionsProvider {
+object Permissions {
   implicit val format: Format[Permissions] = Jsonx.formatCaseClass[Permissions]
+}
 
+class MamPermissionsProvider(stage: String, credsProvider: AWSCredentialsProvider) extends PermissionsProvider {
   val app = "media-atom-maker"
-  val addAsset = Permission("media_atom_add_asset", app, defaultVal = PermissionDenied)
-  val deleteAtom = Permission("media_atom_delete", app, defaultVal = PermissionDenied)
+  val addAsset = Permission("add_media_atom_asset", app, defaultVal = PermissionDenied)
+  val deleteAtom = Permission("delete_media_atom", app, defaultVal = PermissionDenied)
 
   val all = Seq(addAsset, deleteAtom)
   val none = Permissions(addAsset = false, deleteAtom = false)
 
-  implicit def config = PermissionsConfig(app, all)
+  implicit def config = PermissionsConfig(
+    app = "media-atom-maker",
+    all = Seq(addAsset, deleteAtom),
+    s3BucketPrefix = if(stage == "PROD") "PROD" else "CODE",
+    awsCredentials = credsProvider
+  )
 
-  def get(email: String): Future[Permissions] = for {
+  def getAll(email: String): Future[Permissions] = for {
     addAsset <- canAddAsset(email)
     deleteAtom <- canDeleteAtom(email)
   } yield Permissions(addAsset, deleteAtom)

--- a/common/src/main/scala/com/gu/media/Permissions.scala
+++ b/common/src/main/scala/com/gu/media/Permissions.scala
@@ -1,12 +1,16 @@
 package com.gu.media
 
 import com.gu.editorial.permissions.client._
+import org.cvogt.play.json.Jsonx
+import play.api.libs.json.Format
 
 import scala.concurrent.Future
 
 case class Permissions(addAsset: Boolean, deleteAtom: Boolean)
 
 object Permissions extends PermissionsProvider {
+  implicit val format: Format[Permissions] = Jsonx.formatCaseClass[Permissions]
+
   val app = "media-atom-maker"
   val addAsset = Permission("media_atom_add_asset", app, defaultVal = PermissionDenied)
   val deleteAtom = Permission("media_atom_delete", app, defaultVal = PermissionDenied)
@@ -15,6 +19,11 @@ object Permissions extends PermissionsProvider {
   val none = Permissions(addAsset = false, deleteAtom = false)
 
   implicit def config = PermissionsConfig(app, all)
+
+  def get(email: String): Future[Permissions] = for {
+    addAsset <- canAddAsset(email)
+    deleteAtom <- canDeleteAtom(email)
+  } yield Permissions(addAsset, deleteAtom)
 
   def canAddAsset(email: String): Future[Boolean] = {
     get(addAsset)(PermissionsUser(email)).map {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,6 +41,8 @@ object Dependencies {
   val logstashLogbackEncoder = "net.logstash.logback" % "logstash-logback-encoder" % "4.8"
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.3.0"
 
+  val permissionsClient = "com.gu" %% "editorial-permissions-client" % "0.2"
+
   val pandaHmacHeaders = "com.gu" %% "hmac-headers" % "1.1"
 
   val panda = Seq(
@@ -70,7 +72,7 @@ object Dependencies {
 
   val commonDependencies = googleApi ++ Seq(
     typesafeConfig, awsLambdaCore, awsS3, awsDynamo, playJsonExtensions, logstashLogbackEncoder, kinesisLogbackAppender,
-    awsTranscoder, scanamo, okHttp, scalaTest, scalaCheck, awsSQS, awsSNS, aws
+    awsTranscoder, scanamo, okHttp, scalaTest, scalaCheck, awsSQS, awsSNS, aws, permissionsClient
   )
 
   val appDependencies = panda ++ atomMaker ++ slf4j ++ Seq(

--- a/public/video-ui/src/actions/VideoActions/createAsset.js
+++ b/public/video-ui/src/actions/VideoActions/createAsset.js
@@ -1,4 +1,3 @@
-import { browserHistory } from 'react-router';
 import VideosApi from '../../services/VideosApi';
 
 const BLANK_ASSET = {
@@ -14,7 +13,6 @@ function requestAssetCreate(video) {
 }
 
 function receiveAssetCreate(video) {
-  browserHistory.push('/videos/' + video.id );
   return {
     type: 'ASSET_CREATE_RECEIVE',
     video: video,

--- a/public/video-ui/src/actions/VideoActions/deleteVideo.js
+++ b/public/video-ui/src/actions/VideoActions/deleteVideo.js
@@ -1,0 +1,22 @@
+import { browserHistory } from 'react-router';
+import VideosApi from '../../services/VideosApi';
+
+function errorVideoDelete(error) {
+  return {
+    type:       'SHOW_ERROR',
+    message:    `Could not delete atom. ${error}`,
+    error:      error,
+    receivedAt: Date.now()
+  };
+}
+
+export function deleteVideo(video) {
+  return dispatch => {
+    return VideosApi.deleteVideo(video.id)
+        .then(() =>  {
+          browserHistory.push('/videos');
+        }).catch((error) => {
+          dispatch(errorVideoDelete(error.response));
+        });
+  };
+}

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Link} from 'react-router';
 import VideoAssets from '../VideoAssets/VideoAssets';
 import VideoSelectBar from '../VideoSelectBar/VideoSelectBar';
 import VideoPreview from '../VideoPreview/VideoPreview';
@@ -135,6 +136,23 @@ class VideoDisplay extends React.Component {
     }
   }
 
+  renderPreview = () => {
+    let link = false;
+    if(this.props.video && getStore().getState().config.showAssetsPageButton) {
+      link = <Link className="button" to={`/videos/${this.props.video.id}/upload`}>
+        <Icon className="icon__edit" icon="edit"/>
+      </Link>;
+    }
+
+    return <div className="video__detailbox">
+      <div className="video__detailbox__header__container">
+        <header className="video__detailbox__header">Video Asset</header>
+        {link}
+      </div>
+      <VideoPreview video={this.props.video || {}} />
+    </div>;
+  };
+
   render() {
     const video = this.props.video && this.props.params.id === this.props.video.id ? this.props.video : undefined;
 
@@ -149,12 +167,7 @@ class VideoDisplay extends React.Component {
         <div className="video">
           <div className="video__main">
             <div className="video__main__header">
-              <div className="video__detailbox">
-                <div className="video__detailbox__header__container">
-                  <header className="video__detailbox__header">Video Asset</header>
-                </div>
-                <VideoPreview video={this.props.video || {}} />
-              </div>
+              {this.renderPreview()}
               <div className="video__detailbox">
                 <div className="video__detailbox__header__container">
                   <header className="video__detailbox__header">Video Meta Data</header>

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import {Link} from 'react-router';
-import VideoAssets from '../VideoAssets/VideoAssets';
 import VideoSelectBar from '../VideoSelectBar/VideoSelectBar';
 import VideoPreview from '../VideoPreview/VideoPreview';
 import VideoUsages from '../VideoUsages/VideoUsages';
 import VideoMetaData from '../VideoMetaData/VideoMetaData';
 import YoutubeMetaData from '../YoutubeMetaData/YoutubeMetaData';
 import VideoPoster from '../VideoPoster/VideoPoster';
+import AdvancedActions from '../Videos/AdvancedActions';
 import GridImageSelect from '../utils/GridImageSelect';
 import {getVideoBlock} from '../../util/getVideoBlock';
 import {getStore} from '../../util/storeAccessor';
@@ -218,7 +218,7 @@ class VideoDisplay extends React.Component {
                 />
               </div>
               <div className="video__detailbox">
-                <VideoAssets video={this.props.video || {}} />
+                <AdvancedActions video={this.props.video || {}} />
               </div>
             </div>
           </div>

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -137,17 +137,12 @@ class VideoDisplay extends React.Component {
   }
 
   renderPreview = () => {
-    let link = false;
-    if(this.props.video && getStore().getState().config.showAssetsPageButton) {
-      link = <Link className="button" to={`/videos/${this.props.video.id}/upload`}>
-        <Icon className="icon__edit" icon="edit"/>
-      </Link>;
-    }
-
     return <div className="video__detailbox">
       <div className="video__detailbox__header__container">
         <header className="video__detailbox__header">Video Asset</header>
-        {link}
+        <Link className="button" to={`/videos/${this.props.video.id}/upload`}>
+          <Icon className="icon__edit" icon="edit"/>
+        </Link>
       </div>
       <VideoPreview video={this.props.video || {}} />
     </div>;

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -3,6 +3,7 @@ import {YouTubeEmbed} from '../utils/YouTubeEmbed';
 import Icon from '../Icon';
 import {getProcessingStatus} from '../../services/YoutubeApi';
 import _ from 'lodash';
+import {getStore} from '../../util/storeAccessor';
 
 function embed(assetId, platform) {
     if(platform === "Youtube") {
@@ -32,7 +33,9 @@ function VideoAsset({ id, platform, version, active, selectAsset }) {
     const statusClasses = active ? "publish__label label__live label__frontpage__overlay" : "publish__label label__frontpage__novideo label__frontpage__overlay";
     const status = active ? "Live" : "Not Live";
 
-    const selector = !active ?
+    const canAddAsset = getStore().getState().config.permissions.addAsset;
+
+    const selector = !active && canAddAsset ?
       <button className="button__secondary button__active" onClick={() => selectAsset(id, version)}>
           Activate
       </button> : false;

--- a/public/video-ui/src/components/VideoUpload/VideoUpload.js
+++ b/public/video-ui/src/components/VideoUpload/VideoUpload.js
@@ -43,6 +43,10 @@ class AddAssetFromURL extends React.Component {
 class VideoUpload extends React.Component {
   state = { file: null };
 
+  componentWillMount() {
+    this.props.videoActions.getVideo(this.props.params.id);
+  }
+
   componentWillUnmount() {
     this.props.videoActions.updateVideo(blankVideoData);
   }

--- a/public/video-ui/src/components/VideoUpload/VideoUpload.js
+++ b/public/video-ui/src/components/VideoUpload/VideoUpload.js
@@ -87,10 +87,10 @@ class VideoUpload extends React.Component {
   renderActions(uploading) {
     // the permissions are also validated on the server-side for each request
     if(!getStore().getState().config.permissions.addAsset) {
-      return false;
+      return <div className="upload__actions" />;
     }
 
-    return <div>
+    return <div className="upload__actions upload__actions--non-empty">
       <div className="video__detailbox upload__action">
         <div className="video__detailbox__header__container">
           <header className="video__detailbox__header">Upload Video</header>
@@ -122,9 +122,7 @@ class VideoUpload extends React.Component {
 
     return <div className="video__main">
       <div className="video__main__header">
-        <div className="upload__actions">
-          {this.renderActions(uploading)}
-        </div>
+        {this.renderActions(uploading)}
         <VideoTrail
           activeVersion={activeVersion}
           assets={assets}

--- a/public/video-ui/src/components/VideoUpload/VideoUpload.js
+++ b/public/video-ui/src/components/VideoUpload/VideoUpload.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import {Link} from 'react-router';
 import Icon from '../Icon';
 import VideoTrail from './VideoTrail';
+import {getStore} from '../../util/storeAccessor';
 import _ from 'lodash';
 import {blankVideoData} from '../../constants/blankVideoData';
 
@@ -70,14 +70,6 @@ class VideoUpload extends React.Component {
     }
   };
 
-  renderHeader() {
-    if (this.props.video) {
-      <Link className="button" to={`/videos/${this.props.video.id}`}>
-        <Icon className="icon__edit" icon="clear" />
-      </Link>;
-    }
-  }
-
   renderButtons(uploading) {
     if (uploading) {
       return false;
@@ -88,13 +80,21 @@ class VideoUpload extends React.Component {
     }
   }
 
-  renderPicker(uploading) {
-    return <div className="video__detailbox upload__action">
-      <div className="video__detailbox__header__container">
-        <header className="video__detailbox__header">Upload Video</header>
+  renderActions(uploading) {
+    // the permissions are also validated on the server-side for each request
+    if(!getStore().getState().config.permissions.addAsset) {
+      return false;
+    }
+
+    return <div>
+      <div className="video__detailbox upload__action">
+        <div className="video__detailbox__header__container">
+          <header className="video__detailbox__header">Upload Video</header>
+        </div>
+          <input className="form__field" type="file" onChange={this.setFile} disabled={uploading} />
+          {this.renderButtons(uploading)}
       </div>
-        <input className="form__field" type="file" onChange={this.setFile} disabled={uploading} />
-        {this.renderButtons(uploading)}
+      <AddAssetFromURL video={this.props.video} createAsset={this.props.videoActions.createAsset} />
     </div>;
   }
 
@@ -117,11 +117,9 @@ class VideoUpload extends React.Component {
     });
 
     return <div className="video__main">
-      {this.renderHeader()}
       <div className="video__main__header">
         <div className="upload__actions">
-          {this.renderPicker(uploading)}
-          <AddAssetFromURL video={this.props.video} createAsset={this.props.videoActions.createAsset} />
+          {this.renderActions(uploading)}
         </div>
         <VideoTrail
           activeVersion={activeVersion}

--- a/public/video-ui/src/components/Videos/AdvancedActions.js
+++ b/public/video-ui/src/components/Videos/AdvancedActions.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import {getStore} from '../../util/storeAccessor';
+
+class AdvancedActions extends React.Component {
+    renderDelete() {
+        // the permissions are also validated on the server-side for each request
+        if(!getStore().getState().config.permissions.deleteAtom) {
+            return false;
+        }
+
+        const doDelete = () => {
+            this.props.videoActions.deleteVideo(this.props.video);
+        };
+
+        return <li className="asset-list__item">
+            <button className="btn label__expired" onClick={doDelete}>DELETE</button>
+            Usages will not be replaced automatically
+        </li>;
+    }
+
+    render() {
+        return <div>
+            <div className="video__detailbox__header__container">
+                <span className="video__detailbox__header">Advanced</span>
+            </div>  
+            <ul className="asset-list">
+                {this.renderDelete()}
+            </ul>
+        </div>;
+    }
+}
+
+//REDUX CONNECTIONS
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import * as deleteVideo from '../../actions/VideoActions/deleteVideo';
+
+function mapStateToProps(state) {
+  return {
+    video: state.video
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    videoActions: bindActionCreators(Object.assign({}, deleteVideo), dispatch)
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(AdvancedActions);

--- a/public/video-ui/src/components/Videos/AdvancedActions.js
+++ b/public/video-ui/src/components/Videos/AdvancedActions.js
@@ -2,9 +2,12 @@ import React from 'react';
 import {getStore} from '../../util/storeAccessor';
 
 class AdvancedActions extends React.Component {
+    // the permissions are also validated on the server-side for each request
+    permissions = getStore().getState().config.permissions;
+    showActions = this.permissions.deleteAtom;
+
     renderDelete() {
-        // the permissions are also validated on the server-side for each request
-        if(!getStore().getState().config.permissions.deleteAtom) {
+        if(!this.permissions.deleteAtom) {
             return false;
         }
 
@@ -12,18 +15,22 @@ class AdvancedActions extends React.Component {
             this.props.videoActions.deleteVideo(this.props.video);
         };
 
-        return <li className="asset-list__item">
-            <button className="btn label__expired" onClick={doDelete}>DELETE</button>
-            Usages will not be replaced automatically
+        return <li className="action-list__item">
+            <button className="btn label__expired action-list__button" onClick={doDelete}>DELETE</button>
+            <span className="right">Usages will not be replaced and the video will remain on YouTube</span>
         </li>;
     }
 
     render() {
+        if(!this.showActions) {
+            return false;
+        }
+
         return <div>
             <div className="video__detailbox__header__container">
                 <span className="video__detailbox__header">Advanced</span>
             </div>  
-            <ul className="asset-list">
+            <ul className="action-list">
                 {this.renderDelete()}
             </ul>
         </div>;

--- a/public/video-ui/src/components/Videos/AdvancedActions.js
+++ b/public/video-ui/src/components/Videos/AdvancedActions.js
@@ -12,7 +12,11 @@ class AdvancedActions extends React.Component {
         }
 
         const doDelete = () => {
-            this.props.videoActions.deleteVideo(this.props.video);
+            const result = prompt("Enter the atom ID to confirm deletion (it can be copied from the URL)");
+
+            if(result === this.props.video.id) {
+                this.props.videoActions.deleteVideo(this.props.video);
+            }
         };
 
         return <li className="action-list__item">

--- a/public/video-ui/src/constants/blankVideoData.js
+++ b/public/video-ui/src/constants/blankVideoData.js
@@ -5,5 +5,6 @@ export const blankVideoData = {
     duration: 0,
     channelId: '',
     youtubeCategoryId: '',
-    privacyStatus: ''
+    privacyStatus: '',
+    assets: []
 };

--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -90,6 +90,13 @@ export default {
     });
   },
 
+  deleteVideo: (videoId) => {
+    return pandaReqwest({
+      url: '/api2/atom/' + videoId,
+      method: 'delete',
+    });
+  },
+
   createComposerPage(id, metadata, composerUrlBase) {
 
     const initialComposerUrl = composerUrlBase + '/api/content?atomPoweredVideo=true&originatingSystem=composer&type=video';

--- a/public/video-ui/styles/components/_advanced.scss
+++ b/public/video-ui/styles/components/_advanced.scss
@@ -1,0 +1,20 @@
+.action-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    margin: 0;
+    padding: 0;
+
+    &__item {
+        display: flex;
+        position: relative;
+        align-items: center;
+        padding: 5px 10px;
+        width: 100%;
+        background: $color700Grey;
+    }
+
+    &__button {
+        margin-right: 10px;
+    }
+}

--- a/public/video-ui/styles/layout/_upload.scss
+++ b/public/video-ui/styles/layout/_upload.scss
@@ -22,6 +22,7 @@
     flex: 0 0 20%;
     padding: 10px;
     margin: 0 10px 0 15px;
+    border-right: 1px solid $color700Grey;
   }
 
   &__action {

--- a/public/video-ui/styles/layout/_upload.scss
+++ b/public/video-ui/styles/layout/_upload.scss
@@ -22,6 +22,9 @@
     flex: 0 0 20%;
     padding: 10px;
     margin: 0 10px 0 15px;
+  }
+
+  &__actions--non-empty {
     border-right: 1px solid $color700Grey;
   }
 
@@ -65,6 +68,7 @@
 
     &__empty {
       background-color: $color900Grey;
+      height: 140px;
     }
 
     &__running {

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -82,7 +82,6 @@
 
   &__trail {
     margin-top: 20px;
-    border-left: 1px solid $color700Grey;
     padding-left: 20px;
     flex: 1;
   }

--- a/public/video-ui/styles/main.scss
+++ b/public/video-ui/styles/main.scss
@@ -42,4 +42,5 @@
   'components/header',
   'components/usage',
   'components/expiry-date',
-  'components/pluto-list';
+  'components/pluto-list',
+  'components/advanced';


### PR DESCRIPTION
Integrates permissions:

- `add_media_atom_asset`: allows direct upload and adding an asset by URL
- `delete_media_atom`: allows deletion of an atom from the UI

HMAC authenticated requests automatically have permission to add an asset so that upload via Pluto and CDS continues to work.

On deletion, a takedown is sent to CAPI and the atom deleted from the preview and live Dynamo stores. The video remains on YouTube and Composer usages etc are not updated automatically.

The UI adjusts shows/hides functionality based on the permission a user has. Use of the functionality is always validated server-side on each request. This PR also adds a link to the `upload` page from the Video Preview on the main page, thus fully replacing the old assets block.

**No permission**

<img width="1257" alt="42d93fc3-9037-4fad-b3d5-625db2faca77" src="https://cloud.githubusercontent.com/assets/395805/24652330/5911ba78-1929-11e7-99c7-8f200421c011.png">

<img width="1270" alt="09c121e3-24ac-4714-a187-e8f2871d4541" src="https://cloud.githubusercontent.com/assets/395805/24652371/7d176058-1929-11e7-8fc7-3ba55ab22281.png">

**Add asset permission**

<img width="1266" alt="61400705-0784-48a9-871b-f305c57af69f" src="https://cloud.githubusercontent.com/assets/395805/24652408/a4c4bc2c-1929-11e7-999a-187070932c63.png">

**Delete atom permission**

<img width="1255" alt="738808c6-58c8-4ac0-8845-51b89b668e59" src="https://cloud.githubusercontent.com/assets/395805/24652422/bd0b523c-1929-11e7-9c19-6c5afbfeae9a.png">

Fixes #337 