### PR TITLE
Fix logic for disabling pluto sync

### DIFF
--- a/common/src/main/scala/com/gu/media/upload/actions/UploadActionHandler.scala
+++ b/common/src/main/scala/com/gu/media/upload/actions/UploadActionHandler.scala
@@ -104,7 +104,7 @@ abstract class UploadActionHandler(store: UploadsDataStore, plutoStore: PlutoDat
   private def sendToPluto(upload: Upload): Unit = {
     val plutoData: PlutoSyncMetadata = upload.metadata.pluto
 
-    if(plutoData.enabled) {
+    if(!plutoData.enabled) {
       log.info(s"Not syncing to Pluto upload=${upload.id} atom=${plutoData.atomId}")
     } else {
       plutoData.projectId match {


### PR DESCRIPTION
The automated tests (and post #431 uploads from the UI) should not have been running the code to sync to pluto as it has not been finished.

Unfortunately the test was wrong, causing the code to run. The effect of this was that the automated tests caused an email to be sent every time to an address that could not receive email. 

This PR fixes the test to not run the Pluto sync code at all.