### PR TITLE
add new fields to atom

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -180,7 +180,7 @@ class Api (override val stores: DataStores,
 
   }
 
-  private def getAtom(atomId: String, store: DataStore)(fn: Atom => Result): Result = {
+  private def getAtom(atomId: String, store: AtomDataStore)(fn: Atom => Result): Result = {
     store.getAtom(atomId) match {
       case Right(atom) => fn(atom)
       case Left(IDNotFound) => NotFound(s"atom not found $atomId")

--- a/app/data/JsonConversions.scala
+++ b/app/data/JsonConversions.scala
@@ -74,7 +74,7 @@ object JsonConversions {
     (__ \ "posterUrl").writeNullable[String] and
     (__ \ "description").writeNullable[String] and
     (__ \ "trailText").writeNullable[String] and
-    (__ \ "videoSource").writeNullable[String] and
+    (__ \ "source").writeNullable[String] and
     (__ \ "metadata").writeNullable[Metadata]
     ) { mediaAtom: MediaAtom =>
     (
@@ -87,7 +87,7 @@ object JsonConversions {
       mediaAtom.posterUrl,
       mediaAtom.description,
       mediaAtom.trailText,
-      mediaAtom.videoSource,
+      mediaAtom.source,
       mediaAtom.metadata
       )
   }

--- a/app/data/JsonConversions.scala
+++ b/app/data/JsonConversions.scala
@@ -73,6 +73,8 @@ object JsonConversions {
     (__ \ "duration").writeNullable[Long] and
     (__ \ "posterUrl").writeNullable[String] and
     (__ \ "description").writeNullable[String] and
+    (__ \ "trailText").writeNullable[String] and
+    (__ \ "videoSource").writeNullable[String] and
     (__ \ "metadata").writeNullable[Metadata]
     ) { mediaAtom: MediaAtom =>
     (
@@ -84,6 +86,8 @@ object JsonConversions {
       mediaAtom.duration,
       mediaAtom.posterUrl,
       mediaAtom.description,
+      mediaAtom.trailText,
+      mediaAtom.videoSource,
       mediaAtom.metadata
       )
   }
@@ -120,7 +124,9 @@ object JsonConversions {
 
   implicit val flagsWrites = {flags: Flags =>
     (__ \ "legallySensitive").writeNullable[Boolean] and
-      (__ \ "blockAds").writeNullable[Boolean]
+      (__ \ "blockAds").writeNullable[Boolean] and
+      (__ \ "sensitive").writeNullable[Boolean]
+
   }
 
   implicit val atomWrites: Writes[Atom] = (

--- a/app/model/MediaAtom.scala
+++ b/app/model/MediaAtom.scala
@@ -21,7 +21,6 @@ case class MediaAtom(
   source: Option[String],
   description: Option[String],
   trailText: Option[String],
-  videoSource: Option[String],
   posterImage: Option[Image],
   // metadata
   tags: List[String],
@@ -52,7 +51,6 @@ case class MediaAtom(
         description = description,
         trailText = trailText,
         posterImage = posterImage.map(_.asThrift),
-        videoSource = videoSource,
         metadata = Some(ThriftMetadata(
           tags = Some(tags),
           categoryId = youtubeCategoryId,
@@ -116,8 +114,7 @@ object MediaAtom extends MediaAtomImplicits {
       channelId = data.metadata.flatMap(_.channelId),
       legallySensitive = atom.flags.flatMap(_.legallySensitive),
       sensitive = atom.flags.flatMap(_.sensitive),
-      privacyStatus = data.metadata.flatMap(_.privacyStatus).flatMap(PrivacyStatus.fromThrift),
-      videoSource = data.videoSource
+      privacyStatus = data.metadata.flatMap(_.privacyStatus).flatMap(PrivacyStatus.fromThrift)
     )
   }
 

--- a/app/model/MediaAtom.scala
+++ b/app/model/MediaAtom.scala
@@ -20,6 +20,8 @@ case class MediaAtom(
   duration: Option[Long],
   source: Option[String],
   description: Option[String],
+  trailText: Option[String],
+  videoSource: Option[String],
   posterImage: Option[Image],
   // metadata
   tags: List[String],
@@ -28,6 +30,7 @@ case class MediaAtom(
   channelId: Option[String],
   commentsEnabled: Boolean = false,
   legallySensitive: Option[Boolean],
+  sensitive: Option[Boolean],
   privacyStatus: Option[PrivacyStatus],
   expiryDate: Option[Long] = None,
   blockAds: Option[Boolean]) {
@@ -47,7 +50,9 @@ case class MediaAtom(
         source = source,
         posterUrl = posterImage.flatMap(_.master).map(_.file),
         description = description,
+        trailText = trailText,
         posterImage = posterImage.map(_.asThrift),
+        videoSource = videoSource,
         metadata = Some(ThriftMetadata(
           tags = Some(tags),
           categoryId = youtubeCategoryId,
@@ -61,7 +66,8 @@ case class MediaAtom(
       contentChangeDetails = contentChangeDetails.asThrift,
       flags = Some(ThriftFlags(
         legallySensitive = legallySensitive,
-        blockAds = blockAds
+        blockAds = blockAds,
+        sensitive = sensitive
       ))
   )
 
@@ -100,6 +106,7 @@ object MediaAtom extends MediaAtomImplicits {
       source = data.source,
       posterImage = data.posterImage.map(Image.fromThrift),
       description = data.description,
+      trailText = data.trailText,
       tags = data.metadata.flatMap(_.tags.map(_.toList)).getOrElse(Nil),
       youtubeCategoryId = data.metadata.map(_.categoryId).getOrElse(None),
       expiryDate = data.metadata.map(_.expiryDate).getOrElse(None),
@@ -108,7 +115,9 @@ object MediaAtom extends MediaAtomImplicits {
       commentsEnabled = data.metadata.flatMap(_.commentsEnabled).getOrElse(false),
       channelId = data.metadata.flatMap(_.channelId),
       legallySensitive = atom.flags.flatMap(_.legallySensitive),
-      privacyStatus = data.metadata.flatMap(_.privacyStatus).flatMap(PrivacyStatus.fromThrift)
+      sensitive = atom.flags.flatMap(_.sensitive),
+      privacyStatus = data.metadata.flatMap(_.privacyStatus).flatMap(PrivacyStatus.fromThrift),
+      videoSource = data.videoSource
     )
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val awsVersion = "1.11.48"
   val pandaVersion = "0.4.0"
   val mockitoVersion = "2.0.97-beta"
-  val atomMakerVersion = "1.0.1-SNAPSHOT"
+  val atomMakerVersion = "1.0.1"
   val slf4jVersion = "1.7.21"
   val typesafeConfigVersion = "1.3.0" // to match what we get from Play transitively
   val scanamoVersion = "0.9.1" // to match what we get from atom-publisher-lib transitively
@@ -19,7 +19,7 @@ object Dependencies {
   val typesafeConfig = "com.typesafe" % "config" % "1.3.1"
 
   val scanamo = "com.gu" %% "scanamo" % scanamoVersion
-  val contentAtomModel = "com.gu" %% "content-atom-model" %  "2.4.37-SNAPSHOT"
+  val contentAtomModel = "com.gu" %% "content-atom-model" %  "2.4.37"
 
   val scalaTest = "org.scalatest" %% "scalatest" % "2.2.6" % "test"
   val scalaTestPlusPlay = "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % "test"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val awsVersion = "1.11.48"
   val pandaVersion = "0.4.0"
   val mockitoVersion = "2.0.97-beta"
-  val atomMakerVersion = "0.2.4"
+  val atomMakerVersion = "1.0.1-SNAPSHOT"
   val slf4jVersion = "1.7.21"
   val typesafeConfigVersion = "1.3.0" // to match what we get from Play transitively
   val scanamoVersion = "0.9.1" // to match what we get from atom-publisher-lib transitively
@@ -19,7 +19,7 @@ object Dependencies {
   val typesafeConfig = "com.typesafe" % "config" % "1.3.1"
 
   val scanamo = "com.gu" %% "scanamo" % scanamoVersion
-  val contentAtomModel = "com.gu" %% "content-atom-model" %  "2.4.36"
+  val contentAtomModel = "com.gu" %% "content-atom-model" %  "2.4.37-SNAPSHOT"
 
   val scalaTest = "org.scalatest" %% "scalatest" % "2.2.6" % "test"
   val scalaTestPlusPlay = "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % "test"

--- a/public/video-ui/src/actions/VideoActions/videoPageCreate.js
+++ b/public/video-ui/src/actions/VideoActions/videoPageCreate.js
@@ -25,11 +25,11 @@ function errorReceivingVideoPageCreate(error) {
   };
 }
 
-export function createVideoPage(id, metadata, composerUrl, videoBlock) {
+export function createVideoPage(id, video, composerUrl, videoBlock) {
   return dispatch => {
     dispatch(requestVideoPageCreate());
 
-    return VideosApi.createComposerPage(id, metadata, composerUrl)
+    return VideosApi.createComposerPage(id, video, composerUrl)
       .then(res => {
         const pageId = res.data.id;
         const pagePath = res.data.identifiers.path.data;

--- a/public/video-ui/src/actions/VideoActions/videoPageUpdate.js
+++ b/public/video-ui/src/actions/VideoActions/videoPageUpdate.js
@@ -24,19 +24,19 @@ function errorReceivingVideoPageUpdate(error) {
   };
 }
 
-export function updateVideoPage(id, metadata, composerUrl, videoBlock, usages) {
+export function updateVideoPage(id, video, composerUrl, videoBlock, usages) {
   return dispatch => {
     dispatch(requestVideoPageUpdate());
 
     return VideosApi.updateComposerPage(
       id,
-      metadata,
+      video,
       composerUrl,
       videoBlock,
       usages
     )
       .then(() => {
-        return dispatch(receiveVideoPageUpdate(metadata.headline));
+        return dispatch(receiveVideoPageUpdate(video.title));
       })
       .catch(error => {
         dispatch(errorReceivingVideoPageUpdate(error));

--- a/public/video-ui/src/components/FormComponents/CopyTrailButton.js
+++ b/public/video-ui/src/components/FormComponents/CopyTrailButton.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default class CopyTrailButton extends React.Component {
+  render() {
+    return (
+      <button
+        type="button"
+        disabled={!this.props.derivedFrom}
+        className="btn form__label__button"
+        onClick={() => this.props.onUpdateField(this.props.derivedFrom)}
+      >
+        <i className="icon">edit</i>
+        <span data-tip="Copy trail text from description" />
+      </button>
+    );
+  }
+}

--- a/public/video-ui/src/components/FormFields/TextArea.js
+++ b/public/video-ui/src/components/FormFields/TextArea.js
@@ -1,8 +1,18 @@
 import React from 'react';
+import CopyTrailButton from '../FormComponents/CopyTrailButton';
 
 export default class TextArea extends React.Component {
-  displayPlaceholder = () => {
-    return this.props.placeholder === this.props.fieldValue;
+  renderCopyButton = () => {
+    if (this.props.derivedFrom === undefined) {
+      return null;
+    }
+
+    return (
+      <CopyTrailButton
+        onUpdateField={this.props.onUpdateField}
+        derivedFrom={this.props.derivedFrom}
+      />
+    );
   };
 
   renderField = () => {
@@ -13,10 +23,15 @@ export default class TextArea extends React.Component {
           <p
             className={
               'details-list__field ' +
-                (this.displayPlaceholder() ? 'details-list__empty' : '')
+                (this.props.displayPlaceholder(
+                  this.props.placeholder,
+                  this.props.fieldValue
+                )
+                  ? 'details-list__empty'
+                  : '')
             }
           >
-            {' '}{this.props.fieldValue}
+            {this.props.fieldValue}
           </p>
         </div>
       );
@@ -40,10 +55,12 @@ export default class TextArea extends React.Component {
 
     return (
       <div className="form__row">
-        <label className="form__label">{this.props.fieldName}</label>
+        <div className="form__label__layout">
+          <label className="form__label">{this.props.fieldName}</label>
+          {this.renderCopyButton()}
+        </div>
         <textarea
           rows="4"
-          {...this.props.input}
           maxLength={this.props.maxLength || ''}
           className={getTextAreaClassName()}
           type={this.props.inputType || 'text'}

--- a/public/video-ui/src/components/FormFields/TextInput.js
+++ b/public/video-ui/src/components/FormFields/TextInput.js
@@ -6,7 +6,19 @@ export default class TextInput extends React.Component {
       return (
         <div>
           <p className="details-list__title">{this.props.fieldName}</p>
-          <p className="details-list__field"> {this.props.fieldValue}</p>
+          <p
+            className={
+              'details-list__field ' +
+                (this.props.displayPlaceholder(
+                  this.props.placeholder,
+                  this.props.fieldValue
+                )
+                  ? 'details-list__empty'
+                  : '')
+            }
+          >
+            {' '}{this.props.fieldValue}
+          </p>
         </div>
       );
     }

--- a/public/video-ui/src/components/ManagedForm/ManagedField.js
+++ b/public/video-ui/src/components/ManagedForm/ManagedField.js
@@ -103,6 +103,10 @@ export class ManagedField extends React.Component {
     );
   }
 
+  displayPlaceholder(placeholder, fieldValue) {
+    return placeholder && placeholder === fieldValue;
+  }
+
   render() {
     const hydratedChildren = React.Children.map(this.props.children, child => {
       return React.cloneElement(child, {
@@ -118,7 +122,9 @@ export class ManagedField extends React.Component {
         touched: this.state.touched,
         fieldDetails: this.props.fieldDetails,
         hasError: this.hasError,
-        hasWarning: this.hasWarning
+        hasWarning: this.hasWarning,
+        displayPlaceholder: this.displayPlaceholder,
+        derivedFrom: this.props.derivedFrom
       });
     });
     return <div className="form-element">{hydratedChildren}</div>;

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -53,11 +53,42 @@ class VideoData extends React.Component {
               <TextArea />
             </ManagedField>
             <ManagedField
+              fieldLocation="trailText"
+              derivedFrom={this.props.video.description}
+              name="Trail Text"
+              placeholder="No Trail Text"
+            >
+              <TextArea />
+            </ManagedField>
+            <ManagedField
               fieldLocation="blockAds"
               name="Block ads"
               fieldDetails="Ads will not be displayed with this video"
             >
               <CheckBox />
+            </ManagedField>
+            <ManagedField
+              fieldLocation="legallySensitive"
+              name="Legally Sensitive"
+              fieldDetails="This content involves active criminal proceedings."
+            >
+              <CheckBox />
+            </ManagedField>
+            <ManagedField
+              fieldLocation="sensitive"
+              name="Sensitive"
+              fieldDetails="Contains sensitive content"
+            >
+              <CheckBox />
+            </ManagedField>
+          </ManagedSection>
+          <ManagedSection>
+            <ManagedField
+              fieldLocation="videoSource"
+              name="Video Source"
+              placeholder="No video source"
+            >
+              <TextInput />
             </ManagedField>
             <ManagedField fieldLocation="category" name="Category">
               <SelectBox selectValues={videoCategories} />
@@ -81,15 +112,6 @@ class VideoData extends React.Component {
             </ManagedField>
             <ManagedField fieldLocation="tags" name="Keywords">
               <KeywordPicker />
-            </ManagedField>
-          </ManagedSection>
-          <ManagedSection>
-            <ManagedField
-              fieldLocation="legallySensitive"
-              name="Legally Sensitive"
-              fieldDetails="This content involves active criminal proceedings."
-            >
-              <CheckBox />
             </ManagedField>
           </ManagedSection>
         </ManagedForm>

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -27,15 +27,6 @@ export default class VideoPublishBar extends React.Component {
     );
   }
 
-  getVideoMetadata = () => {
-    return {
-      headline: this.props.video.title,
-      standfirst: this.props.video.description
-        ? '<p>' + this.props.video.description + '</p>'
-        : null
-    };
-  };
-
   getComposerUrl = () => {
     return getStore().getState().config.composerUrl;
   };
@@ -43,14 +34,15 @@ export default class VideoPublishBar extends React.Component {
   publishVideo = () => {
     const usages = getComposerPages(this.props.usages);
 
-    const metadata = this.getVideoMetadata();
-
-    const videoBlock = getVideoBlock(this.props.video.id, metadata);
+    const videoBlock = getVideoBlock(
+      this.props.video.id,
+      this.props.video.title
+    );
 
     if (usages.length > 0) {
       this.props.updateVideoPage(
         this.props.video.id,
-        metadata,
+        this.props.video,
         this.getComposerUrl(),
         videoBlock,
         usages

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -1,15 +1,9 @@
 import React from 'react';
 import moment from 'moment';
-import { getVideoBlock } from '../../util/getVideoBlock';
 import { getStore } from '../../util/storeAccessor';
-import { hasUnpublishedChanges } from '../../util/hasUnpublishedChanges';
 import { FrontendIcon, ComposerIcon, ViewerIcon } from '../Icon';
 
 export default class VideoUsages extends React.Component {
-  state = {
-    pageCreated: false
-  };
-
   getComposerUrl = () => {
     return getStore().getState().config.composerUrl;
   };
@@ -17,30 +11,6 @@ export default class VideoUsages extends React.Component {
   getViewerUrl = () => {
     return getStore().getState().config.viewerUrl;
   };
-
-  pageCreate = () => {
-    this.setState({
-      pageCreated: true
-    });
-
-    const metadata = {
-      title: this.props.video.title,
-      standfirst: this.props.video.description
-    };
-
-    const videoBlock = getVideoBlock(this.props.video.id, metadata);
-
-    return this.props.createComposerPage(
-      this.props.video.id,
-      metadata,
-      this.getComposerUrl(),
-      videoBlock
-    );
-  };
-
-  videoHasUnpublishedChanges() {
-    return hasUnpublishedChanges(this.props.video, this.props.publishedVideo);
-  }
 
   renderUsage = usage => {
     const composerLink = `${this.getComposerUrl()}/content/${usage.fields.internalComposerCode}`;

--- a/public/video-ui/src/components/Videos/ComposerPageCreate.js
+++ b/public/video-ui/src/components/Videos/ComposerPageCreate.js
@@ -9,15 +9,6 @@ export default class ComposerPageCreate extends React.Component {
     composerUpdateInProgress: false
   };
 
-  getVideoMetadata = () => {
-    return {
-      headline: this.props.video.title,
-      standfirst: this.props.video.description
-        ? '<p>' + this.props.video.description + '</p>'
-        : null
-    };
-  };
-
   getComposerUrl = () => {
     return getStore().getState().config.composerUrl;
   };
@@ -31,14 +22,15 @@ export default class ComposerPageCreate extends React.Component {
       composerUpdateInProgress: true
     });
 
-    const metadata = this.getVideoMetadata();
-
-    const videoBlock = getVideoBlock(this.props.video.id, metadata);
+    const videoBlock = getVideoBlock(
+      this.props.video.id,
+      this.props.video.title
+    );
 
     return this.props
       .createVideoPage(
         this.props.video.id,
-        metadata,
+        this.props.video,
         this.getComposerUrl(),
         videoBlock
       )

--- a/public/video-ui/src/constants/composerSyncFields.js
+++ b/public/video-ui/src/constants/composerSyncFields.js
@@ -1,1 +1,0 @@
-export const composerSyncFields = ['headline', 'standfirst'];

--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -98,10 +98,9 @@ export default {
       const rightsRequest = pandaReqwest({
         url: `${composerUrlBase}/api/content/${id}/expiry/rights`,
         method: 'post',
-        contentType: 'application/json',
         crossOrigin: true,
         withCredentials: true,
-        data: JSON.stringify(rightsExpiryPayload)
+        data: rightsExpiryPayload
       });
 
       // When article is in preview, composer keeps track of both the live and preview versions of an article
@@ -125,10 +124,9 @@ export default {
         return pandaReqwest({
           url: `${composerUrl}/api/content/${pageId}/${stage}/${data.belongsTo}/${data.name}`,
           method: 'put',
-          contentType: 'application/json',
           crossOrigin: true,
           withCredentials: true,
-          data: `"${value}"`
+          data: `"${data.value}"`
         });
       }
 
@@ -169,7 +167,6 @@ export default {
   },
 
   createComposerPage(id, video, composerUrlBase) {
-
     const composerData = getComposerData(video);
 
     const initialComposerUrl =

--- a/public/video-ui/src/util/getComposerData.js
+++ b/public/video-ui/src/util/getComposerData.js
@@ -1,0 +1,39 @@
+export function getComposerData(video) {
+  return [
+    {
+      name: 'headline',
+      value: video.title,
+      belongsTo: 'fields'
+    },
+    {
+      name: 'standfirst',
+      value: video.description ? '<p>' + video.description + '</p>' : null,
+      belongsTo: 'fields'
+    },
+    {
+      name: 'trailText',
+      value: video.trailText ? '<p>' + video.trailText + '</p>' : null,
+      belongsTo: 'fields'
+    },
+    {
+      name: 'sensitive',
+      value: video.sensitive ? 'true' : 'false',
+      belongsTo: 'settings'
+    },
+    {
+      name: 'legallySensitive',
+      value: video.legallySensitive ? 'true' : 'false',
+      belongsTo: 'settings'
+    }
+  ];
+}
+
+export function getRightsPayload(video) {
+  if (video.expiryDate) {
+    return {
+      command: 'schedule',
+      date: video.expiryDate
+    };
+  }
+  return { command: 'reset' };
+}

--- a/public/video-ui/src/util/getVideoBlock.js
+++ b/public/video-ui/src/util/getVideoBlock.js
@@ -1,4 +1,4 @@
-export function getVideoBlock(id, metadata) {
+export function getVideoBlock(id, title) {
   return {
     elements: [
       {
@@ -7,8 +7,7 @@ export function getVideoBlock(id, metadata) {
           id: id,
           atomType: 'media',
           required: 'true',
-          title: metadata.title,
-          description: metadata.description,
+          title: title,
           published: 'Unable to get published state from atom',
           isMandatory: 'true',
           editorialLink: ''

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -95,6 +95,17 @@
   border-top: 1px solid $color625Grey;
 }
 
+.form__label__layout {
+  display: flex;
+  justify-content: space-between;
+  align-items: center
+}
+
+.form__label__button {
+  font-size: 10px;
+  padding: 5px;
+}
+
 .form__message {
   font-size: 13px;
   margin: 0;

--- a/test/ThriftUtilSpec.scala
+++ b/test/ThriftUtilSpec.scala
@@ -32,19 +32,19 @@ class ThriftUtilSpec extends FunSpec
 
     it("should correctly generate media atom data") {
       inside(parseMediaAtom(makeParams("uri" -> youtubeUrl))) {
-        case Right(MediaAtom(assets, Some(1L), "unknown", Category.News, None, None, None, None, None, None, None)) =>
+        case Right(MediaAtom(assets, Some(1L), "unknown", Category.News, None, None, None, None, None, None, None, None)) =>
           assets should have length 1
           assets.head should equal(Asset(AssetType.Video, 1L, youtubeId, Platform.Youtube))
       }
     }
 
     it("should create empty assets without uri") {
-      parseMediaAtom(Map.empty) should matchPattern { case Right(MediaAtom(Nil, _, _, _, _, _, _, _, _, _, _)) => }
+      parseMediaAtom(Map.empty) should matchPattern { case Right(MediaAtom(Nil, _, _, _, _, _, _, _, _, _, _, _)) => }
     }
 
     it("should create multiple assets with multiple uri params") {
       inside(parseMediaAtom(Map("uri" -> List(youtubeUrl, youtubeUrl)))) {
-        case Right(MediaAtom(assets, _, _, _, _, _, _, _, _, _, _)) =>
+        case Right(MediaAtom(assets, _, _, _, _, _, _, _, _, _, _, _)) =>
           assets should have length 2
       }
     }
@@ -68,7 +68,7 @@ class ThriftUtilSpec extends FunSpec
       val meta = "{\"channelId\":\"channelId\",\"commentsEnabled\":true,\"privacyStatus\":\"private\",\"expiryDate\":1}"
 
       inside(parseMediaAtom(makeParams("uri" -> youtubeUrl, "metadata" -> meta))) {
-        case Right(MediaAtom(assets, Some(1L), "unknown", Category.News, None, None, None, None, None, metadata, None)) =>
+        case Right(MediaAtom(assets, Some(1L), "unknown", Category.News, None, None, None, None, None, metadata, None, None)) =>
           metadata should matchPattern { case Some(Metadata(_, _, _, Some(true), Some("channelId"), Some(PrivacyStatus.Private), Some(1))) => }
       }
     }


### PR DESCRIPTION
- Add source, sensitive and trail fields to media atom. As in composer, there is a button to copy the trail text from the video description.

- Sync trail text, expiry date, legally sensitive and sensitive fields with composer on page create and update. 

- depends on https://github.com/guardian/content-atom/pull/85/files and https://github.com/guardian/atom-maker/pull/25


@mbarton @akash1810 
<img width="1215" alt="screen shot 2017-05-08 at 15 05 56" src="https://cloud.githubusercontent.com/assets/3066534/25807775/de50f2f8-33ff-11e7-8bbf-1f5191400f48.png">
