### PR TITLE
New delete workflow

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -127,7 +127,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
 
   def deleteAtom(id: String) = CanDeleteAtom { implicit req =>
     try {
-      DeleteCommand(id, stores).process()
+      DeleteCommand(id, stores, youTube).process()
       Ok(s"Atom $id deleted")
     }
     catch {

--- a/app/model/commands/DeleteCommand.scala
+++ b/app/model/commands/DeleteCommand.scala
@@ -5,15 +5,21 @@ import java.util.Date
 import com.gu.atom.play.AtomAPIActions
 import com.gu.contentatom.thrift.{ContentAtomEvent, EventType}
 import com.gu.media.logging.Logging
+import com.gu.media.youtube.YouTubeVideos
 import data.DataStores
+import model.Platform.Youtube
+import model.{Asset, MediaAtom}
 
-case class DeleteCommand(id: String, override val stores: DataStores)
+case class DeleteCommand(id: String, override val stores: DataStores, youTube: YouTubeVideos)
   extends Command with AtomAPIActions with Logging {
 
   type T = Unit
 
   override def process(): Unit = {
     val atom = getPreviewAtom(id)
+    val mediaAtom = MediaAtom.fromThrift(atom)
+
+    makeYouTubeVideosPrivate(mediaAtom.assets)
 
     val event = ContentAtomEvent(atom, EventType.Takedown, new Date().getTime)
     livePublisher.publishAtomEvent(event)
@@ -21,5 +27,11 @@ case class DeleteCommand(id: String, override val stores: DataStores)
 
     deletePreviewAtom(id)
     deletePublishedAtom(id)
+  }
+
+  private def makeYouTubeVideosPrivate(assets: List[Asset]): Unit = assets.collect {
+    case Asset(_, _, videoId, Youtube, _) =>
+      log.info(s"Marking $videoId as private as parent atom $id is being deleted")
+      youTube.setStatusToPrivate(videoId)
   }
 }

--- a/public/video-ui/src/components/Videos/AdvancedActions.js
+++ b/public/video-ui/src/components/Videos/AdvancedActions.js
@@ -6,22 +6,31 @@ class AdvancedActions extends React.Component {
     permissions = getStore().getState().config.permissions;
     showActions = this.permissions.deleteAtom;
 
+    state = { deleteDoubleCheck: false }
+
     renderDelete() {
         if(!this.permissions.deleteAtom) {
             return false;
         }
 
-        const doDelete = () => {
-            const result = prompt("Enter the atom ID to confirm deletion (it can be copied from the URL)");
+        const disabled = this.props.usage.length > 0;
+        const deleteMsg = this.state.deleteDoubleCheck ? "Confirm delete from database" : "Delete from database";
 
-            if(result === this.props.video.id) {
+        const doDelete = () => {
+            if(this.state.deleteDoubleCheck) {
                 this.props.videoActions.deleteVideo(this.props.video);
+            } else {
+                this.setState({ deleteDoubleCheck: true });
             }
         };
 
         return <li className="action-list__item">
-            <button className="btn label__expired action-list__button" onClick={doDelete}>DELETE</button>
-            <span className="right">Usages will not be replaced and the video will remain on YouTube</span>
+            <button className="btn label__expired action-list__button" onClick={doDelete} disabled={disabled}>
+                {deleteMsg}
+            </button>
+            <span className="right">
+                The video will remain on YouTube as private
+            </span>
         </li>;
     }
 
@@ -48,7 +57,8 @@ import * as deleteVideo from '../../actions/VideoActions/deleteVideo';
 
 function mapStateToProps(state) {
   return {
-    video: state.video
+    video: state.video,
+    usage: state.usage
   };
 }
 

--- a/public/video-ui/src/components/Videos/AdvancedActions.js
+++ b/public/video-ui/src/components/Videos/AdvancedActions.js
@@ -15,6 +15,7 @@ class AdvancedActions extends React.Component {
 
         const disabled = this.props.usage.length > 0;
         const deleteMsg = this.state.deleteDoubleCheck ? "Confirm delete from database" : "Delete from database";
+        const helpMsg = disabled ? "All usages of the atom must be removed before deletion" : "The video will remain on YouTube as private"; 
 
         const doDelete = () => {
             if(this.state.deleteDoubleCheck) {
@@ -29,7 +30,7 @@ class AdvancedActions extends React.Component {
                 {deleteMsg}
             </button>
             <span className="right">
-                The video will remain on YouTube as private
+                {helpMsg}
             </span>
         </li>;
     }


### PR DESCRIPTION
Modify the UI for deleting atoms to be less confusing and inline with how Composer does permanent deletions.

- The delete button (already behind a permissions flag) is not enabled until all Composer usages have been removed
- The delete button itself now prompts you if you really want to delete the atom (rather than entering the atom id into a text box)
- Any associated YouTube videos remain but are made private