### PR TITLE
Fix step function uploading

### DIFF
--- a/project/StateMachine.scala
+++ b/project/StateMachine.scala
@@ -2,7 +2,7 @@ import sbt._
 import sbt.Keys._
 
 object StateMachine {
-  case class LambdaConfig(description: String, timeout: Int = 60)
+  case class LambdaConfig(description: String, timeout: Int = 300)
 
   val lambdas = settingKey[Map[String, LambdaConfig]]("The lambdas to include in the state machine")
 

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -189,15 +189,18 @@ export default class VideoTrail extends React.Component {
       blocks.push(this.renderS3Upload());
     }
 
-    this.props.uploads.forEach(upload => {
+    const uploads = this.props.s3Upload.id
+      ? this.props.uploads.filter(
+          upload => upload.id !== this.props.s3Upload.id
+        )
+      : this.props.uploads;
+
+    uploads.forEach(upload => {
       const total = upload.parts[upload.parts.length - 1].end;
       const progress =
         upload.progress.uploadedToS3 + upload.progress.uploadedToYouTube;
 
-      // Don't show other users uploads until they have reached YouTube
-      if (upload.progress.uploadedToS3 === total) {
-        blocks.push(this.renderRemoteUpload(upload.id, total, progress));
-      }
+      blocks.push(this.renderRemoteUpload(upload.id, total, progress));
     });
 
     blocks.push(...this.props.assets.map(this.renderAsset));

--- a/public/video-ui/src/components/VideoUpload/VideoUpload.js
+++ b/public/video-ui/src/components/VideoUpload/VideoUpload.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Icon from '../Icon';
 import VideoTrail from './VideoTrail';
 import { getStore } from '../../util/storeAccessor';
-import _ from 'lodash';
 
 class AddAssetFromURL extends React.Component {
   constructor(props) {
@@ -201,14 +200,6 @@ class VideoUpload extends React.Component {
       );
     };
 
-    // We want to display uploads that do not yet have a corresponding asset in the atom.
-    // VideoTrail will poll appropriately.
-    const uploads = _.filter(this.props.uploads, upload => {
-      const version = upload.metadata.pluto.assetVersion;
-      const exists = _.some(assets, asset => asset.version === version);
-      return !exists;
-    });
-
     return (
       <div className="video__main">
         <div className="video__main__header">
@@ -217,7 +208,7 @@ class VideoUpload extends React.Component {
             activeVersion={activeVersion}
             assets={assets}
             s3Upload={this.props.s3Upload}
-            uploads={uploads}
+            uploads={this.props.uploads}
             selectAsset={selectAsset}
             getVideo={() =>
               this.props.videoActions.getVideo(this.props.video.id)}

--- a/public/video-ui/src/reducers/s3UploadReducer.js
+++ b/public/video-ui/src/reducers/s3UploadReducer.js
@@ -1,4 +1,4 @@
-const EMPTY = { handle: null, progress: 0, total: 0 };
+const EMPTY = { id: null, handle: null, progress: 0, total: 0 };
 
 // This key covers the first part of a video upload where we put the video into S3 from the client browser.
 // We hold that progress in a separate state key from the progress of uploading to YouTube on the server side.
@@ -8,6 +8,7 @@ export default function s3Upload(state = EMPTY, action) {
     case 'UPLOAD_STARTED': {
       const total = action.upload.parts[action.upload.parts.length - 1].end;
       return Object.assign({}, state, {
+        id: action.upload.id,
         created: action.receivedAt,
         handle: action.handle,
         total: total

--- a/uploader/src/main/resources/cfn-template.yaml
+++ b/uploader/src/main/resources/cfn-template.yaml
@@ -26,8 +26,11 @@ Parameters:
   UploadBucketName:
     Description: "The S3 bucket where videos are uploaded to"
     Type: "String"
-  UploadProgressTable:
+  UploadTrackingTable:
     Description: "The Dynamo table to store progress"
+    Type: "String"
+  ManualPlutoTable:
+    Description: "The Dynamo table to store videos that must be manually synced with Pluto"
     Type: "String"
 
 Conditions:
@@ -65,9 +68,8 @@ Resources:
               - Effect: "Allow"
                 Action: ["dynamodb:*"]
                 Resource:
-                  - !Sub
-                    - "arn:aws:dynamodb:${Region}:${Account}:table/${Table}"
-                    - { Region: !Ref "AWS::Region", Account: !Ref "AWS::AccountId", Table: !Ref UploadProgressTable }
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${UploadTrackingTable}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ManualPlutoTable}"
 
   StatesExecutionRole:
     Type: "AWS::IAM::Role"

--- a/uploader/src/main/resources/lambda-template.yaml
+++ b/uploader/src/main/resources/lambda-template.yaml
@@ -19,6 +19,8 @@
         CONFIG_KEY: !Sub
           - "${Stage}/media-atom-maker.private.conf"
           - { Stage: !Ref Stage }
+        UPLOAD_TRACKING_TABLE_NAME: !Ref 'UploadTrackingTable'
+        PLUTO_TABLE_NAME: !Ref 'ManualPlutoTable'
     MemorySize: 512
     Role: !GetAtt LambdaExecutionRole.Arn
     Runtime: "java8"

--- a/uploader/src/main/scala/com/gu/media/upload/GetChunkFromS3.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/GetChunkFromS3.scala
@@ -1,18 +1,23 @@
 package com.gu.media.upload
 
-import com.gu.media.aws.S3Access
+import com.gu.media.aws.{DynamoAccess, S3Access}
 import com.gu.media.lambda.LambdaWithParams
 import com.gu.media.upload.model.{Upload, UploadPart}
 
-class GetChunkFromS3 extends LambdaWithParams[Upload, Upload] with S3Access {
+class GetChunkFromS3 extends LambdaWithParams[Upload, Upload] with S3Access with DynamoAccess {
+  private val table = new UploadsDataStore(this)
+
   override def handle(upload: Upload): Upload = {
     val chunk = upload.parts(upload.progress.chunksInS3)
 
-    if(s3Client.doesObjectExist(upload.metadata.bucket, chunk.key)) {
+    val updated = if(s3Client.doesObjectExist(upload.metadata.bucket, chunk.key)) {
       complete(upload, chunk)
     } else {
       retry(upload, chunk)
     }
+
+    table.report(updated)
+    updated
   }
 
   private def complete(upload: Upload, chunk: UploadPart): Upload = {


### PR DESCRIPTION
Follow up to #459 after testing on CODE.

- Add permission for pipeline lambdas to access the upload tracking table and manual pluto table
- Bump up lambda timeout to 5 minutes
    - Addresses timeout when doing a multipart copy of large files
    - May also make things faster by giving us more compute power on the lambda
- Remove UI filtering of uploads
    - This was causing failed uploads to disappear from the UI
- `GetChunkFromS3` lambda writes to the progress table
    - As above, this made the upload disappear