### PR TITLE
content bundling

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -145,8 +145,9 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youTu
       description = previewAtom.description,
       tags = previewAtom.tags,
       license = previewAtom.license,
-      privacyStatus = previewAtom.privacyStatus.map(_.name)
-    ).clean()
+      privacyStatus = previewAtom.privacyStatus.map(_.name))
+      .clean()
+      .withContentBundleTags()
 
     youTube.updateMetadata(asset.id, metadata)
   }

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -146,7 +146,7 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youTu
       tags = previewAtom.tags,
       license = previewAtom.license,
       privacyStatus = previewAtom.privacyStatus.map(_.name))
-      .clean()
+      .withSaneTitle()
       .withContentBundleTags()
 
     youTube.updateMetadata(asset.id, metadata)

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -139,17 +139,14 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youTu
   }
 
   private def updateYoutubeMetadata(previewAtom: MediaAtom, asset: Asset) = {
-    // Editorial add "- video" for on platform SEO, but it isn't needed on a YouTube video title as its a video platform
-    val title = previewAtom.title.replaceAll(" (-|–) video$", "")
-
     val metadata = YouTubeMetadataUpdate(
-      title = Some(title),
+      title = Some(previewAtom.title),
       categoryId = previewAtom.youtubeCategoryId,
       description = previewAtom.description,
       tags = previewAtom.tags,
       license = previewAtom.license,
       privacyStatus = previewAtom.privacyStatus.map(_.name)
-    )
+    ).clean()
 
     youTube.updateMetadata(asset.id, metadata)
   }

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -66,13 +66,12 @@ package object youtube {
     def clean(): YouTubeMetadataUpdate = {
       // Editorial add "- video" for on platform SEO, but it isn't needed on a YouTube video title as its a video platform
       val cleanTitle = this.title.map(_.replaceAll(" (-|–) video$", ""))
+      this.copy(title = cleanTitle)
+    }
 
+    def withContentBundleTags(): YouTubeMetadataUpdate = {
       val contentBundledTags = getContentBundlingTags()
-
-      this.copy (
-        title = cleanTitle,
-        tags = contentBundledTags
-      )
+      this.copy(tags = contentBundledTags)
     }
 
     private def getContentBundlingTags(): List[String] = {
@@ -110,17 +109,12 @@ package object youtube {
         "science" -> "gdnpfpscience"
       )
 
-      val tagsAndContentBundleTags: ListBuffer[String] = new ListBuffer[String]()
-
-      this.tags.map(tag => {
-        val lowerCaseTag = tag.toLowerCase()
-        contentBundlingMap.get(lowerCaseTag) match {
-          case Some(contentBundleTag) => tagsAndContentBundleTags += contentBundleTag += tag
-          case None => tagsAndContentBundleTags += tag
+      this.tags.flatMap { tag =>
+        contentBundlingMap.get(tag.toLowerCase()) match {
+          case Some(contentBundleTag) => List(tag, contentBundleTag)
+          case None => List(tag)
         }
-      })
-
-      tagsAndContentBundleTags.toList
+      }
     }
   }
 

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -63,7 +63,7 @@ package object youtube {
     license: Option[String],
     privacyStatus: Option[String]
   ) {
-    def clean(): YouTubeMetadataUpdate = {
+    def withSaneTitle(): YouTubeMetadataUpdate = {
       // Editorial add "- video" for on platform SEO, but it isn't needed on a YouTube video title as its a video platform
       val cleanTitle = this.title.map(_.replaceAll(" (-|–) video$", ""))
       this.copy(title = cleanTitle)

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -9,14 +9,13 @@ import org.cvogt.play.json.Jsonx
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
+import scala.collection.mutable.ListBuffer
+
 package object youtube {
   class YouTube(override val config: Config) extends Logging with YouTubeAccess with YouTubeVideos
 
   case class YouTubeVideoCategory(id: Int, title: String)
   case class YouTubeChannel(title: String, logo: URI, id: String)
-
-  case class YouTubeMetadataUpdate(title: Option[String], categoryId: Option[String], description: Option[String],
-                                   tags: List[String], license: Option[String], privacyStatus: Option[String])
 
   // failure only set is status is "failed"
   case class YouTubeProcessingStatus(id: String, status: String, total: Long, processed: Long,
@@ -53,6 +52,75 @@ package object youtube {
         logo = URI.create(channel.getSnippet().getThumbnails().getDefault().getUrl()),
         id = channel.getId
       )
+    }
+  }
+
+  case class YouTubeMetadataUpdate(
+    title: Option[String],
+    categoryId: Option[String],
+    description: Option[String],
+    tags: List[String],
+    license: Option[String],
+    privacyStatus: Option[String]
+  ) {
+    def clean(): YouTubeMetadataUpdate = {
+      // Editorial add "- video" for on platform SEO, but it isn't needed on a YouTube video title as its a video platform
+      val cleanTitle = this.title.map(_.replaceAll(" (-|–) video$", ""))
+
+      val contentBundledTags = getContentBundlingTags()
+
+      this.copy (
+        title = cleanTitle,
+        tags = contentBundledTags
+      )
+    }
+
+    private def getContentBundlingTags(): List[String] = {
+      val contentBundlingMap: Map[String, String] = Map (
+        "uk" -> "gdnpfpnewsuk",
+        "us" -> "gdnpfpnewsus",
+        "au" -> "gdnpfpnewsau",
+        "world" -> "gdnpfpnewsworld",
+        "politics" -> "gdnpfpnewspolitics",
+        "opinion" -> "gdnpfpnewsopinion",
+        "football" -> "gdnpfpsportfootball",
+        "cricket" -> "gdnpfpsportcricket",
+        "rugby union" -> "gdnpfpsportrugbyunion",
+        "rugby league" -> "gdnpfpsportrugbyleague",
+        "f1" -> "gdnpfpsportf1",
+        "tennis" -> "gdnpfpsporttennis",
+        "golf" -> "gdnpfpsportgolf",
+        "cycling" -> "gdnpfpsportcycling",
+        "boxing" -> "gdnpfpsportboxing",
+        "racing" -> "gdnpfpsportracing",
+        "us sports" -> "gdnpfpsportus",
+        "sports" -> "gdnpfpsportother",
+        "culture" -> "gdnpfpculture",
+        "film" -> "gdnpfpculturefilm",
+        "music" -> "gdnpfpculturemusic",
+        "lifestyle" -> "gdnpfplifestyle",
+        "food" -> "gdnpfplifestylefood",
+        "health & fitness" -> "gdnpfplifestylehealthfitness",
+        "business" -> "gdnpfpbusiness",
+        "money" -> "gdnpfpmoney",
+        "fashion" -> "gdnpfpfashion",
+        "environment" -> "gdnpfpenvironment",
+        "technology" -> "gdnpfptechnology",
+        "travel" -> "gdnpfptravel",
+        "science" -> "gdnpfpscience"
+      )
+
+      val tagsAndContentBundleTags: ListBuffer[String] = new ListBuffer[String]()
+
+      this.tags.map(tag => {
+        val lowerCaseTag = tag.toLowerCase()
+        contentBundlingMap.get(lowerCaseTag) match {
+          case Some(contentBundleTag) => tagsAndContentBundleTags += contentBundleTag += tag
+          case None => tagsAndContentBundleTags += tag
+        }
+      })
+
+      tagsAndContentBundleTags.toList
     }
   }
 


### PR DESCRIPTION
Commercial want to build content bundles of YouTube videos based on video tags. They have [supplied a mapping](https://docs.google.com/spreadsheets/d/1t0rVeddEaiYhp4yHyY856j9nJh49eJltoisD9XRtUUc/edit#gid=0) of Editorial tags -> DfP content bundles. This PR will map over Editorial tags and add any content bundle matches.

Note:
- these new content bundle tags only touch YouTube and do not get pushed to capi
- this is temporary, the real solution would be to map over Tag Manager section tags