### PR TITLE
use JS_ASSET_HOST envvar to determine inclusion of build css file

### DIFF
--- a/app/controllers/VideoUIApp.scala
+++ b/app/controllers/VideoUIApp.scala
@@ -18,9 +18,17 @@ class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfi
 
     val jsFileName = "video-ui/build/app.js"
 
-    val jsLocation = sys.env.get("JS_ASSET_HOST") match {
-      case Some(assetHost) => assetHost + jsFileName
-      case None => routes.Assets.versioned(jsFileName).toString
+    val jsAssetHost = sys.env.get("JS_ASSET_HOST")
+
+    val isHotReloading = jsAssetHost match {
+      case Some(_) if awsConfig.isDev => true
+      case _ => false
+    }
+
+    val jsLocation = if (isHotReloading) {
+      jsAssetHost.get + jsFileName
+    } else {
+      routes.Assets.versioned(jsFileName).toString
     }
 
     val composerUrl = awsConfig.composerUrl
@@ -41,7 +49,7 @@ class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfi
         permissions
       )
 
-      Ok(views.html.VideoUIApp.app("Media Atom Maker", jsLocation, Json.toJson(clientConfig).toString(), awsConfig.isDev))
+      Ok(views.html.VideoUIApp.app("Media Atom Maker", jsLocation, Json.toJson(clientConfig).toString(), isHotReloading))
     }
   }
 

--- a/app/views/VideoUIApp/app.scala.html
+++ b/app/views/VideoUIApp/app.scala.html
@@ -1,6 +1,6 @@
-@(title: String, jsFileLocation: String, clientConfigJson: String, isDev: Boolean)
+@(title: String, jsFileLocation: String, clientConfigJson: String, isHotReloading: Boolean)
 
-@layout(title, isDev) {
+@layout(title, isHotReloading) {
     <div id="react-mount" class="main">
         <h1>Loading...</h1>
     </div>

--- a/app/views/VideoUIApp/layout.scala.html
+++ b/app/views/VideoUIApp/layout.scala.html
@@ -1,4 +1,4 @@
-@(title: String, isDev: Boolean)(content: Html)
+@(title: String, isHotReloading: Boolean)(content: Html)
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -8,7 +8,7 @@
     <title>@title</title>
     <link rel="icon" type="image/png" href="@routes.Assets.versioned("video-ui/images/favicon.png")">
 
-    @if(!isDev) {
+    @if(!isHotReloading) {
       <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("video-ui/build/main.css")"/>
     }
 


### PR DESCRIPTION
fixes an issue where if you're running the app using `./scripts/start.sh` you're not hot reloading and need the css file on the page

relates to https://github.com/guardian/media-atom-maker/pull/441