### PR TITLE
Temporarily loosen add asset permissions

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -82,7 +82,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
     }
   }
 
-  def addAsset(atomId: String) = CanAddAsset { implicit req =>
+  def addAsset(atomId: String) = APIHMACAuthAction { implicit req =>
     implicit val readCommand: Reads[AddAssetCommand] =
       (JsPath \ "uri").read[String].map { videoUri =>
         AddAssetCommand(atomId, videoUri, stores, youTube, req.user)
@@ -97,7 +97,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
 
   private def atomUrl(id: String) = s"/atom/$id"
 
-  def setActiveAsset(atomId: String) = CanAddAsset { implicit req =>
+  def setActiveAsset(atomId: String) = APIHMACAuthAction { implicit req =>
     implicit val readCommand: Reads[ActiveAssetCommand] =
       (JsPath \ "youtubeId").read[String].map { videoUri =>
         ActiveAssetCommand(atomId, videoUri, stores, youTube, req.user)

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -139,7 +139,7 @@ class VideoDisplay extends React.Component {
   renderPreview = () => {
     return <div className="video__detailbox">
       <div className="video__detailbox__header__container">
-        <header className="video__detailbox__header">Video Asset</header>
+        <header className="video__detailbox__header">Video Preview</header>
         <Link className="button" to={`/videos/${this.props.video.id}/upload`}>
           <Icon className="icon__edit" icon="edit"/>
         </Link>

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -3,7 +3,6 @@ import {YouTubeEmbed} from '../utils/YouTubeEmbed';
 import Icon from '../Icon';
 import {getProcessingStatus} from '../../services/YoutubeApi';
 import _ from 'lodash';
-import {getStore} from '../../util/storeAccessor';
 
 function embed(assetId, platform) {
     if(platform === "Youtube") {
@@ -33,9 +32,7 @@ function VideoAsset({ id, platform, version, active, selectAsset }) {
     const statusClasses = active ? "publish__label label__live label__frontpage__overlay" : "publish__label label__frontpage__novideo label__frontpage__overlay";
     const status = active ? "Live" : "Not Live";
 
-    const canAddAsset = getStore().getState().config.permissions.addAsset;
-
-    const selector = !active && canAddAsset ?
+    const selector = !active ?
       <button className="button__secondary button__active" onClick={() => selectAsset(id, version)}>
           Activate
       </button> : false;

--- a/public/video-ui/src/components/VideoUpload/VideoUpload.js
+++ b/public/video-ui/src/components/VideoUpload/VideoUpload.js
@@ -84,20 +84,24 @@ class VideoUpload extends React.Component {
     }
   }
 
-  renderActions(uploading) {
+  renderUpload(uploading) {
     // the permissions are also validated on the server-side for each request
     if(!getStore().getState().config.permissions.addAsset) {
-      return <div className="upload__actions" />;
+      return false;
     }
 
-    return <div className="upload__actions upload__actions--non-empty">
-      <div className="video__detailbox upload__action">
-        <div className="video__detailbox__header__container">
-          <header className="video__detailbox__header">Upload Video</header>
-        </div>
-          <input className="form__field" type="file" onChange={this.setFile} disabled={uploading} />
-          {this.renderButtons(uploading)}
+    return <div className="video__detailbox upload__action">
+      <div className="video__detailbox__header__container">
+        <header className="video__detailbox__header">Upload Video</header>
       </div>
+        <input className="form__field" type="file" onChange={this.setFile} disabled={uploading} />
+        {this.renderButtons(uploading)}
+    </div>;
+  }
+
+  renderActions(uploading) {
+    return <div className="upload__actions upload__actions--non-empty">
+      {this.renderUpload(uploading)}
       <AddAssetFromURL video={this.props.video} createAsset={this.props.videoActions.createAsset} />
     </div>;
   }


### PR DESCRIPTION
Direct upload remains behind the add asset permission. The other functionality previously on the "Assets" block of the front page is now available to all users but under the uploads page.

The direct upload form is only shown to users with add asset permission. There will be a further PR to rename the permission to clarify intention.