### PR TITLE
add bash script for teamcity run step

### DIFF
--- a/teamcity.sh
+++ b/teamcity.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'howdy partner'

--- a/teamcity.sh
+++ b/teamcity.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
 
+# This is a hacky solution to a boring problem...
+# The branch `aa-pluto-project-ingestion` introduces a new Node lambda, and with it, new build steps.
+# We can't add the new build steps to TC as all other branches will start failing because the build steps are invalid.
+# We could clone the TC project, but that means build numbers get duplicated and every push gets two builds 🤢.
+# So, lets run this file as a build step in every branch. That way, master just gets a friendly message, and other branches,
+# namely `aa-pluto-project-ingestion` can customise it.
+
 echo 'howdy partner'


### PR DESCRIPTION
I'm currently on a branch that needs extra build steps; rather than clone the TC project and risk build number clashes, lets add a build step to run a file checked into the repo that can then be changed per branch.

Ideally the whole build process will be [codified](https://github.com/guardian/media-atom-maker/blob/aa-ci/teamcity.sh) into the repo, but I couldn't get the [build number to follow through](https://teamcity-aws.gutools.co.uk/viewLog.html?buildId=47127&buildTypeId=EditorialTools_MediaAtomMaker&tab=buildLog#_state=98&focus=1348). So hack a temporary solution for now.