### PR TITLE
Disbale create page button

### DIFF
--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -88,12 +88,17 @@ class VideoDisplay extends React.Component {
 
       if(filterUsageType.length === 0){
         return (
-          <button className="button__secondary" onClick={this.pageCreate}><Icon icon="add_to_queue"></Icon> Create Video Page</button>
+          <button
+            className="button__secondary"
+            disabled={this.cannotMakeEdits()}
+            onClick={this.pageCreate}>
+              <Icon icon="add_to_queue"></Icon> Create Video Page
+          </button>
         );
       }
   }
 
-  cannotOpenEditForm = () => {
+  cannotMakeEdits = () => {
     if (this.props.editState && (this.props.editState.metadataEditable || this.props.editState.youtubeEditable)) {
       return true;
     }
@@ -128,8 +133,8 @@ class VideoDisplay extends React.Component {
       );
     } else {
       return (
-        <button disabled={this.cannotOpenEditForm()} onClick={() => this.manageEditingState(property)}>
-          <Icon className={"icon__edit " + (this.cannotOpenEditForm() ? "disabled" : "")} icon="edit" />
+        <button disabled={this.cannotMakeEdits()} onClick={() => this.manageEditingState(property)}>
+          <Icon className={"icon__edit " + (this.cannotMakeEdits() ? "disabled" : "")} icon="edit" />
         </button>
       );
     }

--- a/public/video-ui/styles/abstracts/_mixins.scss
+++ b/public/video-ui/styles/abstracts/_mixins.scss
@@ -12,9 +12,8 @@
   }
 
   &:disabled {
-    background: $btnDisabled;
-    color: $btnTextDisabled;
     cursor: default;
+    opacity: 0.5;
   }
 
   &:focus {


### PR DESCRIPTION
- Disables the create composer page button if one of the edit atom forms are open
- The default disabled button styles looked horrible on this button. Instead of overriding them, I updated the disabled button styling to use opacity instead of greying the disabled buttons. This is also consistent with the disabled styling of the icons that close the edit forms. What do you think?
<img width="729" alt="screen shot 2017-04-07 at 15 46 05" src="https://cloud.githubusercontent.com/assets/3066534/24805356/57a9a1a0-1ba9-11e7-85c2-77d74f424edc.png">

<img width="795" alt="screen shot 2017-04-07 at 15 45 31" src="https://cloud.githubusercontent.com/assets/3066534/24805335/468e4cfe-1ba9-11e7-982b-af44afa78e2c.png">

@mr-mr @mbarton @akash1810 
