### PR TITLE
Fix reqwest defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "lint-video-ui": "eslint public/video-ui/src/ --fix",
     "lint-cloudformation": "jsonlint cloudformation/*.json --quiet",
     "lint": "yarn lint-video-ui && yarn lint-cloudformation",
-    "test": "yarn lint",
-    "precommit": "yarn test"
+    "test": "yarn lint"
   },
   "devDependencies": {
     "argparse": "^1.0.9",

--- a/public/video-ui/src/services/pandaReqwest.js
+++ b/public/video-ui/src/services/pandaReqwest.js
@@ -35,15 +35,14 @@ function poll(reqwestBody, timeout) {
 
 // when `timeout` > 0, the request will be retried every 100ms until success or timeout
 export function pandaReqwest(reqwestBody, timeout = 0) {
-  const data = reqwestBody.data ? { data: JSON.stringify(reqwestBody.data) } : {};
-  const payload = Object.assign({}, reqwestBody, data);
+  const payload = Object.assign({ method: 'get' }, reqwestBody);
 
-  if(payload.data && !payload.contentType) {
-    payload.contentType = 'application/json';
-  }
+  if(payload.data) {
+    payload.contentType = payload.contentType || 'application/json';
 
-  if(!payload.method) {
-    payload.method = 'get';
+    if(payload.contentType === 'application/json' && typeof payload.data === 'object') {
+      payload.data = JSON.stringify(payload.data);
+    }
   }
 
   return new Promise((resolve, reject) => {

--- a/public/video-ui/src/services/pandaReqwest.js
+++ b/public/video-ui/src/services/pandaReqwest.js
@@ -35,16 +35,16 @@ function poll(reqwestBody, timeout) {
 
 // when `timeout` > 0, the request will be retried every 100ms until success or timeout
 export function pandaReqwest(reqwestBody, timeout = 0) {
-  const defaultPayload = {
-    contentType: 'application/json',
-    method: 'get'
-  };
+  const data = reqwestBody.data ? { data: JSON.stringify(reqwestBody.data) } : {};
+  const payload = Object.assign({}, reqwestBody, data);
 
-  const payload = !reqwestBody.data
-    ? Object.assign(defaultPayload, reqwestBody)
-    : Object.assign(defaultPayload, reqwestBody, {
-        data: JSON.stringify(reqwestBody.data)
-      });
+  if(payload.data && !payload.contentType) {
+    payload.contentType = 'application/json';
+  }
+
+  if(!payload.method) {
+    payload.method = 'get';
+  }
 
   return new Promise((resolve, reject) => {
     poll(payload, timeout)


### PR DESCRIPTION
#424 didn't work correctly for requests without a body:

- Direct upload (credentials and complete)
- Create Composer page

This PR fixes it to only set the contentType if the request actually has a body and does not already have a contentType.

I've also disabled the pre-commit hook from #425 as it was not running correctly on my machine.