### PR TITLE
only talk to YouTube Partner API when preview != published

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -27,25 +27,22 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youTu
   def process(): T = {
     log.info(s"Request to publish atom $id")
 
-    val thriftAtom = getPreviewAtom(id)
-    val atom = MediaAtom.fromThrift(thriftAtom)
+    val thriftPreviewAtom = getPreviewAtom(id)
+    val previewAtom = MediaAtom.fromThrift(thriftPreviewAtom)
 
-    if(atom.privacyStatus.contains(PrivacyStatus.Private)) {
-      log.error(s"Unable to publish atom ${atom.id}, privacy status is set to private")
+    if(previewAtom.privacyStatus.contains(PrivacyStatus.Private)) {
+      log.error(s"Unable to publish atom ${previewAtom.id}, privacy status is set to private")
       AtomPublishFailed("Atom status set to private")
     }
 
-    getActiveAsset(atom) match {
+    getActiveAsset(previewAtom) match {
       case Some(asset) if asset.platform == Youtube =>
-        val atomWithDuration = atom.copy(duration = youTube.getDuration(asset.id))
-        updateThumbnail(atomWithDuration, asset)
-        youtubeClaims.createOrUpdateClaim(atomWithDuration.id, asset.id, user.username,
-          atomWithDuration.blockAds.getOrElse(false) )
-        updateYouTube(atomWithDuration, asset)
-        publish(atomWithDuration, user)
+        val atomWithDuration = previewAtom.copy(duration = youTube.getDuration(asset.id))
+        val atomWithYoutubeUpdates = updateYouTube(atomWithDuration, asset)
+        publish(atomWithYoutubeUpdates, user)
 
       case _ =>
-        publish(atom, user)
+        publish(previewAtom, user)
     }
   }
 
@@ -92,20 +89,68 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youTu
     }
   }
 
-  private def updateYouTube(atom: MediaAtom, asset: Asset): Unit = {
+  private def updateYouTube(previewAtom: MediaAtom, asset: Asset): MediaAtom = {
+    updateYoutubeMetadata(previewAtom, asset)
+    updateYoutubeThumbnail(previewAtom, asset)
+    createOrUpdateYoutubeClaim(previewAtom, asset)
+  }
+
+  private def createOrUpdateYoutubeClaim(previewAtom: MediaAtom, asset: Asset): MediaAtom = {
+    if (previewAtom.blockAds.isEmpty) {
+      log.info(s"BlockAds not previously set, defaulting to false")
+      youtubeClaims.createOrUpdateClaim(
+        previewAtom.id,
+        asset.id,
+        blockAds = false
+      )
+
+      previewAtom.copy(blockAds = Some(false))
+    }
+    else {
+      try {
+        val thriftPublishedAtom = getPublishedAtom(id)
+        val publishedAtom = MediaAtom.fromThrift(thriftPublishedAtom)
+
+        if (previewAtom.blockAds.get == publishedAtom.blockAds.getOrElse(false)) {
+          log.info(s"No change to BlockAds field, not editing YouTube Claim")
+        } else {
+          log.info(s"BlockAds changed from ${publishedAtom.blockAds.getOrElse(false)} to ${previewAtom.blockAds.get}. Updating YouTube Claim")
+          youtubeClaims.createOrUpdateClaim(
+            previewAtom.id,
+            asset.id,
+            previewAtom.blockAds.get
+          )
+        }
+        previewAtom
+      } catch {
+        case CommandException(_, 404) => {
+          // atom hasn't been published yet
+          log.info(s"Unable to find Published atom. Creating YouTube Claim")
+          youtubeClaims.createOrUpdateClaim(
+            previewAtom.id,
+            asset.id,
+            previewAtom.blockAds.get
+          )
+          previewAtom
+        }
+      }
+    }
+  }
+
+  private def updateYoutubeMetadata(previewAtom: MediaAtom, asset: Asset) = {
     val metadata = YouTubeMetadataUpdate(
-      title = Some(atom.title),
-      categoryId = atom.youtubeCategoryId,
-      description = atom.description,
-      tags = atom.tags,
-      license = atom.license,
-      privacyStatus = atom.privacyStatus.map(_.name)
+      title = Some(previewAtom.title),
+      categoryId = previewAtom.youtubeCategoryId,
+      description = previewAtom.description,
+      tags = previewAtom.tags,
+      license = previewAtom.license,
+      privacyStatus = previewAtom.privacyStatus.map(_.name)
     )
 
     youTube.updateMetadata(asset.id, metadata)
   }
 
-  private def updateThumbnail(atom: MediaAtom, asset: Asset): Unit = {
+  private def updateYoutubeThumbnail(atom: MediaAtom, asset: Asset): Unit = {
     try {
       val master = atom.posterImage.flatMap(_.master).get
       val MAX_SIZE = 2000000
@@ -116,8 +161,7 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youTu
         atom.posterImage.map(
           _.assets
             .filter(a => a.size.nonEmpty && a.size.get < MAX_SIZE)
-            .sortBy(_.size.get)
-            .last
+            .maxBy(_.size.get)
         ).get
       }
 

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -96,6 +96,7 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youTu
   }
 
   private def createOrUpdateYoutubeClaim(previewAtom: MediaAtom, asset: Asset): MediaAtom = {
+    // if previewAtom.blockAds.isEmpty == true, we know there isn't a published atom and we can save a database call
     if (previewAtom.blockAds.isEmpty) {
       log.info(s"BlockAds not previously set, defaulting to false")
       youtubeClaims.createOrUpdateClaim(

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeClaims.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeClaims.scala
@@ -12,11 +12,12 @@ import scala.collection.JavaConverters._
 //Videos are either tracked or monetized: https://support.google.com/youtube/answer/107383?hl=en-GB
 class YouTubeClaims(override val config: Config) extends YouTubeAccess with Logging {
 
-  private def createAsset(title: String, videoId: String): Asset = {
+  private def createAsset(title: String, videoId: String, atomId: String): Asset = {
 
     val metadata = new Metadata()
       .setTitle(title)
       .setDescription(videoId)
+      .setCustomId(atomId)
 
     val asset = new Asset()
       .setMetadata(metadata)
@@ -70,10 +71,10 @@ class YouTubeClaims(override val config: Config) extends YouTubeAccess with Logg
       policy.setId(monetizationPolicyId)
   }
 
-  private def createVideoClaim(atomId: String, userName: String, blockAds: Boolean, videoId: String): Claim = {
+  private def createVideoClaim(atomId: String, blockAds: Boolean, videoId: String): Claim = {
     val policy = getNewPolicy(blockAds)
-    val assetTitle = s"$atomId-$userName-${DateTime.now()}"
-    val assetId = createAsset(assetTitle, videoId).getId
+    val assetTitle = s"media-atom-maker_atom=${atomId}_video=${videoId}"
+    val assetId = createAsset(assetTitle, videoId, atomId).getId
     setOwnership(assetId)
     claimVideo(assetId, videoId, policy)
   }
@@ -110,7 +111,7 @@ class YouTubeClaims(override val config: Config) extends YouTubeAccess with Logg
     }
   }
 
-  def createOrUpdateClaim(atomId: String, videoId: String, userName: String, blockAds: Boolean): Claim = {
+  def createOrUpdateClaim(atomId: String, videoId: String, blockAds: Boolean): Claim = {
 
     val request: YouTubePartner#ClaimSearch#List = partnerClient
       .claimSearch()
@@ -131,7 +132,7 @@ class YouTubeClaims(override val config: Config) extends YouTubeAccess with Logg
         }
         case None => {
           log.info(s"no partner claim found, creating claim for video=$videoId")
-          createVideoClaim(atomId, userName, blockAds, videoId)
+          createVideoClaim(atomId, blockAds, videoId)
         }
 
       }


### PR DESCRIPTION
to reduce the probability of being rate limited by YouTube

Also changes the template of the YouTube Asset title, removing usernames because 🔒  and setting a CustomID to the Atom ID. This CustomID comes through to various YouTube reports and is useful for grouping videos up to their Atom.