### PR TITLE
Fix video page styling when not full width

### DIFF
--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -164,7 +164,7 @@ class VideoDisplay extends React.Component {
 
         <div className="video">
           <div className="video__main">
-            <div className="video__main__header">
+            <div className="video__row">
               {this.renderPreview()}
               <div className="video__detailbox video__data">
                 <div className="video__detailbox__header__container">
@@ -181,6 +181,8 @@ class VideoDisplay extends React.Component {
                   updateErrors={this.props.formErrorActions.updateFormErrors}
                 />
               </div>
+            </div>
+            <div className="video__row">
               <div className="video__detailbox">
                 <div className="video__detailbox__header__container">
                   <header className="video__detailbox__header">

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -17,6 +17,10 @@
   }
 }
 
+.video__row {
+  display: flex;
+}
+
 .video-preview {
   text-align: center;
   border-style: none;


### PR DESCRIPTION
If the browser is not the full width of my screen the video page renders funny. I've fixed this by splitting each row on the page into a separate flex container.

**Before**
<img width="1211" alt="607b5f1b-e25d-4990-abeb-5e66f9f71852" src="https://cloud.githubusercontent.com/assets/395805/25944450/4faf6348-363b-11e7-9486-91c063eae4ae.png">

**After**
<img width="1216" alt="092c891b-25cb-4ecb-a024-ec0cbf0b2f2f" src="https://cloud.githubusercontent.com/assets/395805/25944456/5551bdbe-363b-11e7-9fb9-a598e215b791.png">
