### PR TITLE
Check access for CAPI kinesis streams on healthcheck

### DIFF
--- a/app/di.scala
+++ b/app/di.scala
@@ -61,7 +61,7 @@ class MediaAtomMaker(context: Context)
   private val transcoder = new util.Transcoder(aws, defaultCacheApi)
   private val transcoderController = new controllers.Transcoder(hmacAuthActions, transcoder)
 
-  private val mainApp = new MainApp(stores, wsClient, configuration, hmacAuthActions, permissions)
+  private val mainApp = new MainApp(stores, wsClient, configuration, hmacAuthActions, permissions, aws)
   private val videoApp = new VideoUIApp(hmacAuthActions, configuration, aws, permissions)
 
   private val assets = new controllers.Assets(httpErrorHandler)

--- a/common/src/main/scala/com/gu/media/aws/KinesisAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/KinesisAccess.scala
@@ -3,6 +3,7 @@ package com.gu.media.aws
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
+import com.amazonaws.AmazonClientException
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.kinesis.AmazonKinesisClient
 import com.gu.media.Settings
@@ -35,5 +36,13 @@ trait KinesisAccess { this: Settings with AwsAccess with CrossAccountAccess =>
     val bytes = ByteBuffer.wrap(json.getBytes(StandardCharsets.UTF_8))
 
     kinesisClient.putRecord(streamName, bytes, partitionKey)
+  }
+
+  def testKinesisAccess(streamName: String): Boolean = try {
+    crossAccountKinesisClient.describeStream(streamName)
+    true
+  } catch {
+    case e: AmazonClientException =>
+      false
   }
 }


### PR DESCRIPTION
The app suffered problems last week when one of the 3 PROD machines did not have permission to access the CAPI streams for publishing. This is the first of several PRs to mitigate such problems in the future.

It simply adds a Kinesis DescribeStream call for the CAPI streams to the healthcheck, such that an instance without access would eventually be recycled by the load balancer/auto scaling group.