### PR TITLE
Fix lambda credentials and cloud-formation

### DIFF
--- a/cloudformation/media-atom-maker.json
+++ b/cloudformation/media-atom-maker.json
@@ -660,12 +660,13 @@
                           {
                             "Effect": "Allow",
                             "Action": ["dynamodb:*"],
-                            "Resource": {
-                              "Fn::Sub": [
+                            "Resource": [
+                              { "Fn::Sub": [
                                 "arn:aws:dynamodb:${Region}:${Account}:table/${Table}",
                                 { "Region": { "Ref": "AWS::Region"}, "Account": { "Ref": "AWS::AccountId" }, "Table": { "Ref": "UploadTrackingTable" } }
-                              ]
-                            }
+                              ]},
+                              { "Fn::Join": ["", ["arn:aws:dynamodb:", {"Ref": "AWS::Region"}, ":", {"Ref": "AWS::AccountId"}, ":table/", {"Ref": "ManualPlutoTable"} ] ] }
+                            ]
                           },
                           {
                             "Effect": "Allow",
@@ -1038,7 +1039,7 @@
                 }
               ]
             },
-            "Roles": [{"Ref": "DistributionRole"}]
+            "Roles": [{ "Ref": "DistributionRole" }, { "Ref": "UploaderRole" }]
           }
         },
         "PlutoKinesisPolicy": {

--- a/common/src/main/scala/com/gu/media/lambda/LambdaBase.scala
+++ b/common/src/main/scala/com/gu/media/lambda/LambdaBase.scala
@@ -12,10 +12,10 @@ trait LambdaBase extends Settings with AwsAccess {
   final override def regionName = sys.env.get("REGION")
   final override def readTag(tag: String) = sys.env.get(tag.toUpperCase(Locale.ENGLISH))
 
+  final override val credentials = AwsCredentials.lambda()
+
   private val remoteConfig = downloadConfig()
   private val mergedConfig = remoteConfig.withFallback(ConfigFactory.load())
-
-  final override val credentials = AwsCredentials.lambda()
 
   override def config: Config = mergedConfig
 

--- a/integration-tests/src/test/scala/VideoUploadTests.scala
+++ b/integration-tests/src/test/scala/VideoUploadTests.scala
@@ -13,6 +13,7 @@ import integration.IntegrationTestBase
 import integration.services.Config
 import org.scalatest.CancelAfterFailure
 import org.scalatest.time.{Minutes, Seconds, Span}
+import play.api.Logger
 import play.api.libs.json.{JsArray, JsValue, Json}
 import services.AWS
 
@@ -56,6 +57,7 @@ class VideoUploadTests extends IntegrationTestBase with CancelAfterFailure {
     val source = s3.getObject(Config.testVideoBucket, Config.testVideo).getObjectContent
 
     uploadParts.foreach { case(uploadKey, start, end) =>
+      Logger.info(s"Getting credentials for $uploadKey")
       val credentials = partRequest(uploadKey, s"$targetBaseUrl/api2/uploads/$uploadId/credentials")
       val temporaryClient = stsCredentialsS3Client(credentials)
 
@@ -65,6 +67,7 @@ class VideoUploadTests extends IntegrationTestBase with CancelAfterFailure {
       val metadata = new ObjectMetadata()
       metadata.setContentLength(length)
 
+      Logger.info(s"Uploading $uploadKey")
       temporaryClient.putObject(uploadBucket, uploadKey, part, metadata)
 
       val response = partRequest(uploadKey, s"$targetBaseUrl/api2/uploads/$uploadId/complete")


### PR DESCRIPTION
#395 broke construction of the lambda functions. This was a NPE due to initialisation order problems. This has been fixed by changing the order.

During the investigation, I also saw problems where the lambda could not send emails or access the manual pluto dynamo table. I've updated the CFN to fix this and already deployed it to CODE.