### PR TITLE
Revert "coursier RC1"

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
 // The Typesafe repository
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/maven-releases/"
 
-// a faster, alternative, dependancy resolver to ivy
+// a, faster, alternative dependancy resolver to ivy
 // https://github.com/coursier/coursier#sbt-plugin
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC1")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15")
 
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.4")


### PR DESCRIPTION
Reverts guardian/media-atom-maker#386

This change seems to have broken builds:

```console
[15:06:22][Step 8/11] /opt/teamcity/buildAgent/work/92ffd722307ca558/test/AuthTests.scala:3: object test is not a member of package com.gu.atom.play
[15:06:22][Step 8/11] [error] import com.gu.atom.play.test.AtomSuite
[15:06:22][Step 8/11] import com.gu.atom.play.test.AtomSuite
```

Not too sure why though, especially as `master` is green...