### PR TITLE
Revert "Adding embedmode to the header"

### DIFF
--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -125,27 +125,6 @@ export default class Header extends React.Component {
 
         </header>
       );
-    } if (this.props.embeddedMode === 'live'){
-      return (
-        <header className="topbar flex-container">
-          {this.renderHome()}
-
-          <div>
-            {this.renderVideoTitle()}
-          </div>
-
-          <VideoPublishBar className="flex-grow"
-            video={this.props.video}
-            embeddedMode={this.props.embeddedMode}
-            publishedVideo={this.props.publishedVideo}
-            saveState={this.props.saveState}
-            publishVideo={this.publishVideo} />
-
-          <div className="flex-container">
-            {this.renderAuditLink()}
-          </div>
-        </header>
-      );
     } else {
       return (
         <header className="topbar flex-container">

--- a/public/video-ui/src/components/ReactApp.js
+++ b/public/video-ui/src/components/ReactApp.js
@@ -46,7 +46,6 @@ class ReactApp extends React.Component {
             currentPath={this.props.location.pathname}
             video={this.props.video || {}}
             publishedVideo={this.props.publishedVideo || {}}
-            embeddedMode={this.props.config.embeddedMode}
             showPublishedState={this.props.params.id ? true : false}
             s3Upload={this.props.s3Upload}
             publishVideo={this.props.appActions.publishVideo}
@@ -79,8 +78,7 @@ function mapStateToProps(state) {
     publishedVideo: state.publishedVideo,
     error: state.error,
     uploads: state.uploads,
-    s3Upload: state.s3Upload,
-    config: state.config
+    s3Upload: state.s3Upload
   };
 }
 

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import VideoAssets from '../VideoAssets/VideoAssets';
+import VideoSelectBar from '../VideoSelectBar/VideoSelectBar';
 import VideoPreview from '../VideoPreview/VideoPreview';
 import VideoUsages from '../VideoUsages/VideoUsages';
 import VideoMetaData from '../VideoMetaData/VideoMetaData';
@@ -143,6 +144,7 @@ class VideoDisplay extends React.Component {
 
     return (
       <div>
+        <VideoSelectBar video={video} onSelectVideo={this.selectVideo} publishedVideo={this.props.publishedVideo} embeddedMode={this.props.config.embeddedMode} />
 
         <div className="video">
           <div className="video__main">

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -55,28 +55,6 @@ class VideoPublishBar extends React.Component {
     return <div className="publish__label label__draft">Draft</div>;
   }
 
-  renderEmbedButton() {
-    // you can always select a video in 'preview' mode (this is used by the Pluto embed)
-    // otherwise you should only be able to select published videos (when embedded inside Composer for example)
-
-    const embedButton = <button type="button" className="btn" onSelectVideo={this.selectVideo} publishedVideo={this.props.publishedVideo} onClick={this.props.onSelectVideo}>Select this Video</button>;
-
-    switch(this.props.embeddedMode) {
-      case "preview":
-        return embedButton;
-
-      case "live":
-        if(isVideoPublished(this.props.publishedVideo)) {
-          return embedButton;
-        } else {
-          return <div>This atom cannot be embedded because it has not been published</div>;
-        }
-
-      default:
-        return false;
-    }
-  }
-
 
   render() {
 
@@ -88,9 +66,6 @@ class VideoPublishBar extends React.Component {
       <div className="flex-container flex-grow publish-bar">
         {this.renderVideoPublishedInfo()}
         <div className="flex-spacer"></div>
-        <div className="icon__spacing">
-          {this.renderEmbedButton()}
-        </div>
         {this.renderPublishButton()}
       </div>
     );


### PR DESCRIPTION
Reverts guardian/media-atom-maker#363

as embedded MAM in Pluto is broken