### PR TITLE
more aggressive video title cleaning

### DIFF
--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -65,7 +65,7 @@ package object youtube {
   ) {
     def withSaneTitle(): YouTubeMetadataUpdate = {
       // Editorial add "- video" for on platform SEO, but it isn't needed on a YouTube video title as its a video platform
-      val cleanTitle = this.title.map(_.replaceAll(" (-|–) video$", ""))
+      val cleanTitle = this.title.map(_.replaceAll(" (-|–) video( .*)?$", ""))
       this.copy(title = cleanTitle)
     }
 


### PR DESCRIPTION
We don't want to send videos to YouTube with titles such as "foo bar - video" as its pointless. This PR makes the regex more aggressive, catching trailing spaces and also things like "foo - video report".