### PR TITLE
Add new endpoint to be used by Workflow to create a new atom

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -73,6 +73,15 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
     }
   }
 
+  def createWorkflowMediaAtom = APIAuthAction { implicit req =>
+    parse(req) { title: String =>
+      val command = CreateWorkflowAtomCommand(title, stores, req.user)
+      val atom = command.process()
+
+      Created(Json.toJson(atom)).withHeaders("Location" -> atomUrl(atom.id))
+    }
+  }
+
   def putMediaAtom(id: String) = APIHMACAuthAction { implicit req =>
     parse(req) { atom: MediaAtom =>
       val command = UpdateAtomCommand(id, atom, stores, req.user)

--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -1,6 +1,5 @@
 package controllers
 
-import _root_.util.AWSConfig
 import com.gu.atom.play.AtomAPIActions
 import com.gu.media.MediaAtomMakerPermissionsProvider
 import com.gu.media.logging.Logging
@@ -8,12 +7,14 @@ import com.gu.media.upload.model.PlutoSyncMetadata
 import com.gu.media.youtube.{YouTube, YouTubeClaims}
 import com.gu.pandahmac.HMACAuthActions
 import data.DataStores
-import model.MediaAtom
 import model.commands.CommandExceptions._
 import model.commands._
+import model.{MediaAtom, WorkflowMediaAtom}
 import play.api.Configuration
+import util.{AWSConfig, CORSable}
 import util.atom.MediaAtomImplicits
 import play.api.libs.json._
+import play.api.mvc._
 
 class Api2 (override val stores: DataStores, conf: Configuration, override val authActions: HMACAuthActions,
             youTube: YouTube, youTubeClaims: YouTubeClaims, awsConfig: AWSConfig, override val permissions: MediaAtomMakerPermissionsProvider)
@@ -25,6 +26,13 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
     with Logging {
 
   import authActions.{APIAuthAction, APIHMACAuthAction}
+
+  def allowCORSAccess(methods: String, args: Any*) = CORSable(awsConfig.workflowUrl) {
+    Action { implicit req =>
+      val requestedHeaders = req.headers("Access-Control-Request-Headers")
+      NoContent.withHeaders("Access-Control-Allow-Methods" -> methods, "Access-Control-Allow-Headers" -> requestedHeaders)
+    }
+  }
 
   def getMediaAtoms(search: Option[String], limit: Option[Int]) = APIAuthAction {
     val atoms = stores.atomListStore.getAtoms(search, limit)
@@ -73,14 +81,15 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
     }
   }
 
-  def createWorkflowMediaAtom = APIAuthAction { implicit req =>
-    parse(req) { title: String =>
-      val command = CreateWorkflowAtomCommand(title, stores, req.user)
-      val atom = command.process()
-
-      Created(Json.toJson(atom)).withHeaders("Location" -> atomUrl(atom.id))
+  def createWorkflowMediaAtom = CORSable(awsConfig.workflowUrl) {
+      APIAuthAction { implicit req =>
+        parse(req) { wma: WorkflowMediaAtom =>
+          val command = CreateWorkflowAtomCommand(wma.title, stores, req.user)
+          val atom = command.process()
+          Created(Json.toJson(atom)).withHeaders("Location" -> atomUrl(atom.id))
+        }
+      }
     }
-  }
 
   def putMediaAtom(id: String) = APIHMACAuthAction { implicit req =>
     parse(req) { atom: MediaAtom =>

--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -83,8 +83,8 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
 
   def createWorkflowMediaAtom = CORSable(awsConfig.workflowUrl) {
       APIAuthAction { implicit req =>
-        parse(req) { wma: WorkflowMediaAtom =>
-          val command = CreateWorkflowAtomCommand(wma.title, stores, req.user)
+        parse(req) { workflowMediaAtom: WorkflowMediaAtom =>
+          val command = CreateWorkflowAtomCommand(workflowMediaAtom, stores, req.user)
           val atom = command.process()
           Created(Json.toJson(atom)).withHeaders("Location" -> atomUrl(atom.id))
         }

--- a/app/model/WorkflowMediaAtom.scala
+++ b/app/model/WorkflowMediaAtom.scala
@@ -1,0 +1,9 @@
+package model
+
+import org.cvogt.play.json.Jsonx
+import play.api.libs.json.Format
+
+case class WorkflowMediaAtom(title: String)
+object WorkflowMediaAtom {
+  implicit val userFormat: Format[WorkflowMediaAtom] = Jsonx.formatCaseClassUseDefaults[WorkflowMediaAtom]
+}

--- a/app/model/commands/CreateWorkflowAtomCommand.scala
+++ b/app/model/commands/CreateWorkflowAtomCommand.scala
@@ -1,0 +1,89 @@
+package model.commands
+
+import java.util.Date
+import java.util.UUID._
+
+import com.gu.atom.data.IDConflictError
+import com.gu.contentatom.thrift.atom.media.{Category => ThriftCategory, MediaAtom => ThriftMediaAtom, Metadata => ThriftMetadata}
+import com.gu.contentatom.thrift.{Atom => ThriftAtom, _}
+import com.gu.media.logging.Logging
+import com.gu.pandomainauth.model.{User => PandaUser}
+import data.DataStores
+import model.commands.CommandExceptions._
+import model.{ChangeRecord, MediaAtom}
+
+import scala.util.{Failure, Success}
+
+case class CreateWorkflowAtomCommand(title: String, override val stores: DataStores, user: PandaUser)
+
+  extends Command with Logging {
+
+  type T = MediaAtom
+
+  def process(): MediaAtom = {
+    val atomId = randomUUID().toString
+    log.info(s"Request to create new atom $atomId [$title] from Workflow")
+
+    val createdChangeRecord = Some(ChangeRecord.now(user).asThrift)
+
+    val atom = ThriftAtom(
+      id = atomId,
+      atomType = AtomType.Media,
+      labels = Nil,
+      defaultHtml = "<div></div>", // No content set so empty div
+      data = AtomData.Media(ThriftMediaAtom(
+        title = title,
+        assets = Nil,
+        activeVersion = None,
+        category = ThriftCategory.News,
+        plutoProjectId = None,
+        source = None,
+        posterImage= None,
+        duration = None,
+        description = None,
+        metadata = Some(ThriftMetadata(
+          categoryId = None,
+          channelId = None,
+          privacyStatus = None,
+          expiryDate = None
+        ))
+      )),
+      contentChangeDetails = ContentChangeDetails(
+        lastModified = createdChangeRecord,
+        created = createdChangeRecord,
+        published = None,
+        revision = 1L
+      )
+    )
+
+    auditDataStore.auditCreate(atom.id, user)
+
+    log.info(s"Creating new atom $atomId [$title] from Workflow")
+
+    previewDataStore.createAtom(atom).fold({
+        case IDConflictError =>
+          log.error(s"Cannot create new atom $atomId. The id is already in use")
+          AtomIdConflict
+
+        case other =>
+          log.error(s"Cannot create new atom $atomId. $other")
+          UnknownFailure
+      },
+      _ => {
+        log.info(s"Successfully created new atom $atomId [$title]")
+
+        val event = ContentAtomEvent(atom, EventType.Update, new Date().getTime)
+
+        previewPublisher.publishAtomEvent(event) match {
+          case Success(_)  =>
+            log.info(s"New atom published to preview $atomId [$title]")
+            MediaAtom.fromThrift(atom)
+
+          case Failure(err) =>
+            log.error(s"Unable to published new atom to preview $atomId [$title]", err)
+            AtomPublishFailed(err.toString)
+        }
+      }
+    )
+  }
+}

--- a/app/util/AWS.scala
+++ b/app/util/AWS.scala
@@ -30,6 +30,7 @@ class AWSConfig(override val config: Config, override val credentials: AwsCreden
   )
 
   lazy val composerUrl = getMandatoryString("flexible.url")
+  lazy val workflowUrl = getMandatoryString("workflow.url")
   lazy val viewerUrl = getMandatoryString("viewer.url")
 
   lazy val gridUrl = getMandatoryString("grid.url")

--- a/app/util/CORSable.scala
+++ b/app/util/CORSable.scala
@@ -1,0 +1,20 @@
+package util
+
+import play.api.mvc.{Action, BodyParser, Request, Result}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+case class CORSable[A](origins: String*)(action: Action[A]) extends Action[A] {
+
+  def apply(request: Request[A]): Future[Result] = {
+    val headers = request.headers.get("Origin").map { origin =>
+      if(origins.contains(origin)) {
+        List("Access-Control-Allow-Origin" -> origin, "Access-Control-Allow-Credentials" -> "true")
+      } else { Nil }
+    }
+    action(request).map(_.withHeaders(headers.getOrElse(Nil) :_*))
+  }
+
+  lazy val parser: BodyParser[A] = action.parser
+}

--- a/conf/routes
+++ b/conf/routes
@@ -32,9 +32,12 @@ GET     /api2/pluto                     controllers.Api2.getPlutoAtoms()
 DELETE  /api2/atom/:id                  controllers.Api2.deleteAtom(id)
 
 GET     /api2/pluto/projects            controllers.PlutoProjectController.listProjects()
-GET     /api2/pluto/projects/:id         controllers.PlutoProjectController.getProject(id)
+GET     /api2/pluto/projects/:id        controllers.PlutoProjectController.getProject(id)
 POST    /api2/pluto/projects            controllers.PlutoProjectController.createProject()
 PUT     /api2/pluto/projects/:id        controllers.PlutoProjectController.updateProject(id)
+
+# endpoint used by workflow
+POST    /api2/workflow/atoms            controllers.Api2.createWorkflowMediaAtom
 
 # user uploaded videos
 GET     /api2/uploads                   controllers.UploadController.list(atomId)

--- a/conf/routes
+++ b/conf/routes
@@ -37,6 +37,7 @@ POST    /api2/pluto/projects            controllers.PlutoProjectController.creat
 PUT     /api2/pluto/projects/:id        controllers.PlutoProjectController.updateProject(id)
 
 # endpoint used by workflow
+OPTIONS /api2/workflow/*url             controllers.Api2.allowCORSAccess(methods = "PUT, POST, DELETE", url: String)
 POST    /api2/workflow/atoms            controllers.Api2.createWorkflowMediaAtom
 
 # user uploaded videos


### PR DESCRIPTION
- [x] The current endpoint has too many required fields, we need a more relaxed one.
- [x] Allow CORS.