### PR TITLE
Revert "fix riffraff warnings" (as it is quite magical™)

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -29,7 +29,9 @@ deployments:
     template: lambda
     parameters:
       functionNames: [media-atom-maker-expirer-]
+      fileName: media-atom-expirer.zip
   pluto-message-ingestion:
     template: lambda
     parameters:
       functionNames: [pluto-message-ingestion-]
+      fileName: pluto-message-ingestion.zip


### PR DESCRIPTION
Reverts #432 which removed warnings for all of a day before guardian/riff-raff#436 put some new ones in.