### PR TITLE
Add permission to access permissions

### DIFF
--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -1105,6 +1105,22 @@
                 "Roles": [{"Ref": "DistributionRole"}]
             }
         },
+        "PermissionsPolicy": {
+          "Type": "AWS::IAM::Policy",
+          "Properties": {
+            "PolicyName": "PermissionsPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": ["s3:GetObject"],
+                  "Resource": ["arn:aws:s3:::permissions-cache/*"]
+                }
+              ]
+            },
+            "Roles": [{"Ref": "DistributionRole"}]
+          }
+        },
         "AlertTopic": {
             "Type": "AWS::SNS::Topic",
             "Properties": {


### PR DESCRIPTION
Follow up to #362, giving the EC2 instances permission to access the bucket where permissions are defined.