### PR TITLE
Fix error updating title (if we have a composer page)

### DIFF
--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -129,7 +129,7 @@ export default {
           contentType: 'application/json',
           crossOrigin: true,
           withCredentials: true,
-          data: value
+          data: `"${value}"`
         });
       }
 


### PR DESCRIPTION
User reported an error when updating the title on an atom that had a composer page.

This happened because the format was wrong on the updates requests to composer. This PR fixes the format (by adding quotes!)