### PR TITLE
Set to null if no expiry date

### DIFF
--- a/public/video-ui/src/components/FormFields/DatePicker.js
+++ b/public/video-ui/src/components/FormFields/DatePicker.js
@@ -105,7 +105,13 @@ export default function DatePicker({editable, onUpdateField, fieldValue}) {
   const date = fieldValue ? moment(fieldValue) : null;
 
   if(editable) {
-    return <Editor date={date} onChange={(newDate) => { onUpdateField(newDate.valueOf()); }} />;
+    return <Editor date={date} onChange={(newDate) => {
+      if (newDate) {
+        onUpdateField(newDate.valueOf());
+      } else {
+        onUpdateField(null);
+      }
+    }} />;
   } else {
     return <Display date={date} />;
   }


### PR DESCRIPTION
Set the expiry date to null if it is being removed to avoid an error on the client when trying to get valueOf of null. @mbarton @jennysivapalan 