### PR TITLE
Revert "allow hmac auth to list atoms"

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -26,7 +26,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
 
   import authActions.{APIAuthAction, APIHMACAuthAction}
 
-  def getMediaAtoms(search: Option[String], limit: Option[Int]) = APIHMACAuthAction {
+  def getMediaAtoms(search: Option[String], limit: Option[Int]) = APIAuthAction {
     val atoms = stores.atomListStore.getAtoms(search, limit)
     Ok(Json.toJson(atoms))
   }


### PR DESCRIPTION
Reverts guardian/media-atom-maker#419.

We're using CAPI exclusively now https://github.com/guardian/media-atom-statistics/commit/269731b42b7ab7b912708d6831a41d80140d9139 as this endpoint in MAM is just a proxy to CAPI anyway.