### PR TITLE
disable keyword deletion when not in edit mode

### DIFF
--- a/public/video-ui/src/components/FormFields/KeywordPicker.js
+++ b/public/video-ui/src/components/FormFields/KeywordPicker.js
@@ -57,7 +57,7 @@ class KeywordPicker extends React.Component {
     return (
       <div className="keywords__item" key={keyword}>
         <div className="keyword__item__text">{keyword}</div>
-        <button className="keyword__item__remove" onClick={this.removeKeyword.bind(this, keyword)}>X</button>
+        <button className="keyword__item__remove" disabled={!this.props.editable} onClick={this.removeKeyword.bind(this, keyword)}>X</button>
       </div>
     );
   }

--- a/public/video-ui/styles/components/_keywords.scss
+++ b/public/video-ui/styles/components/_keywords.scss
@@ -37,8 +37,12 @@
   border-left-width: 0;
   color: $color400Grey;
 
-  .keywords__item:hover & {
+  &:hover:not(:disabled) {
     color: white;
+  }
+
+  &:disabled {
+    cursor: default;
   }
 }
 


### PR DESCRIPTION
This fixes a bug where existing keywords could be removed from the atom even if the youtube data edit form was not open for editing. @akash1810 @mbarton 