### PR TITLE
don't send "- video" to YouTube's title

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -139,8 +139,11 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youTu
   }
 
   private def updateYoutubeMetadata(previewAtom: MediaAtom, asset: Asset) = {
+    // Editorial add "- video" for on platform SEO, but it isn't needed on a YouTube video title as its a video platform
+    val title = previewAtom.title.replaceAll(" (-|–) video$", "")
+
     val metadata = YouTubeMetadataUpdate(
-      title = Some(previewAtom.title.replaceAll(" (-|–) video$", "")),
+      title = Some(title),
       categoryId = previewAtom.youtubeCategoryId,
       description = previewAtom.description,
       tags = previewAtom.tags,

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -140,7 +140,7 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youTu
 
   private def updateYoutubeMetadata(previewAtom: MediaAtom, asset: Asset) = {
     val metadata = YouTubeMetadataUpdate(
-      title = Some(previewAtom.title),
+      title = Some(previewAtom.title.replaceAll(" (-|–) video$", "")),
       categoryId = previewAtom.youtubeCategoryId,
       description = previewAtom.description,
       tags = previewAtom.tags,


### PR DESCRIPTION
Editorial add "- video" as it helps with SEO on platform. This just isn't needed on a YouTube video title because its a video platform.