### PR TITLE
Prompt user before reloading the page when uploading to S3

### DIFF
--- a/public/video-ui/src/actions/UploadActions/s3Upload.js
+++ b/public/video-ui/src/actions/UploadActions/s3Upload.js
@@ -26,9 +26,15 @@ function uploadComplete() {
 
 export function startUpload(id, file, completeFn) {
   return dispatch => {
+    // Start prompting the user about reloading the page
+    window.onbeforeunload = () => { return false; };
+
     UploadsApi.createUpload(id, file).then((upload) => {
       const progress = (completed) => dispatch(uploadProgress(completed));
       const complete = () => {
+        // Stop prompting the user. The upload continues server-side
+        window.onbeforeunload = undefined;
+
         dispatch(uploadComplete());
         completeFn();
       };

--- a/public/video-ui/src/actions/UploadActions/s3Upload.js
+++ b/public/video-ui/src/actions/UploadActions/s3Upload.js
@@ -24,6 +24,15 @@ function uploadComplete() {
   };
 }
 
+function uploadError(error) {
+  return {
+    type: 'SHOW_ERROR',
+    message: `Error uploading video ${error}`,
+    error: error,
+    receivedAt: Date.now()
+  };
+}
+
 export function startUpload(id, file, completeFn) {
   return dispatch => {
     // Start prompting the user about reloading the page
@@ -31,6 +40,12 @@ export function startUpload(id, file, completeFn) {
 
     UploadsApi.createUpload(id, file).then((upload) => {
       const progress = (completed) => dispatch(uploadProgress(completed));
+      
+      const err = (err) => {
+        window.onbeforeunload = undefined;
+        dispatch(uploadError(err));
+      };
+      
       const complete = () => {
         // Stop prompting the user. The upload continues server-side
         window.onbeforeunload = undefined;
@@ -39,10 +54,13 @@ export function startUpload(id, file, completeFn) {
         completeFn();
       };
       
-      const handle = new UploadHandle(upload, file, progress, complete);
+      const handle = new UploadHandle(upload, file, progress, complete, err);
       handle.start();
 
       dispatch(uploadStarted(upload));
+    }).catch((err) => {
+      window.onbeforeunload = undefined;
+      dispatch(uploadError(err));
     });
   };
 }


### PR DESCRIPTION
If the user reloads the page whilst uploading a video to S3 they will have to try again from scratch. This PR adds the classic "do you really want to reload the page" dialog as a safeguard.