### PR TITLE
client side pluto project selection

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -164,7 +164,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
         previewDataStore.getAtom(upload.atomId) match {
           case Right(atom) => {
             val mediaAtom = MediaAtom.fromThrift(atom)
-            mediaAtom.plutoProjectId match {
+            mediaAtom.plutoData match {
               case None => acc ++ Map(upload.atomId -> mediaAtom)
               case Some(string) => acc
             }

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -127,7 +127,7 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
 
     val plutoData = PlutoSyncMetadata(
       enabled = syncWithPluto,
-      projectId = atom.plutoProjectId,
+      projectId = atom.plutoData.flatMap(_.projectId),
       s3Key = CompleteUploadKey(awsConfig.userUploadFolder, id).toString,
       assetVersion = -1,
       atomId = atom.id

--- a/app/data/JsonConversions.scala
+++ b/app/data/JsonConversions.scala
@@ -21,7 +21,7 @@ object JsonConversions {
     }
   })
 
-  implicit val mediaAsset = (
+  implicit val mediaAsset: Writes[Asset] = (
     (__ \ "id").write[String] and
     (__ \ "version").write[Long] and
     (__ \ "platform").write[String] and
@@ -33,6 +33,18 @@ object JsonConversions {
     }
   }
 
+  implicit val plutoReads: Reads[PlutoData] = (
+    (__ \ "commissionId").readNullable[String] and
+    (__ \ "projectId").readNullable[String] and
+    (__ \ "masterId").readNullable[String]
+  )(PlutoData.apply _)
+
+  implicit val plutoWrites: Writes[PlutoData] = (
+    (__ \ "commissionId").writeNullable[String] and
+    (__ \ "projectId").writeNullable[String] and
+    (__ \ "masterId").writeNullable[String]
+  ) {pluto: PlutoData => (pluto.commissionId, pluto.projectId, pluto.masterId )}
+
   implicit val mediaMetadata: Writes[Metadata] = (
     (__ \ "tags").writeNullable[Seq[String]] and
     (__ \ "categoryId").writeNullable[String] and
@@ -40,7 +52,8 @@ object JsonConversions {
     (__ \ "commentsEnabled").writeNullable[Boolean] and
     (__ \ "channelId").writeNullable[String] and
     (__ \ "privacyStatus").writeNullable[PrivacyStatus] and
-    (__ \ "expiryDate").writeNullable[Long]
+    (__ \ "expiryDate").writeNullable[Long] and
+    (__ \ "pluto").writeNullable[PlutoData]
 
   ) { metadata: Metadata =>
       (
@@ -50,7 +63,8 @@ object JsonConversions {
         metadata.commentsEnabled,
         metadata.channelId,
         metadata.privacyStatus,
-        metadata.expiryDate
+        metadata.expiryDate,
+        metadata.pluto
         )
   }
 
@@ -61,7 +75,8 @@ object JsonConversions {
     (__ \ "commentsEnabled").readNullable[Boolean] and
     (__ \ "channelId").readNullable[String] and
     (__ \ "privacyStatus").readNullable[PrivacyStatus] and
-    (__ \ "expiryDate").readNullable[Long]
+    (__ \ "expiryDate").readNullable[Long] and
+    (__ \ "pluto").readNullable[PlutoData]
   )(Metadata.apply _)
 
   implicit val atomDataMedia = (

--- a/app/model/MediaAtom.scala
+++ b/app/model/MediaAtom.scala
@@ -16,9 +16,7 @@ case class MediaAtom(
   activeVersion: Option[Long],
   title: String,
   category: Category,
-  plutoCommissionId: Option[String],
-  plutoProjectId: Option[String],
-  plutoMasterId: Option[String],
+  plutoData: Option[PlutoData],
   duration: Option[Long],
   source: Option[String],
   description: Option[String],
@@ -61,11 +59,7 @@ case class MediaAtom(
           channelId = channelId,
           privacyStatus = privacyStatus.flatMap(_.asThrift),
           expiryDate = expiryDate,
-          pluto = Some(ThriftPlutoData(
-            commissionId = plutoCommissionId,
-            projectId = plutoProjectId,
-            masterId = plutoMasterId
-          ))
+          pluto = plutoData.map(_.asThrift)
           ))
         )),
       contentChangeDetails = contentChangeDetails.asThrift,
@@ -106,9 +100,7 @@ object MediaAtom extends MediaAtomImplicits {
       activeVersion = data.activeVersion,
       title = data.title,
       category = Category.fromThrift(data.category),
-      plutoCommissionId = data.metadata.flatMap(_.pluto.flatMap(_.commissionId)),
-      plutoProjectId = data.metadata.flatMap(_.pluto.flatMap(_.projectId)),
-      plutoMasterId = data.metadata.flatMap(_.pluto.flatMap(_.masterId)),
+      plutoData = data.metadata.flatMap(_.pluto).map(PlutoData.fromThrift),
       duration = data.duration,
       source = data.source,
       posterImage = data.posterImage.map(Image.fromThrift),

--- a/app/model/MediaAtom.scala
+++ b/app/model/MediaAtom.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.gu.contentatom.thrift.atom.media.{MediaAtom => ThriftMediaAtom, Metadata => ThriftMetadata}
+import com.gu.contentatom.thrift.atom.media.{MediaAtom => ThriftMediaAtom, Metadata => ThriftMetadata, PlutoData => ThriftPlutoData}
 import com.gu.contentatom.thrift.{AtomData, Atom => ThriftAtom, AtomType => ThriftAtomType, Flags => ThriftFlags}
 import org.cvogt.play.json.Jsonx
 import util.atom.MediaAtomImplicits
@@ -16,7 +16,9 @@ case class MediaAtom(
   activeVersion: Option[Long],
   title: String,
   category: Category,
+  plutoCommissionId: Option[String],
   plutoProjectId: Option[String],
+  plutoMasterId: Option[String],
   duration: Option[Long],
   source: Option[String],
   description: Option[String],
@@ -45,7 +47,6 @@ case class MediaAtom(
         activeVersion = activeVersion,
         title = title,
         category = category.asThrift,
-        plutoProjectId = plutoProjectId,
         duration = duration,
         source = source,
         posterUrl = posterImage.flatMap(_.master).map(_.file),
@@ -59,7 +60,12 @@ case class MediaAtom(
           commentsEnabled = Some(commentsEnabled),
           channelId = channelId,
           privacyStatus = privacyStatus.flatMap(_.asThrift),
-          expiryDate = expiryDate
+          expiryDate = expiryDate,
+          pluto = Some(ThriftPlutoData(
+            commissionId = plutoCommissionId,
+            projectId = plutoProjectId,
+            masterId = plutoMasterId
+          ))
           ))
         )),
       contentChangeDetails = contentChangeDetails.asThrift,
@@ -100,7 +106,9 @@ object MediaAtom extends MediaAtomImplicits {
       activeVersion = data.activeVersion,
       title = data.title,
       category = Category.fromThrift(data.category),
-      plutoProjectId = data.plutoProjectId,
+      plutoCommissionId = data.metadata.flatMap(_.pluto.flatMap(_.commissionId)),
+      plutoProjectId = data.metadata.flatMap(_.pluto.flatMap(_.projectId)),
+      plutoMasterId = data.metadata.flatMap(_.pluto.flatMap(_.masterId)),
       duration = data.duration,
       source = data.source,
       posterImage = data.posterImage.map(Image.fromThrift),

--- a/app/model/PlutoData.scala
+++ b/app/model/PlutoData.scala
@@ -1,0 +1,23 @@
+package model
+
+import com.gu.contentatom.thrift.atom.media.{PlutoData => ThriftPlutoData}
+import org.cvogt.play.json.Jsonx
+import play.api.libs.json.Format
+
+case class PlutoData (
+  commissionId: Option[String],
+  projectId: Option[String],
+  masterId: Option[String]
+) {
+  def asThrift: ThriftPlutoData = ThriftPlutoData(commissionId,projectId,masterId)
+}
+
+object PlutoData {
+  implicit val plutoDataFormat: Format[PlutoData] = Jsonx.formatCaseClass[PlutoData]
+
+  def fromThrift(plutoData: ThriftPlutoData) = PlutoData(
+    plutoData.commissionId,
+    plutoData.projectId,
+    plutoData.masterId
+  )
+}

--- a/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
@@ -3,11 +3,26 @@ package com.gu.media.upload.model
 import org.cvogt.play.json.Jsonx
 import play.api.libs.json.Format
 
-case class UploadMetadata(user: String, bucket: String, region: String, title: String, channel: String,
-                          pluto: PlutoSyncMetadata, selfHost: Boolean = false, youTubeId: Option[String] = None,
-                          youTubeUploadUri: Option[String] = None, useStepFunctions: Boolean = false)
+case class UploadMetadata(
+  user: String,
+  bucket: String,
+  region: String,
+  title: String,
+  channel: String,
+  pluto: PlutoSyncMetadata,
+  selfHost: Boolean = false,
+  youTubeId: Option[String] = None,
+  youTubeUploadUri: Option[String] = None,
+  useStepFunctions: Boolean = false
+)
 
-case class PlutoSyncMetadata(enabled: Boolean, projectId: Option[String], s3Key: String, assetVersion: Long, atomId: String)
+case class PlutoSyncMetadata (
+  enabled: Boolean,
+  projectId: Option[String],
+  s3Key: String,
+  assetVersion: Long,
+  atomId: String
+)
 
 object UploadMetadata {
   implicit val format: Format[UploadMetadata] = Jsonx.formatCaseClass[UploadMetadata]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val awsVersion = "1.11.125"
   val pandaVersion = "0.4.0"
   val mockitoVersion = "2.0.97-beta"
-  val atomMakerVersion = "1.0.1"
+  val atomMakerVersion = "1.0.2"
   val slf4jVersion = "1.7.21"
   val typesafeConfigVersion = "1.3.0" // to match what we get from Play transitively
   val scanamoVersion = "0.9.1" // to match what we get from atom-publisher-lib transitively

--- a/public/video-ui/src/actions/PlutoActions/getProjects.js
+++ b/public/video-ui/src/actions/PlutoActions/getProjects.js
@@ -1,0 +1,38 @@
+import { getPlutoProjects } from '../../services/PlutoApi';
+
+function requestProjects() {
+  return {
+    type: 'PLUTO_PROJECTS_GET_REQUEST',
+    receivedAt: Date.now()
+  };
+}
+
+function receiveProjects(response) {
+  return {
+    type: 'PLUTO_PROJECTS_GET_RECEIVE',
+    receivedAt: Date.now(),
+    projects: response
+  };
+}
+
+function errorReceivingProjects(error) {
+  return {
+    type: 'SHOW_ERROR',
+    message: 'Could not get Pluto Projects',
+    receivedAt: Date.now(),
+    error: error
+  };
+}
+
+export function getProjects() {
+  return dispatch => {
+    dispatch(requestProjects());
+    return getPlutoProjects()
+      .then(res => {
+        dispatch(receiveProjects(res));
+      })
+      .catch(err => {
+        dispatch(errorReceivingProjects(err));
+      });
+  };
+}

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -13,6 +13,7 @@ import { privacyStates } from '../../constants/privacyStates';
 class VideoData extends React.Component {
   hasCategories = () => this.props.youtube.categories.length !== 0;
   hasChannels = () => this.props.youtube.channels.length !== 0;
+  hasPlutoProjects = () => this.props.pluto.projects.length !== 0;
 
   componentWillMount() {
     if (!this.hasCategories()) {
@@ -20,6 +21,9 @@ class VideoData extends React.Component {
     }
     if (!this.hasChannels()) {
       this.props.youtubeActions.getChannels();
+    }
+    if (!this.hasPlutoProjects()) {
+      this.props.plutoActions.getProjects();
     }
   }
 
@@ -113,6 +117,13 @@ class VideoData extends React.Component {
             <ManagedField fieldLocation="tags" name="Keywords">
               <KeywordPicker />
             </ManagedField>
+            <ManagedField
+              fieldLocation="plutoProjectId"
+              name="Pluto Project"
+              isRequired={true}
+            >
+              <SelectBox selectValues={this.props.pluto.projects} />
+            </ManagedField>
           </ManagedSection>
         </ManagedForm>
       </div>
@@ -125,10 +136,12 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as getCategories from '../../actions/YoutubeActions/getCategories';
 import * as getChannels from '../../actions/YoutubeActions/getChannels';
+import * as getProjects from '../../actions/PlutoActions/getProjects';
 
 function mapStateToProps(state) {
   return {
-    youtube: state.youtube
+    youtube: state.youtube,
+    pluto: state.pluto
   };
 }
 
@@ -137,7 +150,8 @@ function mapDispatchToProps(dispatch) {
     youtubeActions: bindActionCreators(
       Object.assign({}, getCategories, getChannels),
       dispatch
-    )
+    ),
+    plutoActions: bindActionCreators(Object.assign({}, getProjects), dispatch)
   };
 }
 

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -118,7 +118,7 @@ class VideoData extends React.Component {
               <KeywordPicker />
             </ManagedField>
             <ManagedField
-              fieldLocation="plutoProjectId"
+              fieldLocation="plutoData.projectId"
               name="Pluto Project"
               isRequired={false}
             >

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -120,7 +120,7 @@ class VideoData extends React.Component {
             <ManagedField
               fieldLocation="plutoProjectId"
               name="Pluto Project"
-              isRequired={true}
+              isRequired={false}
             >
               <SelectBox selectValues={this.props.pluto.projects} />
             </ManagedField>

--- a/public/video-ui/src/reducers/plutoReducer.js
+++ b/public/video-ui/src/reducers/plutoReducer.js
@@ -1,0 +1,10 @@
+export default function pluto(state = { projects: [] }, action) {
+  switch (action.type) {
+    case 'PLUTO_PROJECTS_GET_RECEIVE':
+      return Object.assign({}, state, {
+        projects: action.projects || []
+      });
+    default:
+      return state;
+  }
+}

--- a/public/video-ui/src/reducers/rootReducer.js
+++ b/public/video-ui/src/reducers/rootReducer.js
@@ -17,6 +17,7 @@ import plutoVideos from './plutoVideosReducer';
 import checkedFormFields from './checkedFormFieldsReducer';
 import uploads from './uploadsReducer';
 import path from './pathReducer';
+import pluto from './plutoReducer';
 
 export default combineReducers({
   audits,
@@ -36,5 +37,6 @@ export default combineReducers({
   videoEditOpen,
   uploads,
   path,
-  routing: routerReducer
+  routing: routerReducer,
+  pluto
 });

--- a/public/video-ui/src/services/PlutoApi.js
+++ b/public/video-ui/src/services/PlutoApi.js
@@ -1,0 +1,7 @@
+import { pandaReqwest } from './pandaReqwest';
+
+export function getPlutoProjects() {
+  return pandaReqwest({
+    url: '/api2/pluto/projects'
+  });
+}

--- a/test/ThriftUtilSpec.scala
+++ b/test/ThriftUtilSpec.scala
@@ -69,7 +69,7 @@ class ThriftUtilSpec extends FunSpec
 
       inside(parseMediaAtom(makeParams("uri" -> youtubeUrl, "metadata" -> meta))) {
         case Right(MediaAtom(assets, Some(1L), "unknown", Category.News, None, None, None, None, None, metadata, None, None)) =>
-          metadata should matchPattern { case Some(Metadata(_, _, _, Some(true), Some("channelId"), Some(PrivacyStatus.Private), Some(1))) => }
+          metadata should matchPattern { case Some(Metadata(_, _, _, Some(true), Some("channelId"), Some(PrivacyStatus.Private), Some(1), _)) => }
       }
     }
   }


### PR DESCRIPTION
Annoyingly I've realised that [CDS](https://github.com/guardian/content_delivery_system/blob/master/CDS/scripts/js_utils/media-atom/media-atom.js#L119-L140) is currently setting the Pluto Master ID as the `plutoProjectId` in the Atom.

I've raised [this PR](https://github.com/guardian/content-atom/pull/86) to add more fields to the thrift definition on the assumption we want to push these links to capi (and because its the cheapest option).

<img width="544" alt="screen shot 2017-05-11 at 14 10 20" src="https://cloud.githubusercontent.com/assets/836140/25950714/b75fb3ea-3653-11e7-8b34-a7cb2a4ac368.png">
