### PR TITLE
Use consistent reads for uploads

### DIFF
--- a/app/util/AWS.scala
+++ b/app/util/AWS.scala
@@ -5,13 +5,14 @@ import com.amazonaws.services.ec2.model.{DescribeTagsRequest, Filter}
 import com.amazonaws.util.EC2MetadataUtils
 import com.gu.media.Settings
 import com.gu.media.aws._
-import com.gu.media.logging.KinesisLogging
+import com.gu.media.logging.{KinesisLogging, Logging}
 import com.typesafe.config.Config
 
 import scala.collection.JavaConverters._
 
 class AWSConfig(override val config: Config, override val credentials: AwsCredentials)
   extends Settings
+    with Logging
     with AwsAccess
     with S3Access
     with DynamoAccess

--- a/common/src/main/scala/com/gu/media/aws/KinesisAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/KinesisAccess.scala
@@ -4,12 +4,12 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
 import com.amazonaws.AmazonClientException
-import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.kinesis.AmazonKinesisClient
 import com.gu.media.Settings
+import com.gu.media.logging.Logging
 import play.api.libs.json.{Json, Writes}
 
-trait KinesisAccess { this: Settings with AwsAccess =>
+trait KinesisAccess { this: Settings with AwsAccess with Logging =>
   val liveKinesisStreamName: String = getMandatoryString("aws.kinesis.liveStreamName")
   val previewKinesisStreamName: String = getMandatoryString("aws.kinesis.previewStreamName")
 
@@ -24,6 +24,8 @@ trait KinesisAccess { this: Settings with AwsAccess =>
 
   def sendOnKinesis[T: Writes](streamName: String, partitionKey: String, value: T): Unit = {
     val json = Json.stringify(Json.toJson(value))
+    log.info(s"Sending JSON on Kinesis [$streamName]: $json")
+
     val bytes = ByteBuffer.wrap(json.getBytes(StandardCharsets.UTF_8))
 
     kinesisClient.putRecord(streamName, bytes, partitionKey)

--- a/common/src/main/scala/com/gu/media/upload/UploadsDataStore.scala
+++ b/common/src/main/scala/com/gu/media/upload/UploadsDataStore.scala
@@ -33,7 +33,7 @@ class UploadsDataStore(aws: DynamoAccess) {
   }
 
   def get(id: String): Option[Upload] = {
-    val operation = table.get('id -> id)
+    val operation = table.consistently.get('id -> id)
     val result = Scanamo.exec(aws.dynamoDB)(operation)
 
     result.map {

--- a/common/src/main/scala/com/gu/media/upload/actions/UploadActionSender.scala
+++ b/common/src/main/scala/com/gu/media/upload/actions/UploadActionSender.scala
@@ -1,13 +1,16 @@
 package com.gu.media.upload.actions
 
 import com.gu.media.aws.KinesisAccess
+import com.gu.media.logging.Logging
 
 trait UploadActionSender {
   def send(action: UploadAction): Unit
 }
 
-class KinesisActionSender(aws: KinesisAccess) extends UploadActionSender {
+class KinesisActionSender(aws: KinesisAccess) extends UploadActionSender with Logging {
   override def send(action: UploadAction): Unit = {
+    log.info(s"Sending action on Kinesis: $action")
+
     aws.sendOnKinesis(aws.uploadActionsStreamName, action.upload.id, action)
   }
 }

--- a/uploader/src/main/scala/com/gu/media/UploadActionsLambda.scala
+++ b/uploader/src/main/scala/com/gu/media/UploadActionsLambda.scala
@@ -22,7 +22,7 @@ class UploadActionsLambda extends RequestHandler[KinesisEvent, Unit]
   with SESSettings
   with KinesisAccess
   with ElasticTranscodeAccess {
-  
+
   val store = new UploadsDataStore(this)
   val plutoStore = new PlutoDataStore(this.dynamoDB, this.manualPlutoDynamo)
   val uploader = new YouTubeUploader(this, this)
@@ -43,8 +43,11 @@ class UploadActionsLambda extends RequestHandler[KinesisEvent, Unit]
     val record = input.getRecords.get(0)
     val data = new String(record.getKinesis.getData.array(), "UTF-8")
 
+    log.info(s"Received JSON from Kinesis: $data")
+
     Json.parse(data).validate[UploadAction] match {
       case JsSuccess(action, _) =>
+        log.info(s"Received action from Kinesis: $action")
         Some(action)
 
       case JsError(err) =>


### PR DESCRIPTION
User reported issue with direct upload:

![picture 412](https://cloud.githubusercontent.com/assets/395805/25907498/83bfe168-359f-11e7-9705-896e0e1241dd.jpg)

The investigation to this is still on-going. This PR kicks things off:

- Uses consistent reads on the uploads table
    - The code does currently expect to be able to read out what was previously written in (by ID)

- Add low level logging for the JSON in and out of the uploads Kinesis stream
    - The lambda appeared to run the `DeleteParts` command rather than the expected `UploadPartToYouTube` command
