### PR TITLE
Switch to step functions!

### DIFF
--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -4,126 +4,66 @@ import java.util.UUID
 
 import _root_.model.MediaAtom
 import _root_.model.commands.CommandExceptions._
-import com.amazonaws.services.stepfunctions.model.StartExecutionRequest
+import com.gu.media.MediaAtomMakerPermissionsProvider
+import com.gu.media.PermissionsUploadHelper._
 import com.gu.media.logging.Logging
 import com.gu.media.upload._
-import com.gu.media.upload.actions.{CopyParts, DeleteParts, UploadActionSender, UploadPartToYouTube, UploadPartsToSelfHost}
 import com.gu.media.upload.model._
-import com.gu.media.youtube.{YouTubeAccess, YouTubeUploader}
-import com.gu.media.{MediaAtomMakerPermissionsProvider, Permissions, PermissionsUploadHelper}
 import com.gu.pandahmac.HMACAuthActions
 import com.gu.pandomainauth.model.User
-import controllers.UploadController.{CompleteResponse, CreateRequest}
+import controllers.UploadController.CreateRequest
 import data.{DataStores, UnpackedDataStores}
 import org.cvogt.play.json.Jsonx
 import play.api.libs.json.{Format, Json}
-import play.api.mvc.{Request, Result}
-import util.AWSConfig
+import util.{AWSConfig, CredentialsGenerator, StepFunctions}
 
-class UploadController(override val authActions: HMACAuthActions, awsConfig: AWSConfig, youTube: YouTubeAccess,
-                       uploadActions: UploadActionSender, override val stores: DataStores,
-                       override val permissions: MediaAtomMakerPermissionsProvider)
+class UploadController(override val authActions: HMACAuthActions, awsConfig: AWSConfig, stepFunctions: StepFunctions,
+                       override val stores: DataStores, override val permissions: MediaAtomMakerPermissionsProvider)
 
   extends AtomController with Logging with JsonRequestParsing with UnpackedDataStores {
 
   import authActions.APIAuthAction
 
-  private val UPLOAD_KEY_HEADER = "X-Upload-Key"
-  private val UPLOAD_URI_HEADER = "X-Upload-Uri"
-  private val UPLOAD_METHOD_HEADER = "X-Upload-Method"
-
-  private val table = stores.uploadStore
   private val credsGenerator = new CredentialsGenerator(awsConfig)
-  private val uploader = YouTubeUploader(awsConfig, youTube)
 
   def list(atomId: String) = APIAuthAction {
     // Anyone can see the running uploads.
     // Only users with permission can create/complete/delete them.
-    val uploads = table.list(atomId)
-    Ok(Json.toJson(uploads))
+    val running = stepFunctions.getStatus(atomId)
+    Ok(Json.toJson(running))
   }
 
   def create = CanUploadAsset { implicit raw =>
     parse(raw) { req: CreateRequest =>
-      val useStepFunctions = raw.headers.get(UPLOAD_METHOD_HEADER).contains("StepFunctions")
-
-      if (PermissionsUploadHelper.canPerformUpload(raw.permissions, req.selfHost)) {
+      if(canPerformUpload(raw.permissions, req.selfHost)) {
         log.info(s"Request for upload under atom ${req.atomId}. filename=${req.filename}. size=${req.size}, selfHosted=${req.selfHost}")
+
         val atom = MediaAtom.fromThrift(getPreviewAtom(req.atomId))
-        val upload = buildUpload(atom, raw.user, req.size, req.selfHost, req.syncWithPluto, useStepFunctions)
-        table.put(upload)
+        val upload = buildUpload(atom, raw.user, req.size, req.selfHost, req.syncWithPluto)
 
-        if(useStepFunctions) {
-          val stepFunctionsRequest = new StartExecutionRequest()
-            .withName(s"${upload.metadata.pluto.atomId}--${upload.id}")
-            .withStateMachineArn(awsConfig.pipelineArn)
-            .withInput(Json.stringify(Json.toJson(upload)))
-
-          awsConfig.stepFunctionsClient.startExecution(stepFunctionsRequest)
-        }
+        stepFunctions.start(upload)
 
         log.info(s"Upload created under atom ${req.atomId}. upload=${upload.id}. parts=${upload.parts.size}, selfHosted=${upload.metadata.selfHost}")
         Ok(Json.toJson(upload))
+      } else {
+        Unauthorized(s"User ${raw.user.email} is not authorised with permissions to upload asset, self-hosted value: ${req.selfHost}")
       }
-      else Unauthorized(s"User ${raw.user.email} is not authorised with permissions to upload asset, self-hosted value: ${req.selfHost}")
     }
   }
 
-  def delete(id: String) = CanUploadAsset { implicit req =>
-    table.delete(id)
-    NoContent
-  }
+  def credentials(id: String, key: String) = CanUploadAsset { implicit req =>
+    getPart(id, key) match {
+      case Some(part) =>
+        val credentials = credsGenerator.forKey(part.key)
+        Ok(Json.toJson(credentials))
 
-  def credentials(id: String) = CanUploadAsset { implicit req =>
-    partRequest(id, req) { (upload, part, _) =>
-      val credentials = credsGenerator.forKey(upload.id, part.key)
-      Ok(Json.toJson(credentials))
+      case None =>
+        NotFound
     }
   }
 
-  def complete(id: String) = CanUploadAsset { implicit req =>
-    partRequest(id, req) { (upload, part, optionalUri) =>
-      val selfHost = upload.metadata.selfHost
-      if(!PermissionsUploadHelper.canPerformUpload(req.permissions, selfHost))
-        Unauthorized(s"User ${req.user.email} is not authorised with permissions to complete upload, self-hosted value: ${selfHost}")
-      else if (upload.metadata.useStepFunctions)
-        Ok(Json.toJson(CompleteResponse(s"${upload.id} running using step functions")))
-      else if (selfHost)
-        startUploadToSelfHost(upload, part, req.permissions)
-      else
-        startUploadToYouTube(upload, part, optionalUri, req.permissions)
-    }
-  }
-
-  private def startUploadToSelfHost(upload: Upload, part: UploadPart, permission: Permissions) = {
-    if(part == upload.parts.last) {
-      completeAndDeleteParts(upload, part)
-      val key = completeKey(upload)
-      uploadActions.send(UploadPartsToSelfHost(upload, key, awsConfig.transcodePipelineId))
-      log.info(s"$key has been sent to transcoding to pipeline ${awsConfig.transcodePipelineId}")
-      Ok(Json.toJson(CompleteResponse(s"$key has been sent for transcoding to S3")))
-    }
-    else {
-      log.info(s"${upload.id} has not finished uploading to S3 yet")
-      Ok(Json.toJson(CompleteResponse(s"${upload.id} has not finished uploading to S3 yet")))
-    }
-  }
-
-  private def startUploadToYouTube(upload: Upload, part: UploadPart, uploadUri: Option[String], permission: Permissions) = {
-    uploadUri.map { u =>
-      partComplete(upload, part, u)
-      Ok(Json.toJson(CompleteResponse(u)))
-    }.getOrElse {
-      val uploadUri = uploader.startUpload(upload.metadata.title, upload.metadata.channel, upload.id, upload.parts.last.end)
-      log.info(s"Starting upload to YouTube. atom=${upload.metadata.pluto.atomId} upload=${upload.id} uploadUri=${uploadUri}")
-
-      partComplete(upload, part, uploadUri)
-      Ok(Json.toJson(CompleteResponse(uploadUri)))
-    }
-  }
-
-  private def buildUpload(atom: MediaAtom, user: User, size: Long, selfHosted: Boolean, syncWithPluto: Boolean, useStepFunctions: Boolean) = {
-    val id = UUID.randomUUID().toString
+  private def buildUpload(atom: MediaAtom, user: User, size: Long, selfHosted: Boolean, syncWithPluto: Boolean) = {
+    val id = s"${atom.id}--${UUID.randomUUID().toString}"
 
     val plutoData = PlutoSyncMetadata(
       enabled = syncWithPluto,
@@ -140,14 +80,12 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
       title = atom.title,
       channel = atom.channelId.getOrElse { AtomMissingYouTubeChannel },
       pluto = plutoData,
-      selfHost = selfHosted,
-      useStepFunctions = useStepFunctions
+      selfHost = selfHosted
     )
 
     val progress = UploadProgress(
-      uploadedToS3 = 0,
-      uploadedToYouTube = 0,
       chunksInS3 = 0,
+      chunksInYouTube = 0,
       fullyUploaded = false,
       fullyTranscoded = false,
       retries = 0
@@ -158,50 +96,6 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
     Upload(id, parts, metadata, progress)
   }
 
-  private def partRequest(id: String, request: Request[_])(fn: (Upload, UploadPart, Option[String]) => Result): Result = {
-    table.get(id) match {
-      case Some(upload) =>
-        request.headers.get(UPLOAD_KEY_HEADER) match {
-          case Some(key) =>
-            upload.parts.find(_.key == key) match {
-              case Some(part) =>
-                fn(upload, part, request.headers.get(UPLOAD_URI_HEADER))
-
-              case None =>
-                BadRequest(s"Unknown part key $key")
-            }
-
-          case None =>
-            BadRequest(s"Missing header $UPLOAD_KEY_HEADER")
-        }
-
-      case None =>
-        BadRequest(s"Unknown upload id $id")
-    }
-  }
-
-  private def partComplete(upload: Upload, part: UploadPart, uploadUri: String): Upload = {
-    val complete = upload.copy(progress = upload.progress.copy(uploadedToS3 = part.end))
-    table.report(complete)
-    uploadActions.send(UploadPartToYouTube(upload, part, uploadUri))
-
-    log.info(s"Part ${part.key} uploaded to S3. upload=${upload.id} atom=${upload.metadata.pluto.atomId}")
-
-    completeAndDeleteParts(upload, part)
-    complete
-  }
-
-  private def completeAndDeleteParts(upload: Upload, part: UploadPart) {
-    if(part.key == upload.parts.last.key) {
-      log.info(s"All parts uploaded to S3. upload=${upload.id} atom=${upload.metadata.pluto.atomId}")
-
-      uploadActions.send(CopyParts(upload, completeKey(upload)))
-      uploadActions.send(DeleteParts(upload))
-    }
-  }
-
-  private def completeKey(upload: Upload) = CompleteUploadKey(awsConfig.userUploadFolder, upload.id).toString
-
   private def chunk(uploadId: String, size: Long): List[UploadPart] = {
     val boundaries = Upload.calculateChunks(size)
 
@@ -209,14 +103,17 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
       UploadPart(UploadPartKey(awsConfig.userUploadFolder, uploadId, id).toString, start, end)
     }
   }
+
+  private def getPart(id: String, key: String): Option[UploadPart] = for {
+    upload <- stepFunctions.getById(id)
+    part <- upload.parts.find(_.key == key)
+  } yield part
 }
 
 object UploadController {
   case class CreateRequest(atomId: String, filename: String, size: Long, selfHost: Boolean, syncWithPluto: Boolean)
   case class CreateResponse(id: String, region: String, bucket: String, parts: List[UploadPart])
-  case class CompleteResponse(uploadUri: String)
 
   implicit val createRequestFormat: Format[CreateRequest] = Jsonx.formatCaseClass[CreateRequest]
   implicit val createResponseFormat: Format[CreateResponse] = Jsonx.formatCaseClass[CreateResponse]
-  implicit val completeResponseFormat: Format[CompleteResponse] = Jsonx.formatCaseClass[CompleteResponse]
 }

--- a/app/di.scala
+++ b/app/di.scala
@@ -1,7 +1,5 @@
 import com.gu.atom.play.ReindexController
 import com.gu.media.aws.AwsCredentials
-import com.gu.media.ses.Mailer
-import com.gu.media.upload.actions.KinesisActionSender
 import com.gu.media.youtube.{YouTube, YouTubeClaims}
 import com.gu.media.{CapiPreview, MediaAtomMakerPermissionsProvider, Settings}
 import controllers._
@@ -12,7 +10,7 @@ import play.api.cache.EhCacheComponents
 import play.api.inject.DefaultApplicationLifecycle
 import play.api.libs.ws.ahc.AhcWSComponents
 import router.Routes
-import util.{AWSConfig, DevUploadHandler, DevUploadSender, PlutoMessageConsumer}
+import util._
 
 class MediaAtomMakerLoader extends ApplicationLoader {
   override def load(context: Context): Application = new MediaAtomMaker(context).application
@@ -56,8 +54,8 @@ class MediaAtomMaker(context: Context)
 
   private val api2 = new Api2(stores, configuration, hmacAuthActions, youTube, youTubeClaims, aws, permissions)
 
-  private val uploadSender = buildUploadSender()
-  private val uploads = new UploadController(hmacAuthActions, aws, youTube, uploadSender, stores, permissions)
+  private val stepFunctions = new StepFunctions(aws)
+  private val uploads = new UploadController(hmacAuthActions, aws, stepFunctions, stores, permissions)
 
   private val support = new Support(hmacAuthActions, capi)
   private val youTubeController = new controllers.Youtube(hmacAuthActions, youTube, defaultCacheApi)
@@ -92,15 +90,5 @@ class MediaAtomMaker(context: Context)
     new ReindexController(stores.preview, stores.published, stores.reindexPreview, stores.reindexPublished,
       configuration, actorSystem)
 
-  }
-
-  private def buildUploadSender() = aws.stage match {
-    case "DEV" =>
-      // Disable this case to use the lambdas, even in dev
-      val handler = new DevUploadHandler(stores, aws, youTube)
-      new DevUploadSender(handler)
-
-    case _ =>
-      new KinesisActionSender(aws)
   }
 }

--- a/app/util/CredentialsGenerator.scala
+++ b/app/util/CredentialsGenerator.scala
@@ -1,4 +1,4 @@
-package com.gu.media.upload
+package util
 
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest
 import com.gu.media.aws.UploadAccess
@@ -7,18 +7,18 @@ import com.gu.media.upload.model.UploadCredentials
 import play.api.libs.json.{JsArray, JsObject, JsString, Json}
 
 class CredentialsGenerator(aws: UploadAccess) extends Logging {
-  def forKey(uploadId: String, key: String): UploadCredentials = {
+  def forKey(key: String): UploadCredentials = {
     val keyPolicy = generateKeyPolicy(key)
 
-    generateCredentials(uploadId, key, keyPolicy)
+    generateCredentials(key, keyPolicy)
   }
 
-  private def generateCredentials(uploadId: String, key: String, keyPolicy: String): UploadCredentials = {
+  private def generateCredentials(key: String, keyPolicy: String): UploadCredentials = {
     val request = new AssumeRoleRequest()
       .withRoleArn(aws.userUploadRole)
       .withDurationSeconds(900) // 15 minutes (the minimum allowed in STS requests)
       .withPolicy(keyPolicy)
-      .withRoleSessionName(s"media-atom-maker-upload-$uploadId")
+      .withRoleSessionName(s"media-atom-pipeline")
 
     log.info(s"Issuing STS request for $key")
     val result = aws.uploadSTSClient.assumeRole(request)

--- a/app/util/DevUploadHandler.scala
+++ b/app/util/DevUploadHandler.scala
@@ -11,7 +11,7 @@ import model.commands.AddAssetCommand
   * For use in dev, uploads the video and adds the asset directly rather than via a Lambda
   */
 class DevUploadHandler(stores: DataStores, access: UploaderAccess, youTube: YouTube)
-  extends UploadActionHandler(stores.uploadStore, stores.pluto, access, YouTubeUploader(access, youTube)) {
+  extends UploadActionHandler(stores.uploadStore, stores.pluto, access, new YouTubeUploader(youTube, access.s3Client)) {
 
   private val user = PandaUser("Media", "Atom Maker", "media-atom-maker@theguardian.co.uk", None)
 

--- a/app/util/StepFunctions.scala
+++ b/app/util/StepFunctions.scala
@@ -1,0 +1,120 @@
+package util
+
+import java.time.Instant
+
+import com.amazonaws.services.stepfunctions.model._
+import com.fasterxml.jackson.core.JsonParseException
+import com.gu.media.upload.model._
+import play.api.libs.json.{JsResultException, JsSuccess, Json}
+
+import scala.collection.JavaConverters._
+
+class StepFunctions(awsConfig: AWSConfig) {
+  def getById(id: String): Option[Upload] = {
+    val arn = s"${awsConfig.pipelineArn.replace(":stateMachine:", ":execution:")}:$id"
+
+    try {
+      val request = new DescribeExecutionRequest().withExecutionArn(arn)
+      val result = awsConfig.stepFunctionsClient.describeExecution(request)
+      val json = Json.parse(result.getInput)
+
+      Some(json.as[Upload])
+    } catch {
+      case _: ExecutionDoesNotExistException =>
+        None
+    }
+  }
+
+  def getStatus(atomId: String): Iterable[UploadStatus] = {
+    val runningJobs = getExecutions(atomId, ExecutionStatus.RUNNING)
+    val failedJobs = getExecutions(atomId, ExecutionStatus.FAILED).filter(lessThan10MinutesOld)
+
+    val running = runningJobs.map(getRunningStatus)
+    val failed = failedJobs.map(getFailedStatus)
+
+    running ++ failed
+  }
+
+  def start(upload: Upload): Unit = {
+    val stepFunctionsRequest = new StartExecutionRequest()
+      .withName(upload.id)
+      .withStateMachineArn(awsConfig.pipelineArn)
+      .withInput(Json.stringify(Json.toJson(upload)))
+
+    awsConfig.stepFunctionsClient.startExecution(stepFunctionsRequest)
+  }
+
+  private def getExecutions(atomId: String, filter: ExecutionStatus): Iterable[ExecutionListItem] = {
+    val request = new ListExecutionsRequest()
+      .withStateMachineArn(awsConfig.pipelineArn)
+      .withStatusFilter(filter)
+
+    val results = awsConfig.stepFunctionsClient.listExecutions(request).getExecutions.asScala
+
+    results.filter(_.getName.startsWith(atomId))
+  }
+
+  private def getEvents(execution: ExecutionListItem): Iterable[HistoryEvent] = {
+    val request = new GetExecutionHistoryRequest()
+      .withExecutionArn(execution.getExecutionArn)
+      .withReverseOrder(true)
+      .withMaxResults(20)
+
+    awsConfig.stepFunctionsClient.getExecutionHistory(request).getEvents.asScala
+  }
+
+  private def getRunningStatus(execution: ExecutionListItem): UploadStatus = {
+    val id = execution.getName
+    val events = getEvents(execution)
+
+    events.find(_.getType == "TaskStateEntered") match {
+      case Some(event) =>
+        val state = event.getStateEnteredEventDetails.getName
+        val upload = Json.parse(event.getStateEnteredEventDetails.getInput).as[Upload]
+
+        if(upload.metadata.selfHost) {
+          UploadStatus.indeterminate(id, state)
+        } else {
+          val current = upload.progress.chunksInYouTube
+          val total = upload.parts.length
+
+          if(current < total) {
+            UploadStatus(id, "Uploading to YouTube", current, total, failed = false)
+          } else {
+            UploadStatus.indeterminate(id, state)
+          }
+        }
+
+      case None =>
+        UploadStatus.indeterminate(id, "Uploading")
+    }
+  }
+
+  private def getFailedStatus(execution: ExecutionListItem): UploadStatus = {
+    val id = execution.getName
+    val events = getEvents(execution)
+
+    val cause = events.find(_.getType == "ExecutionFailed") match {
+      case Some(event) =>
+        val cause = event.getExecutionFailedEventDetails.getCause
+
+        try {
+          (Json.parse(cause) \ "errorMessage").as[String]
+        } catch {
+          case _: JsonParseException | _: JsResultException =>
+            id
+        }
+
+      case None => "Failed (unknown error)"
+    }
+
+    UploadStatus.indeterminate(id, cause).copy(failed = true)
+  }
+
+  private def lessThan10MinutesOld(e: ExecutionListItem): Boolean = {
+    val now = Instant.now().toEpochMilli
+    val end = e.getStopDate.toInstant.toEpochMilli
+
+    (now - end) < (1000 * 60 * 10)
+  }
+}

--- a/app/util/StepFunctions.scala
+++ b/app/util/StepFunctions.scala
@@ -79,7 +79,7 @@ class StepFunctions(awsConfig: AWSConfig) {
           val total = upload.parts.length
 
           if(current < total) {
-            UploadStatus(id, "Uploading to YouTube", current, total, failed = false)
+            UploadStatus(id, "Uploading to YouTube", current, total)
           } else {
             UploadStatus.indeterminate(id, state)
           }
@@ -108,7 +108,7 @@ class StepFunctions(awsConfig: AWSConfig) {
       case None => "Failed (unknown error)"
     }
 
-    UploadStatus.indeterminate(id, cause).copy(failed = true)
+    UploadStatus.indeterminate(id, cause, failed = true)
   }
 
   private def lessThan10MinutesOld(e: ExecutionListItem): Boolean = {

--- a/common/src/main/scala/com/gu/media/upload/S3UploadActions.scala
+++ b/common/src/main/scala/com/gu/media/upload/S3UploadActions.scala
@@ -33,7 +33,7 @@ class S3UploadActions(s3: AmazonS3Client) extends Logging {
 
       log.info(s"Multipart copy complete. upload=${upload.id} multipart=${multipart.getUploadId}")
     } else {
-      log.error(s"Unable to create complete object $destination since the parts have been deleted from S3")
+      throw new IllegalStateException(s"Unable to create complete object $destination since the parts have been deleted from S3")
     }
   }
 

--- a/common/src/main/scala/com/gu/media/upload/S3UploadActions.scala
+++ b/common/src/main/scala/com/gu/media/upload/S3UploadActions.scala
@@ -17,41 +17,20 @@ class S3UploadActions(s3: AmazonS3Client) extends Logging {
     val bucket = upload.metadata.bucket
     val parts = upload.parts.map { case UploadPart(key, _, _) => key }
 
-    if(parts.forall(objectExists(bucket, _))) {
-      val start = new InitiateMultipartUploadRequest(bucket, destination)
-      log.info(s"Starting multipart copy for upload ${upload.id}")
+    val start = new InitiateMultipartUploadRequest(bucket, destination)
+    log.info(s"Starting multipart copy for upload ${upload.id}")
 
-      val multipart = s3.initiateMultipartUpload(start)
-      val eTags = parts.zipWithIndex.map { case(key, part) =>
-        copyPart(multipart.getUploadId, bucket, part, key, destination)
-      }
-
-      val complete = new CompleteMultipartUploadRequest(
-        bucket, destination, multipart.getUploadId, eTags.asJava)
-
-      s3.completeMultipartUpload(complete)
-
-      log.info(s"Multipart copy complete. upload=${upload.id} multipart=${multipart.getUploadId}")
-    } else {
-      throw new IllegalStateException(s"Unable to create complete object $destination since the parts have been deleted from S3")
+    val multipart = s3.initiateMultipartUpload(start)
+    val eTags = parts.zipWithIndex.map { case(key, part) =>
+      copyPart(multipart.getUploadId, bucket, part, key, destination)
     }
-  }
 
-  // TODO MRB: remove this once moved to step functions
-  def objectExists(bucket: String, key: String) = try {
-    s3.doesObjectExist(bucket, key)
-  } catch {
-    case e: AmazonS3Exception =>
-      log.error(s"Error checking $key", e)
-      false
-  }
+    val complete = new CompleteMultipartUploadRequest(
+      bucket, destination, multipart.getUploadId, eTags.asJava)
 
-  def getObjectInput(bucket: String, key: String): Option[InputStream] = {
-    if(objectExists(bucket, key)) {
-      Some(s3.getObject(bucket, key).getObjectContent)
-    } else {
-      None
-    }
+    s3.completeMultipartUpload(complete)
+
+    log.info(s"Multipart copy complete. upload=${upload.id} multipart=${multipart.getUploadId}")
   }
 
   def deleteParts(upload: Upload): Unit = {

--- a/common/src/main/scala/com/gu/media/upload/actions/UploadActionHandler.scala
+++ b/common/src/main/scala/com/gu/media/upload/actions/UploadActionHandler.scala
@@ -18,9 +18,6 @@ abstract class UploadActionHandler(store: UploadsDataStore, plutoStore: PlutoDat
   def addAsset(atomId: String, videoId: String): Long
 
   def handle(action: UploadAction): Unit = action match {
-    case _ if action.upload.metadata.useStepFunctions =>
-      log.info("Bypassing kinesis powered lambdas")
-
     case UploadPartToYouTube(upload, part, uploadUri) =>
       val updated = youTube.uploadPart(upload, part, uploadUri)
 

--- a/common/src/main/scala/com/gu/media/upload/model/Upload.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/Upload.scala
@@ -31,10 +31,9 @@ object Upload {
 
   def mergeProgress(upload: Upload, progress: UploadProgress): Upload = {
     upload.copy(progress = UploadProgress(
-      uploadedToS3 = Math.max(upload.progress.uploadedToS3, progress.uploadedToS3),
-      uploadedToYouTube = Math.max(upload.progress.uploadedToYouTube, progress.uploadedToYouTube),
       retries = Math.max(upload.progress.retries, progress.retries),
       chunksInS3 = Math.max(upload.progress.chunksInS3, progress.chunksInS3),
+      chunksInYouTube = Math.max(upload.progress.chunksInYouTube, progress.chunksInYouTube),
       fullyUploaded = upload.progress.fullyUploaded || progress.fullyUploaded,
       fullyTranscoded = upload.progress.fullyTranscoded || progress.fullyTranscoded
     ))

--- a/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
@@ -12,8 +12,7 @@ case class UploadMetadata(
   pluto: PlutoSyncMetadata,
   selfHost: Boolean = false,
   youTubeId: Option[String] = None,
-  youTubeUploadUri: Option[String] = None,
-  useStepFunctions: Boolean = false
+  youTubeUploadUri: Option[String] = None
 )
 
 case class PlutoSyncMetadata (

--- a/common/src/main/scala/com/gu/media/upload/model/UploadProgress.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadProgress.scala
@@ -3,8 +3,7 @@ package com.gu.media.upload.model
 import org.cvogt.play.json.Jsonx
 import play.api.libs.json.Format
 
-case class UploadProgress(uploadedToS3: Long, uploadedToYouTube: Long, chunksInS3: Int,
-                          fullyUploaded: Boolean, fullyTranscoded: Boolean, retries: Int)
+case class UploadProgress(chunksInS3: Int, chunksInYouTube: Int, fullyUploaded: Boolean, fullyTranscoded: Boolean, retries: Int)
 
 object UploadProgress {
   implicit val format: Format[UploadProgress] = Jsonx.formatCaseClass[UploadProgress]

--- a/common/src/main/scala/com/gu/media/upload/model/UploadStatus.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadStatus.scala
@@ -1,0 +1,14 @@
+package com.gu.media.upload.model
+
+import org.cvogt.play.json.Jsonx
+import play.api.libs.json.Format
+
+case class UploadStatus(id: String, status: String, current: Int, total: Int, failed: Boolean)
+
+object UploadStatus {
+  def indeterminate(id: String, status: String): UploadStatus = {
+    UploadStatus(id, status, current = -1, total = -1, failed = false)
+  }
+
+  implicit val format: Format[UploadStatus] = Jsonx.formatCaseClass[UploadStatus]
+}

--- a/common/src/main/scala/com/gu/media/upload/model/UploadStatus.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadStatus.scala
@@ -3,11 +3,15 @@ package com.gu.media.upload.model
 import org.cvogt.play.json.Jsonx
 import play.api.libs.json.Format
 
-case class UploadStatus(id: String, status: String, current: Int, total: Int, failed: Boolean)
+case class UploadStatus(id: String, status: String, current: Option[Int], total: Option[Int], failed: Boolean)
 
 object UploadStatus {
-  def indeterminate(id: String, status: String): UploadStatus = {
-    UploadStatus(id, status, current = -1, total = -1, failed = false)
+  def apply(id: String, status: String, current: Int, total: Int, failed: Boolean = false): UploadStatus = {
+    UploadStatus(id, status, current = Some(current), total = Some(total), failed)
+  }
+
+  def indeterminate(id: String, status: String, failed: Boolean = false): UploadStatus = {
+    UploadStatus(id, status, current = None, total = None, failed)
   }
 
   implicit val format: Format[UploadStatus] = Jsonx.formatCaseClass[UploadStatus]

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeUploader.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeUploader.scala
@@ -50,7 +50,12 @@ class YouTubeUploader(youTube: YouTubeAccess, s3: S3UploadActions) extends Loggi
       .build()
 
     val response = http.newCall(request).execute()
-    response.header("Location")
+
+    if(response.code() == 200) {
+      response.header("Location")
+    } else {
+      throw new IllegalStateException(s"${response.code()} when starting YouTube upload: ${response.body().string()}")
+    }
   }
 
   def uploadPart(upload: Upload, part: UploadPart, uploadUri: String): Upload = {

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeUploader.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeUploader.scala
@@ -71,20 +71,17 @@ class YouTubeUploader(youTube: YouTubeAccess, s3: S3UploadActions) extends Loggi
             upload.copy(metadata = upload.metadata.copy(youTubeId = Some(videoId)))
 
           case MoveToNextChunk if part == upload.parts.last =>
-            log.error("YouTube did not provide a video id. The asset cannot be added")
-            upload
+            throw new IllegalStateException("YouTube did not provide a video id. The asset cannot be added")
 
           case MoveToNextChunk =>
             upload
 
           case UploadError(error) =>
-            log.error(error)
-            upload
+            throw new IllegalStateException(error)
         }
 
       case None =>
-        log.error(s"Unable to upload ${part.key} since it has been deleted from S3")
-        upload
+        throw new IllegalStateException(s"Unable to upload ${part.key} since it has been deleted from S3")
     }
 
     updated.copy(progress = upload.progress.copy(

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeUploader.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeUploader.scala
@@ -82,7 +82,9 @@ class YouTubeUploader(youTube: YouTubeAccess, s3: S3UploadActions) extends Loggi
         upload
     }
 
-    updated.copy(progress = upload.progress.copy(uploadedToYouTube = part.end))
+    updated.copy(progress = upload.progress.copy(
+      chunksInYouTube = upload.progress.chunksInYouTube + 1
+    ))
   }
 
   private def uploadChunk(uri: String, input: InputStream, start: Long, end: Long, total: Long): YouTubeUploader.Result = {

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeUploader.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeUploader.scala
@@ -22,7 +22,7 @@ class YouTubeUploader(youTube: YouTubeAccess, s3: S3UploadActions) extends Loggi
     val params = s"uploadType=resumable&part=snippet,statistics,status&$contentOwnerParams"
     val endpoint = s"https://www.googleapis.com/upload/youtube/v3/videos?$params"
 
-    val videoTitle = s"$title-$id"
+    val videoTitle = s"$title-$id".take(70) // YouTube character limit
     val description = s"Uploaded by the media-atom-maker. Pending publishing"
 
     val json =

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeUploader.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeUploader.scala
@@ -2,16 +2,15 @@ package com.gu.media.youtube
 
 import java.io.InputStream
 
-import com.gu.media.aws.S3Access
+import com.amazonaws.services.s3.AmazonS3Client
 import com.gu.media.logging.Logging
-import com.gu.media.upload.S3UploadActions
 import com.gu.media.upload.model.{Upload, UploadPart}
 import com.gu.media.util.InputStreamRequestBody
-import com.gu.media.youtube.YouTubeUploader.{MoveToNextChunk, UploadError, VideoFullyUpload}
+import com.gu.media.youtube.YouTubeUploader.{MoveToNextChunk, UploadError, VideoFullyUploaded}
 import com.squareup.okhttp.{MediaType, OkHttpClient, Request, RequestBody}
 import play.api.libs.json.{JsObject, Json}
 
-class YouTubeUploader(youTube: YouTubeAccess, s3: S3UploadActions) extends Logging {
+class YouTubeUploader(youTube: YouTubeAccess, s3: AmazonS3Client) extends Logging {
   private val JSON = MediaType.parse("application/json; charset=utf-8")
   private val VIDEO = MediaType.parse("video/*")
 
@@ -64,29 +63,26 @@ class YouTubeUploader(youTube: YouTubeAccess, s3: S3UploadActions) extends Loggi
     val UploadPart(key, start, end) = part
     val total = upload.parts.last.end
 
-    val updated = s3.getObjectInput(upload.metadata.bucket, key.toString) match {
-      case Some(input) =>
-        uploadChunk(uploadUri, input, start, end, total) match {
-          case VideoFullyUpload(videoId) =>
-            upload.copy(metadata = upload.metadata.copy(youTubeId = Some(videoId)))
+    val input = s3.getObject(upload.metadata.bucket, key).getObjectContent
 
-          case MoveToNextChunk if part == upload.parts.last =>
-            throw new IllegalStateException("YouTube did not provide a video id. The asset cannot be added")
+    uploadChunk(uploadUri, input, start, end, total) match {
+      case VideoFullyUploaded(videoId) =>
+        upload.copy(
+          progress = upload.progress.copy(chunksInYouTube = upload.progress.chunksInYouTube + 1),
+          metadata = upload.metadata.copy(youTubeId = Some(videoId))
+        )
 
-          case MoveToNextChunk =>
-            upload
+      case MoveToNextChunk if part == upload.parts.last =>
+        throw new IllegalStateException("YouTube did not provide a video id. The asset cannot be added")
 
-          case UploadError(error) =>
-            throw new IllegalStateException(error)
-        }
+      case MoveToNextChunk =>
+        upload.copy(progress = upload.progress.copy(
+          chunksInYouTube = upload.progress.chunksInYouTube + 1
+        ))
 
-      case None =>
-        throw new IllegalStateException(s"Unable to upload ${part.key} since it has been deleted from S3")
+      case UploadError(error) =>
+        throw new IllegalStateException(error)
     }
-
-    updated.copy(progress = upload.progress.copy(
-      chunksInYouTube = upload.progress.chunksInYouTube + 1
-    ))
   }
 
   private def uploadChunk(uri: String, input: InputStream, start: Long, end: Long, total: Long): YouTubeUploader.Result = {
@@ -122,7 +118,7 @@ class YouTubeUploader(youTube: YouTubeAccess, s3: S3UploadActions) extends Loggi
           UploadError(s"YouTube upload error $code: $message")
 
         case (Some(id), None) =>
-          VideoFullyUpload(id)
+          VideoFullyUploaded(id)
 
         case (None, None) =>
           UploadError(s"Unable to parse YouTube response $result")
@@ -134,10 +130,6 @@ class YouTubeUploader(youTube: YouTubeAccess, s3: S3UploadActions) extends Loggi
 object YouTubeUploader {
   sealed trait Result
   case object MoveToNextChunk extends Result
-  case class VideoFullyUpload(videoId: String) extends Result
+  case class VideoFullyUploaded(videoId: String) extends Result
   case class UploadError(error: String) extends Result
-
-  def apply(aws: S3Access, youTube: YouTubeAccess): YouTubeUploader = {
-    new YouTubeUploader(youTube, new S3UploadActions(aws.s3Client))
-  }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -43,9 +43,7 @@ POST    /api2/workflow/atoms            controllers.Api2.createWorkflowMediaAtom
 # user uploaded videos
 GET     /api2/uploads                   controllers.UploadController.list(atomId)
 POST    /api2/uploads                   controllers.UploadController.create
-DELETE  /api2/uploads/:id               controllers.UploadController.delete(id)
-POST    /api2/uploads/:id/credentials   controllers.UploadController.credentials(id)
-POST    /api2/uploads/:id/complete      controllers.UploadController.complete(id)
+POST    /api2/uploads/:id/credentials   controllers.UploadController.credentials(id, key)
 
 GET     /api2/audits/:id                controllers.Api2.getAuditTrailForAtomId(id)
 

--- a/public/video-ui/src/actions/UploadActions/getUploads.js
+++ b/public/video-ui/src/actions/UploadActions/getUploads.js
@@ -1,4 +1,4 @@
-import { UploadsApi } from '../../services/UploadsApi';
+import * as UploadsApi from '../../services/UploadsApi';
 import { errorDetails } from '../../util/errorDetails';
 
 function runningUploads(uploads) {

--- a/public/video-ui/src/actions/UploadActions/s3Upload.js
+++ b/public/video-ui/src/actions/UploadActions/s3Upload.js
@@ -33,13 +33,8 @@ function uploadError(error) {
   };
 }
 
-export function startUpload(id, file, selfHost, completeFn) {
+export function startUpload(id, file, selfHost) {
   return dispatch => {
-    // Start prompting the user about reloading the page
-    window.onbeforeunload = () => {
-      return false;
-    };
-
     createUpload(id, file, selfHost).then(upload => {
       dispatch(uploadStarted(upload));
 
@@ -47,14 +42,9 @@ export function startUpload(id, file, selfHost, completeFn) {
 
       return uploadParts(upload, upload.parts, file, progress)
         .then(() => {
-          // Stop prompting the user. The upload continues server-side
-          window.onbeforeunload = undefined;
-
           dispatch(uploadComplete());
-          completeFn();
         })
         .catch(err => {
-          window.onbeforeunload = undefined;
           dispatch(uploadError(errorDetails(err)));
         });
     });

--- a/public/video-ui/src/actions/UploadActions/s3Upload.js
+++ b/public/video-ui/src/actions/UploadActions/s3Upload.js
@@ -1,4 +1,4 @@
-import { UploadsApi } from '../../services/UploadsApi';
+import { createUpload, uploadParts } from '../../services/UploadsApi';
 import { errorDetails } from '../../util/errorDetails';
 
 function uploadStarted(upload) {
@@ -40,12 +40,12 @@ export function startUpload(id, file, selfHost, completeFn) {
       return false;
     };
 
-    UploadsApi.createUpload(id, file, selfHost).then(upload => {
+    createUpload(id, file, selfHost).then(upload => {
       dispatch(uploadStarted(upload));
 
       const progress = completed => dispatch(uploadProgress(completed));
 
-      return UploadsApi.uploadParts(upload, upload.parts, file, progress)
+      return uploadParts(upload, upload.parts, file, progress)
         .then(() => {
           // Stop prompting the user. The upload continues server-side
           window.onbeforeunload = undefined;

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -13,6 +13,11 @@ export default class Header extends React.Component {
 
   renderProgress() {
     if (this.props.s3Upload.total) {
+      // Start prompting the user about reloading the page
+      window.onbeforeunload = () => {
+        return false;
+      };
+
       return (
         <progress
           className="topbar__progress"
@@ -21,6 +26,8 @@ export default class Header extends React.Component {
         />
       );
     } else {
+      // Stop prompting the user. The upload continues server-side
+      window.onbeforeunload = undefined;
       return false;
     }
   }

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -201,17 +201,14 @@ export default class VideoTrail extends React.Component {
     );
 
     uploads.forEach(upload => {
-      const total = upload.total == -1 ? undefined : upload.total;
-      const current = upload.current == -1 ? undefined : upload.current;
-
       blocks.push(
         upload.failed
           ? <FailedUpload key={upload.id} message={upload.status} />
           : <UploadAsset
               key={upload.id}
               message={upload.status}
-              total={total}
-              progress={current}
+              total={upload.total}
+              progress={upload.current}
             />
       );
     });

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -120,7 +120,10 @@ export default class VideoTrail extends React.Component {
   }
 
   pollIfRequired = () => {
-    if (this.props.uploads.length > 0) {
+    const existingUploads = this.props.uploads.length > 0;
+    const missingUploads = this.props.s3Upload.id && !existingUploads;
+
+    if (existingUploads || missingUploads) {
       this.props.getUploads();
       this.props.getVideo();
     }

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -77,6 +77,27 @@ function UploadAsset({ message, total, progress }) {
   );
 }
 
+function FailedUpload({ message }) {
+  return (
+    <div className="grid__item">
+      <div className="upload__asset__video">
+        <p>
+          <strong>Upload Failed</strong><br />
+          You may retry your upload.<br />
+          This message will disappear after 10 minutes.
+        </p>
+      </div>
+      <div className="grid__item__footer">
+        <span className="grid__item__title">
+          <small>
+            <code>{message}</code>
+          </small>
+        </span>
+      </div>
+    </div>
+  );
+}
+
 export default class VideoTrail extends React.Component {
   polling = null;
   state = { status: [] };
@@ -121,9 +142,7 @@ export default class VideoTrail extends React.Component {
   };
 
   renderS3Upload = () => {
-    // Multiply by 2 to give the impression of a continuous progress bar once this component is swapped out with
-    // another showing the progress of uploading to YouTube server-side
-    const total = this.props.s3Upload.total * 2;
+    const total = this.props.s3Upload.total;
     const progress = this.props.s3Upload.progress;
 
     return (
@@ -131,18 +150,6 @@ export default class VideoTrail extends React.Component {
         key="s3Upload"
         message="Uploading To S3"
         total={total}
-        progress={progress}
-      />
-    );
-  };
-
-  renderRemoteUpload = (id, total, progress) => {
-    // See renderS3Upload() for why we multiply by 2
-    return (
-      <UploadAsset
-        key={id}
-        message="Uploading to YouTube"
-        total={total * 2}
         progress={progress}
       />
     );
@@ -189,18 +196,24 @@ export default class VideoTrail extends React.Component {
       blocks.push(this.renderS3Upload());
     }
 
-    const uploads = this.props.s3Upload.id
-      ? this.props.uploads.filter(
-          upload => upload.id !== this.props.s3Upload.id
-        )
-      : this.props.uploads;
+    const uploads = this.props.uploads.filter(
+      upload => upload.id !== this.props.s3Upload.id
+    );
 
     uploads.forEach(upload => {
-      const total = upload.parts[upload.parts.length - 1].end;
-      const progress =
-        upload.progress.uploadedToS3 + upload.progress.uploadedToYouTube;
+      const total = upload.total == -1 ? undefined : upload.total;
+      const current = upload.current == -1 ? undefined : upload.current;
 
-      blocks.push(this.renderRemoteUpload(upload.id, total, progress));
+      blocks.push(
+        upload.failed
+          ? <FailedUpload key={upload.id} message={upload.status} />
+          : <UploadAsset
+              key={upload.id}
+              message={upload.status}
+              total={total}
+              progress={current}
+            />
+      );
     });
 
     blocks.push(...this.props.assets.map(this.renderAsset));

--- a/public/video-ui/src/components/VideoUpload/VideoUpload.js
+++ b/public/video-ui/src/components/VideoUpload/VideoUpload.js
@@ -73,15 +73,10 @@ class VideoUpload extends React.Component {
 
   startUpload = selfHost => {
     if (this.props.video && this.state.file) {
-      const atomId = this.props.video.id;
-
       this.props.uploadActions.startUpload(
-        atomId,
+        this.props.video.id,
         this.state.file,
-        selfHost,
-        () => {
-          this.props.uploadActions.getUploads(atomId);
-        }
+        selfHost
       );
     }
   };

--- a/public/video-ui/src/components/VideoUpload/VideoUpload.js
+++ b/public/video-ui/src/components/VideoUpload/VideoUpload.js
@@ -53,7 +53,7 @@ class AddAssetFromURL extends React.Component {
 }
 
 class VideoUpload extends React.Component {
-  state = { file: null, useStepFunctions: false };
+  state = { file: null };
 
   componentWillMount() {
     this.props.videoActions.getVideo(this.props.params.id);
@@ -78,12 +78,10 @@ class VideoUpload extends React.Component {
       this.props.uploadActions.startUpload(
         atomId,
         this.state.file,
-        () => {
-          // on complete
-          this.props.uploadActions.getUploads(atomId);
-        },
         selfHost,
-        this.state.useStepFunctions
+        () => {
+          this.props.uploadActions.getUploads(atomId);
+        }
       );
     }
   };
@@ -98,8 +96,6 @@ class VideoUpload extends React.Component {
           {this.renderAddAssetUpload()}
           {' '}
           {this.renderAddSelfHostAssetUpload()}
-          {' '}
-          {this.renderMethodPicker()}
         </div>
       );
     }
@@ -114,23 +110,6 @@ class VideoUpload extends React.Component {
   renderAddSelfHostAssetUpload() {
     if (getStore().getState().config.permissions.addSelfHostedAsset) {
       return this.renderStartUpload(true, 'Upload avoiding YouTube');
-    }
-  }
-
-  // TODO MRB: remove this once step functions are in use
-  renderMethodPicker() {
-    if (getStore().getState().config.permissions.addSelfHostedAsset) {
-      return (
-        <div>
-          Use Step Functions
-          <input
-            type="checkbox"
-            onChange={e =>
-              this.setState({ useStepFunctions: e.target.checked })}
-            checked={this.state.useStepFunctions}
-          />
-        </div>
-      );
     }
   }
 
@@ -187,7 +166,7 @@ class VideoUpload extends React.Component {
   }
 
   render() {
-    const uploading = this.props.s3Upload.handle !== null;
+    const uploading = this.props.s3Upload.total > 0;
 
     const activeVersion = this.props.video ? this.props.video.activeVersion : 0;
     const assets = this.props.video ? this.props.video.assets : [];

--- a/public/video-ui/src/reducers/s3UploadReducer.js
+++ b/public/video-ui/src/reducers/s3UploadReducer.js
@@ -19,6 +19,9 @@ export default function s3Upload(state = EMPTY, action) {
     case 'UPLOAD_COMPLETE':
       return EMPTY;
 
+    case 'SHOW_ERROR':
+      return EMPTY;
+
     default:
       return state;
   }

--- a/public/video-ui/src/reducers/s3UploadReducer.js
+++ b/public/video-ui/src/reducers/s3UploadReducer.js
@@ -1,4 +1,4 @@
-const EMPTY = { id: null, handle: null, progress: 0, total: 0 };
+const EMPTY = { id: null, progress: 0, total: 0 };
 
 // This key covers the first part of a video upload where we put the video into S3 from the client browser.
 // We hold that progress in a separate state key from the progress of uploading to YouTube on the server side.
@@ -9,8 +9,6 @@ export default function s3Upload(state = EMPTY, action) {
       const total = action.upload.parts[action.upload.parts.length - 1].end;
       return Object.assign({}, state, {
         id: action.upload.id,
-        created: action.receivedAt,
-        handle: action.handle,
         total: total
       });
     }

--- a/public/video-ui/src/services/UploadsApi.js
+++ b/public/video-ui/src/services/UploadsApi.js
@@ -5,99 +5,94 @@ import { errorDetails } from '../util/errorDetails';
 import 'aws-sdk/dist/aws-sdk';
 const AWS = window.AWS;
 
-class UploadFunctions {
-  getUploads = atomId => {
-    return pandaReqwest({
-      url: `/api2/uploads?atomId=${atomId}`
-    });
-  };
-
-  createUpload = (atomId, file, selfHost) => {
-    return pandaReqwest({
-      url: `/api2/uploads?atomId=${atomId}`,
-      method: 'post',
-      data: {
-        atomId: atomId,
-        filename: file.name,
-        size: file.size,
-        selfHost: selfHost,
-        syncWithPluto: false // TODO change this once full Pluto integration is complete
-      }
-    });
-  };
-
-  uploadParts = (upload, parts, file, progressFn) => {
-    return new Promise((resolve, reject) => {
-      const uploadPartRecursive = parts => {
-        if (parts.length === 0) {
-          resolve(true);
-        } else {
-          const part = parts[0];
-
-          this.uploadPart(upload, part, file, progressFn)
-            .then(s3Request => {
-              return s3Request.promise().then(() => {
-                uploadPartRecursive(parts.slice(1));
-              });
-            })
-            .catch(err => {
-              reject(errorDetails(err));
-            });
-        }
-      };
-
-      uploadPartRecursive(parts);
-    });
-  };
-
-  uploadPart = (upload, part, file, progressFn) => {
-    const slice = file.slice(part.start, part.end);
-
-    return this.getCredentials(upload.id, part.key).then(credentials => {
-      const s3 = this.getS3(
-        upload.metadata.bucket,
-        upload.metadata.region,
-        credentials
-      );
-
-      const params = {
-        Key: part.key,
-        Body: slice,
-        ACL: 'private',
-        Metadata: { original: file.name }
-      };
-      const request = s3.upload(params);
-
-      request.on('httpUploadProgress', event => {
-        progressFn(part.start + event.loaded);
-      });
-
-      return request;
-    });
-  };
-
-  getCredentials = (id, key) => {
-    return pandaReqwest({
-      url: `/api2/uploads/${id}/credentials?key=${key}`,
-      method: 'post'
-    });
-  };
-
-  getS3 = (bucket, region, credentials) => {
-    const { temporaryAccessId, temporarySecretKey, sessionToken } = credentials;
-    const awsCredentials = new AWS.Credentials(
-      temporaryAccessId,
-      temporarySecretKey,
-      sessionToken
-    );
-
-    return new AWS.S3({
-      apiVersion: '2006-03-01',
-      credentials: awsCredentials,
-      params: { Bucket: bucket },
-      region: region
-    });
-  };
+export function getUploads(atomId) {
+  return pandaReqwest({
+    url: `/api2/uploads?atomId=${atomId}`
+  });
 }
 
-export const UploadsApi = new UploadFunctions();
+export function createUpload(atomId, file, selfHost) {
+  return pandaReqwest({
+    url: `/api2/uploads?atomId=${atomId}`,
+    method: 'post',
+    data: {
+      atomId: atomId,
+      filename: file.name,
+      size: file.size,
+      selfHost: selfHost,
+      syncWithPluto: false // TODO change this once full Pluto integration is complete
+    }
+  });
+}
+
+function getCredentials(id, key) {
+  return pandaReqwest({
+    url: `/api2/uploads/${id}/credentials?key=${key}`,
+    method: 'post'
+  });
+}
+
+function getS3(bucket, region, credentials) {
+  const { temporaryAccessId, temporarySecretKey, sessionToken } = credentials;
+  const awsCredentials = new AWS.Credentials(
+    temporaryAccessId,
+    temporarySecretKey,
+    sessionToken
+  );
+
+  return new AWS.S3({
+    apiVersion: '2006-03-01',
+    credentials: awsCredentials,
+    params: { Bucket: bucket },
+    region: region
+  });
+}
+
+function uploadPart(upload, part, file, progressFn) {
+  const slice = file.slice(part.start, part.end);
+
+  return getCredentials(upload.id, part.key).then(credentials => {
+    const s3 = getS3(
+      upload.metadata.bucket,
+      upload.metadata.region,
+      credentials
+    );
+
+    const params = {
+      Key: part.key,
+      Body: slice,
+      ACL: 'private',
+      Metadata: { original: file.name }
+    };
+    const request = s3.upload(params);
+
+    request.on('httpUploadProgress', event => {
+      progressFn(part.start + event.loaded);
+    });
+
+    return request.promise();
+  });
+}
+
+export function uploadParts(upload, parts, file, progressFn) {
+  return new Promise((resolve, reject) => {
+    function uploadPartRecursive(parts) {
+      if (parts.length === 0) {
+        resolve(true);
+      } else {
+        const part = parts[0];
+        const result = uploadPart(upload, part, file, progressFn);
+
+        result
+          .then(() => {
+            uploadPartRecursive(parts.slice(1));
+          })
+          .catch(err => {
+            reject(errorDetails(err));
+          });
+      }
+    }
+
+    uploadPartRecursive(parts);
+  });
+}

--- a/uploader/src/main/resources/cfn-template.yaml
+++ b/uploader/src/main/resources/cfn-template.yaml
@@ -32,6 +32,10 @@ Parameters:
   ManualPlutoTable:
     Description: "The Dynamo table to store videos that must be manually synced with Pluto"
     Type: "String"
+  NotificationEmailFrom:
+    Description: "email address where notifications of missing pluto ids are sent from"
+    Type: "String"
+    Default: "digitalcms.dev@guardian.co.uk"
 
 Conditions:
   CreateProdResources: !Equals [!Ref "Stage", "PROD"]
@@ -70,6 +74,16 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${UploadTrackingTable}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ManualPlutoTable}"
+              - Effect: "Allow"
+                Action: ["elastictranscoder:CreateJob"]
+                Resource: "arn:aws:elastictranscoder:*"
+              - Effect: Allow
+                Action:
+                - ses:SendEmail
+                Resource: '*'
+                Condition:
+                  StringEquals:
+                    ses:FromAddress: !Ref 'NotificationEmailFrom'
 
   StatesExecutionRole:
     Type: "AWS::IAM::Role"

--- a/uploader/src/main/scala/com/gu/media/AddAssetActions.scala
+++ b/uploader/src/main/scala/com/gu/media/AddAssetActions.scala
@@ -31,11 +31,7 @@ class AddAssetActions(config: Settings with AwsAccess, hmac: HmacRequestSupport)
 
       val response = http.newCall(request).execute()
       if (response.code() != 200) {
-        log.error(s"Unexpected response adding asset ${response.code()}")
-        log.error(s"uri=$uri body=$body responseBody=${response.body().string()}")
-        log.error(s"atomId=$atomId youTubeId=$videoId")
-
-        -1
+        throw new IllegalStateException(s"Unexpected response adding asset ${response.code()} ${response.body().string()}")
       } else {
         val str = response.body().string()
         val json = Json.parse(str)

--- a/uploader/src/main/scala/com/gu/media/UploadActionsLambda.scala
+++ b/uploader/src/main/scala/com/gu/media/UploadActionsLambda.scala
@@ -25,7 +25,7 @@ class UploadActionsLambda extends RequestHandler[KinesisEvent, Unit]
 
   val store = new UploadsDataStore(this)
   val plutoStore = new PlutoDataStore(this.dynamoDB, this.manualPlutoDynamo)
-  val uploader = YouTubeUploader(this, this)
+  val uploader = new YouTubeUploader(this, this.s3Client)
   val mailer = new Mailer(this.sesClient, getMandatoryString("host"))
   val handler = new LambdaActionHandler(store, plutoStore, this, uploader, this)
 

--- a/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
@@ -16,7 +16,7 @@ class AddAssetToAtom extends LambdaWithParams[Upload, Upload] with DynamoAccess 
         actions.addAsset(upload.metadata.pluto.atomId, videoId)
 
       case None =>
-        log.info("Missing YouTube video ID. Cannot add asset")
+        throw new IllegalStateException("Missing YouTube video ID. Cannot add asset")
     }
 
     table.delete(upload.id)

--- a/uploader/src/main/scala/com/gu/media/upload/GetChunkFromS3.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/GetChunkFromS3.scala
@@ -23,7 +23,6 @@ class GetChunkFromS3 extends LambdaWithParams[Upload, Upload] with S3Access with
   private def complete(upload: Upload, chunk: UploadPart): Upload = {
     upload.copy(progress = upload.progress.copy(
       fullyUploaded = chunk == upload.parts.last,
-      uploadedToS3 = chunk.end,
       chunksInS3 = upload.progress.chunksInS3 + 1,
       retries = 0
     ))

--- a/uploader/src/main/scala/com/gu/media/upload/UploadChunkToYouTube.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/UploadChunkToYouTube.scala
@@ -12,7 +12,7 @@ class UploadChunkToYouTube extends LambdaWithParams[Upload, Upload]
   with S3Access
   with DynamoAccess
 {
-  private val uploader = YouTubeUploader(this, this)
+  private val uploader = new YouTubeUploader(this, this.s3Client)
   private val table = new UploadsDataStore(this)
 
   override def handle(upload: Upload): Upload = {

--- a/uploader/src/main/scala/com/gu/media/upload/UploadChunkToYouTube.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/UploadChunkToYouTube.scala
@@ -23,7 +23,7 @@ class UploadChunkToYouTube extends LambdaWithParams[Upload, Upload]
 
     val updated = after.copy(
       metadata = after.metadata.copy(youTubeUploadUri = Some(uploadUri)),
-      progress = after.progress.copy(uploadedToYouTube = chunk.end)
+      progress = after.progress.copy(chunksInYouTube = upload.progress.chunksInYouTube + 1)
     )
 
     table.put(updated)


### PR DESCRIPTION
This PR switches the video upload pipeline to only use step functions.

The `list()` end-point for uploads has been reworked to read the status of the step functions for a particular atom. The front-end now merely displays the `UploadStatus` information it is given.

If the invocation fails, an error is displayed on the upload page asking the user to retry the upload. It disappears after 10 minutes - the result is however still viewable from the AWS console.

Additional goodies:

- Pass the key to the `credentials` end-point as a GET parameter rather than a header (cleaner)
- Remove the `complete` end-point - no longer required
- Fix problem where the new IDs were too long for the STS role session name
- `UploadHandle` on the front-end has been removed in favour of a simpler recursive function call

Things still left to do:

- Don't fire an alert for test failures due to YouTube 503s (by looking at the `UploadStatus`)
- Cloudwatch alarm for failed step function runs
- Move the code called by each lambda into the lambda itself (since we don't need to share it any more)
- Remove the old Kinesis stream etc from the cloud-formation
- Properly poll for progress from the transcoder (when avoiding YouTube)
- Add the asset to the atom in DEV (maybe)