### PR TITLE
log when about to send an email

### DIFF
--- a/common/src/main/scala/com/gu/media/upload/actions/UploadActionHandler.scala
+++ b/common/src/main/scala/com/gu/media/upload/actions/UploadActionHandler.scala
@@ -113,6 +113,7 @@ abstract class UploadActionHandler(store: UploadsDataStore, plutoStore: PlutoDat
 
         case None =>
           val metadata = upload.metadata
+          log.info(s"Sending missing Pluto ID email user=${metadata.user} atom=${plutoData.atomId}")
           mailer.sendPlutoIdMissingEmail(metadata.title, metadata.user, uploaderAccess.fromEmailAddress,
             uploaderAccess.replyToAddresses)
           plutoStore.put(plutoData)


### PR DESCRIPTION
because you can never log too much!

A point of contention is logging `metadata.user` which is an email address 🔒 