### PR TITLE
Explicit serialisation for UploadActions

### DIFF
--- a/app/util/DevUploadSender.scala
+++ b/app/util/DevUploadSender.scala
@@ -3,14 +3,19 @@ package util
 import java.util.concurrent.Executors
 
 import com.gu.media.upload.actions.{UploadAction, UploadActionHandler, UploadActionSender}
+import play.api.libs.json.Json
 
 class DevUploadSender(handler: UploadActionHandler) extends UploadActionSender {
   private val threadPool = Executors.newSingleThreadScheduledExecutor()
 
   override def send(action: UploadAction): Unit = {
+    // Serialise to/from JSON, just as we do with Kinesis
+    val serialised = Json.stringify(Json.toJson(action))
+
     threadPool.submit(new Runnable {
       override def run(): Unit = {
-        handler.handle(action)
+        val deserialised = Json.parse(serialised).as[UploadAction]
+        handler.handle(deserialised)
       }
     })
   }

--- a/common/src/main/scala/com/gu/media/upload/actions/package.scala
+++ b/common/src/main/scala/com/gu/media/upload/actions/package.scala
@@ -3,7 +3,7 @@ package com.gu.media.upload
 import com.gu.media.upload.model.{Upload, UploadPart}
 import com.gu.media.aws._
 import org.cvogt.play.json.Jsonx
-import play.api.libs.json.Format
+import play.api.libs.json._
 
 package object actions {
   sealed abstract class UploadAction { def upload: Upload }
@@ -18,5 +18,30 @@ package object actions {
   implicit val copyPartsFormat: Format[CopyParts] = Jsonx.formatCaseClass[CopyParts]
   implicit val deletePartsFormat: Format[DeleteParts] = Jsonx.formatCaseClass[DeleteParts]
   implicit val uploadPartsToSelfHostFormat: Format[UploadPartsToSelfHost] = Jsonx.formatCaseClass[UploadPartsToSelfHost]
-  implicit val uploadActionFormat: Format[UploadAction] = Jsonx.formatSealed[UploadAction]
+
+  implicit val uploadActionsRead: Reads[UploadAction] = Reads[UploadAction] { json =>
+    (json \ "type").validate[String].flatMap {
+      case "UploadPartToYouTube" => (json \ "data").validate[UploadPartToYouTube]
+      case "CopyParts" => (json \ "data").validate[CopyParts]
+      case "UploadPartsToSelfHost" => (json \ "data").validate[UploadPartsToSelfHost]
+      case "DeleteParts" => (json \ "data").validate[DeleteParts]
+      case unknown => JsError(s"Unknown UploadAction type $unknown")
+    }
+  }
+
+  implicit val uploadActionsWrite: Writes[UploadAction] = Writes[UploadAction] {
+    case value: UploadPartToYouTube =>
+      writeHelper("UploadPartToYouTube", Json.toJson(value)(uploadPartToYouTubeFormat))
+
+    case value: CopyParts =>
+      writeHelper("CopyParts", Json.toJson(value)(copyPartsFormat))
+
+    case value: UploadPartsToSelfHost =>
+      writeHelper("UploadPartsToSelfHost", Json.toJson(value)(uploadPartsToSelfHostFormat))
+
+    case value: DeleteParts =>
+      writeHelper("DeleteParts", Json.toJson(value)(deletePartsFormat))
+  }
+
+  private def writeHelper(tpe: String, data: JsValue) = JsObject(Map("type" -> JsString(tpe), "data" -> data))
 }


### PR DESCRIPTION
Following on into the investigation for #436, this PR removes the use of `formatSealed` which *may* be ambiguous with explicit serialisation code.

NB: if we go down the step functions route (#435) then this nasty serialisation code will be removed entirely.