### PR TITLE
disable add asset link if edits open

### DIFF
--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -132,6 +132,12 @@ class VideoDisplay extends React.Component {
     return null;
   }
 
+  handleAssetClick = (e) => {
+    if (this.cannotMakeEdits()) {
+      e.preventDefault();
+    }
+  }
+
   renderEditButton = (property) => {
 
     if (this.props && this.props.editState[property]) {
@@ -153,7 +159,8 @@ class VideoDisplay extends React.Component {
     return <div className="video__detailbox">
       <div className="video__detailbox__header__container">
         <header className="video__detailbox__header">Video Preview</header>
-        <Link className="button" to={`/videos/${this.props.video.id}/upload`}>
+        <Link className={"button " + (this.cannotMakeEdits() ? "disabled" : "")} to={`/videos/${this.props.video.id}/upload`}
+            onClick={e => this.handleAssetClick(e)}>
           <Icon className="icon__edit video__temporary_button" icon="edit">
             Edit Assets
           </Icon>

--- a/public/video-ui/styles/abstracts/_mixins.scss
+++ b/public/video-ui/styles/abstracts/_mixins.scss
@@ -20,3 +20,9 @@
     outline: 1px solid $cWhite;
   }
 }
+
+@mixin disabled {
+  opacity: 0.4;
+  cursor: default;
+  background-color: darken($color600Grey, 10%);
+}

--- a/public/video-ui/styles/components/_buttons.scss
+++ b/public/video-ui/styles/components/_buttons.scss
@@ -66,4 +66,8 @@ button {
 
 a.button {
   text-decoration: none;
+
+  &.disabled {
+    @include disabled;
+  }
 }

--- a/public/video-ui/styles/layout/_icons.scss
+++ b/public/video-ui/styles/layout/_icons.scss
@@ -57,9 +57,7 @@
     background-color: darken($color600Grey, 10%);
   }
   &.disabled {
-    opacity: 0.4;
-    cursor: default;
-    background-color: darken($color600Grey, 10%);
+    @include disabled;
   }
 }
 


### PR DESCRIPTION
To force the user to save edits before adding assets to prevent the edits from disappearing. 

@akash1810 @jennysivapalan @mbarton 