### PR TITLE
Fix automatic panda renegotiation

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -24,9 +24,9 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
     with JsonRequestParsing
     with Logging {
 
-  import authActions.APIHMACAuthAction
+  import authActions.{APIAuthAction, APIHMACAuthAction}
 
-  def getMediaAtoms(search: Option[String], limit: Option[Int]) = APIHMACAuthAction {
+  def getMediaAtoms(search: Option[String], limit: Option[Int]) = APIAuthAction {
     val atoms = stores.atomListStore.getAtoms(search, limit)
     Ok(Json.toJson(atoms))
   }
@@ -40,7 +40,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
     }
   }
 
-  def getPublishedMediaAtom(id: String) = APIHMACAuthAction {
+  def getPublishedMediaAtom(id: String) = APIAuthAction {
     try {
       val atom = getPublishedAtom(id)
       Ok(Json.toJson(MediaAtom.fromThrift(atom)))
@@ -53,7 +53,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
     }
   }
 
-  def publishMediaAtom(id: String) = APIHMACAuthAction { implicit req =>
+  def publishMediaAtom(id: String) = APIAuthAction { implicit req =>
     try {
       val command = PublishAtomCommand(id, stores, youTube, youTubeClaims, req.user)
 
@@ -64,7 +64,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
     }
   }
 
-  def createMediaAtom = APIHMACAuthAction { implicit req =>
+  def createMediaAtom = APIAuthAction { implicit req =>
     parse(req) { data: CreateAtomCommandData =>
       val command = CreateAtomCommand(data, stores, req.user)
       val atom = command.process()
@@ -121,7 +121,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
     }
   }
 
-  def getAuditTrailForAtomId(id: String) = APIHMACAuthAction { implicit req =>
+  def getAuditTrailForAtomId(id: String) = APIAuthAction { implicit req =>
     Ok(Json.toJson(auditDataStore.getAuditTrailForAtomId(id)))
   }
 
@@ -135,7 +135,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
     }
   }
 
-  def getPlutoAtoms = APIHMACAuthAction {  implicit req =>
+  def getPlutoAtoms = APIAuthAction {  implicit req =>
 
     val unprocessedAssetResponses: List[PlutoSyncMetadata] = stores.pluto.list()
 
@@ -159,7 +159,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
     Ok(Json.toJson(uploadsWithoutPlutoId))
   }
 
-  def sendToPluto(id: String) = APIHMACAuthAction { implicit req =>
+  def sendToPluto(id: String) = APIAuthAction { implicit req =>
 
     implicit val readCommand: Reads[AddPlutoProjectCommand] =
 

--- a/app/controllers/AtomController.scala
+++ b/app/controllers/AtomController.scala
@@ -33,11 +33,11 @@ trait AtomController extends Controller with UnpackedDataStores {
 
   def jsonError(msg: String): JsObject = JsObject(Seq("error" -> JsString(msg)))
 
-  import authActions.APIHMACAuthAction
+  import authActions.APIAuthAction
 
   object CanUploadAsset extends ActionBuilder[UploadUserRequest] {
     override def invokeBlock[A](request: Request[A], block: UploadUserRequest[A] => Future[Result]): Future[Result] = {
-      APIHMACAuthAction.invokeBlock(request, { req: UserRequest[A] =>
+      APIAuthAction.invokeBlock(request, { req: UserRequest[A] =>
         permissions.getAll(req.user.email).flatMap { p =>
           if(p.addAsset || p.addSelfHostedAsset ) block(new UploadUserRequest(req.user, request, p))
           else Future.successful(Unauthorized(s"User ${req.user.email} is not authorised to upload assets"))
@@ -48,7 +48,7 @@ trait AtomController extends Controller with UnpackedDataStores {
 
   class PermissionedAction(permission: Permission) extends ActionBuilder[UserRequest] {
     override def invokeBlock[A](request: Request[A], block: UserRequest[A] => Future[Result]): Future[Result] = {
-      APIHMACAuthAction.invokeBlock(request, { req: UserRequest[A] =>
+      APIAuthAction.invokeBlock(request, { req: UserRequest[A] =>
 
           permissions.get(permission)(PermissionsUser(req.user.email)).flatMap {
             case PermissionGranted =>

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -25,7 +25,7 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
 
   extends AtomController with Logging with JsonRequestParsing with UnpackedDataStores {
 
-  import authActions.APIHMACAuthAction
+  import authActions.APIAuthAction
 
   private val UPLOAD_KEY_HEADER = "X-Upload-Key"
   private val UPLOAD_URI_HEADER = "X-Upload-Uri"
@@ -34,7 +34,7 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
   private val credsGenerator = new CredentialsGenerator(awsConfig)
   private val uploader = new YouTubeUploader(awsConfig, youTube)
 
-  def list(atomId: String) = APIHMACAuthAction {
+  def list(atomId: String) = APIAuthAction {
     // Anyone can see the running uploads.
     // Only users with permission can create/complete/delete them.
     val uploads = table.list(atomId)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,7 +59,7 @@ object Dependencies {
     "com.gu" %% "pan-domain-auth-play_2-5" % pandaVersion,
     "com.gu" %% "pan-domain-auth-verification" % pandaVersion,
     "com.gu" %% "pan-domain-auth-core" % pandaVersion,
-    "com.gu" %% "panda-hmac" % "1.1.0",
+    "com.gu" %% "panda-hmac" % "1.2.0",
     PlayImport.ws
   )
 

--- a/public/video-ui/src/services/pandaReqwest.js
+++ b/public/video-ui/src/services/pandaReqwest.js
@@ -9,7 +9,7 @@ function poll(reqwestBody, timeout) {
   function makeRequest(resolve, reject) {
     reqwest(reqwestBody)
       .then(response => resolve(response))
-      .catch(err => {
+      .fail(err => {
         if (err.status === 419) {
           const store = getStore();
           const reauthUrl = store.getState().config.reauthUrl;

--- a/public/video-ui/src/services/pandaReqwest.js
+++ b/public/video-ui/src/services/pandaReqwest.js
@@ -9,8 +9,8 @@ function poll(reqwestBody, timeout) {
   function makeRequest(resolve, reject) {
     reqwest(reqwestBody)
       .then(response => resolve(response))
-      .fail(err => {
-        if (err === 419) {
+      .catch(err => {
+        if (err.status === 419) {
           const store = getStore();
           const reauthUrl = store.getState().config.reauthUrl;
 


### PR DESCRIPTION
Fixes a couple of bugs that were stopping [automatic panda session renegotiation](https://github.com/guardian/media-atom-maker/blob/bf1e6bf7e1950ec993e37079b2f69176145b6e65/public/video-ui/src/services/pandaReqwest.js#L17) from working:

- [Correct status code check](https://github.com/guardian/media-atom-maker/blob/bf1e6bf7e1950ec993e37079b2f69176145b6e65/public/video-ui/src/services/pandaReqwest.js#L13)
- Upgrade panda-hmac to avoid https://github.com/guardian/panda-hmac/pull/1

I've also taken the opportunity to disallow HMAC access to all end-points by default, enabling it only for those required by [CDS](https://github.com/guardian/content_delivery_system/blob/master/CDS/scripts/js_utils/media-atom/media-atom.js#L10) and the upload lambda.