### PR TITLE
collect editable form field names to check for unpublished changes

### DIFF
--- a/public/video-ui/src/actions/FormErrorActions/updateFormErrors.js
+++ b/public/video-ui/src/actions/FormErrorActions/updateFormErrors.js
@@ -1,6 +1,6 @@
 export function updateFormErrors(error) {
   return {
-    type:       'FORM_ERRORS_UPDATE_REQUEST',
+    type:       'CHECKED_FIELDS_UPDATE_REQUEST',
     error:      error,
     receivedAt: Date.now()
   };

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -138,6 +138,7 @@ export default class Header extends React.Component {
           <VideoPublishBar className="flex-grow"
             video={this.props.video}
             publishedVideo={this.props.publishedVideo}
+            editableFields={this.props.editableFields}
             saveState={this.props.saveState}
             publishVideo={this.publishVideo} />
 

--- a/public/video-ui/src/components/ManagedForm/ManagedField.js
+++ b/public/video-ui/src/components/ManagedForm/ManagedField.js
@@ -44,7 +44,7 @@ export class ManagedField extends React.Component {
         fieldWarnings: notifications.warnings
       });
 
-      this.props.updateFormErrors(notifications.errors, this.props.name);
+      this.props.updateFormErrors(notifications.errors, this.props.fieldLocation);
     }
 
   }

--- a/public/video-ui/src/components/ReactApp.js
+++ b/public/video-ui/src/components/ReactApp.js
@@ -37,6 +37,15 @@ class ReactApp extends React.Component {
     this.props.appActions.updateSearchTerm(searchTerm);
   };
 
+  getEditableFields = () => {
+    const allFields = this.props.checkedFormFields;
+
+    const editableFormFields = Object.keys(allFields).reduce((fields, formName) => {
+      return fields.concat(Object.keys(this.props.checkedFormFields[formName]));
+    }, []);
+    return editableFormFields;
+  }
+
   render() {
     return (
         <div className="wrap">
@@ -50,6 +59,7 @@ class ReactApp extends React.Component {
             s3Upload={this.props.s3Upload}
             publishVideo={this.props.appActions.publishVideo}
             saveState={this.props.saveState}
+            editableFields={this.getEditableFields()}
           />
           {this.props.error ? <div className="error-bar">{this.props.error}</div> : false}
           <div>
@@ -78,7 +88,8 @@ function mapStateToProps(state) {
     publishedVideo: state.publishedVideo,
     error: state.error,
     uploads: state.uploads,
-    s3Upload: state.s3Upload
+    s3Upload: state.s3Upload,
+    checkedFormFields: state.checkedFormFields
   };
 }
 

--- a/public/video-ui/src/components/Video/Create.js
+++ b/public/video-ui/src/components/Video/Create.js
@@ -38,7 +38,7 @@ class VideoCreate extends React.Component {
           />
           <SaveButton
             video={this.props.video}
-            formErrors={this.props.formErrors[formNames.create] ? this.props.formErrors[formNames.create] : {}}
+            checkedFormFields={this.props.checkedFormFields[formNames.create] ? this.props.checkedFormFields[formNames.create] : {}}
             saveState={this.props.saveState}
             onSaveClick={this.createVideo}
             onResetClick={this.resetVideo} />
@@ -59,7 +59,7 @@ function mapStateToProps(state) {
   return {
     video: state.video,
     saveState: state.saveState,
-    formErrors: state.formErrors
+    checkedFormFields: state.checkedFormFields,
   };
 }
 

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -111,7 +111,7 @@ class VideoDisplay extends React.Component {
     } else if (property === 'youtubeEditable') {
       formName = formNames.youtube;
     }
-    const errors = this.props.formErrors[formName] ? this.props.formErrors[formName] : {};
+    const errors = this.props.checkedFormFields[formName] ? this.props.checkedFormFields[formName] : {};
     return Object.keys(errors).some(field => {
       const value = errors[field];
       return value.length !== 0;
@@ -188,7 +188,6 @@ class VideoDisplay extends React.Component {
                   video={this.props.video || {}}
                   updateVideo={this.updateVideo}
                   editable={this.props.editState.youtubeEditable}
-                  updateFormErrors={this.updateYoutubeFormErrors}
                   formName={formNames.youtube}
                   updateErrors={this.props.formErrorActions.updateFormErrors}
                 />
@@ -206,6 +205,8 @@ class VideoDisplay extends React.Component {
                 <VideoPoster
                   video={this.props.video || {}}
                   updateVideo={this.saveAndUpdateVideo}
+                  formName={formNames.posterImage}
+                  updateErrors={this.props.formErrorActions.updateFormErrors}
                 />
               </div>
               <div className="video__detailbox">
@@ -250,7 +251,7 @@ function mapStateToProps(state) {
     composerPageWithUsage: state.pageCreate,
     publishedVideo: state.publishedVideo,
     editState: state.editState,
-    formErrors: state.formErrors
+    checkedFormFields: state.checkedFormFields
   };
 }
 

--- a/public/video-ui/src/components/VideoMetaData/VideoMetaData.js
+++ b/public/video-ui/src/components/VideoMetaData/VideoMetaData.js
@@ -18,6 +18,7 @@ export default class VideoMetaData extends React.Component {
           updateData={this.props.updateVideo}
           editable={this.props.editable}
           updateErrors={this.props.updateErrors}
+          formName={this.props.formName}
         >
           <ManagedField
             fieldLocation="title"

--- a/public/video-ui/src/components/VideoPoster/VideoPoster.js
+++ b/public/video-ui/src/components/VideoPoster/VideoPoster.js
@@ -10,6 +10,7 @@ export default class VideoPoster extends React.Component {
         data={this.props.video}
         updateData={this.props.updateVideo}
         editable={this.props.editable}
+        updateErrors={this.props.updateErrors}
       >
         <ManagedField
           fieldLocation="posterImage"

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -10,7 +10,7 @@ class VideoPublishBar extends React.Component {
   }
 
   videoHasUnpublishedChanges() {
-    return hasUnpublishedChanges(this.props.video, this.props.publishedVideo);
+    return hasUnpublishedChanges(this.props.video, this.props.publishedVideo, this.props.editableFields);
   }
 
   isPublishingDisabled() {

--- a/public/video-ui/src/constants/appUpdatedFields.js
+++ b/public/video-ui/src/constants/appUpdatedFields.js
@@ -1,0 +1,1 @@
+export const appUpdatedFields = ['activeVersion'];

--- a/public/video-ui/src/constants/formNames.js
+++ b/public/video-ui/src/constants/formNames.js
@@ -1,5 +1,6 @@
 export const formNames = {
   create: 'createForm',
   metadata: 'metadataForm',
-  youtube: 'youtubeForm'
+  youtube: 'youtubeForm',
+  posterImage: 'posterImage',
 };

--- a/public/video-ui/src/reducers/checkedFormFieldsReducer.js
+++ b/public/video-ui/src/reducers/checkedFormFieldsReducer.js
@@ -2,7 +2,7 @@ export default function errors(state = {}, action) {
 
   let formName, newFormErrors, currentFormErrors, updatedFormErrors, updatedForm;
   switch (action.type) {
-    case 'FORM_ERRORS_UPDATE_REQUEST':
+    case 'CHECKED_FIELDS_UPDATE_REQUEST':
       formName = Object.keys(action.error)[0];
       newFormErrors = action.error[formName];
       currentFormErrors = state[formName] || {};

--- a/public/video-ui/src/reducers/rootReducer.js
+++ b/public/video-ui/src/reducers/rootReducer.js
@@ -14,7 +14,7 @@ import pageCreate from './composerPageReducer';
 import s3Upload from './s3UploadReducer';
 import editState from './editStateReducer';
 import plutoVideos from './plutoVideosReducer';
-import formErrors from './formErrorsReducer';
+import checkedFormFields from './checkedFormFieldsReducer';
 import uploads from './uploadsReducer';
 
 export default combineReducers({
@@ -31,7 +31,7 @@ export default combineReducers({
   pageCreate,
   publishedVideo,
   plutoVideos,
-  formErrors,
+  checkedFormFields,
   s3Upload,
   editState,
   uploads

--- a/public/video-ui/src/util/hasUnpublishedChanges.js
+++ b/public/video-ui/src/util/hasUnpublishedChanges.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
+import {appUpdatedFields} from '../constants/appUpdatedFields';
 
-export function hasUnpublishedChanges(previewVideo, publishedVideo) {
+export function hasUnpublishedChanges(previewVideo, publishedVideo, editableFields) {
   if (!previewVideo) {
     return false;
   }
@@ -9,9 +10,9 @@ export function hasUnpublishedChanges(previewVideo, publishedVideo) {
     return true;
   }
 
-  const propertiesToCheck = ['title', 'description', 'category', 'expiryDate', 'legallySensitive', 'posterImage', 'youtubeCategoryId', 'privacyStatus', 'tags', 'activeVersion'];
+  const allFields = editableFields.concat(appUpdatedFields);
 
-  return !propertiesToCheck.every(key => {
+  return !allFields.every(key => {
     return _.isEqual(previewVideo[key], publishedVideo[key]);
   });
 }


### PR DESCRIPTION
Instead of hardcoding a list of all atom fields we need to compare to check for unpublished changes we compile a list of editable form fields by looking at which form fields get validated. This covers all the atom fields we check except for the assetVersion which is updated by the app when a new asset is selected. This means that we can go from hardcoding all the fields to hardcoding one. 

@akash1810 @mbarton @jennysivapalan 