### PR TITLE
Disable prop-types warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,7 @@ module.exports = {
         tabWidth: 2
       }
     ],
-    "react/prop-types": "warn",
+    "react/prop-types": "off",
     "jsx-quotes": ["error", "prefer-double"],
     "prefer-const": "error",
     "semi": ["error", "always"],


### PR DESCRIPTION
We've got 101 of these guys and we're not going to be fixing them all any time soon. So the warning goes for now.