### PR TITLE
Fix disappearing video uploads in UI

### DIFF
--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -115,6 +115,12 @@ export default class VideoTrail extends React.Component {
     }
   }
 
+  componentDidReceiveProps(nextProps) {
+    if (nextProps.s3Upload.id === null && this.props.s3Upload.id !== null) {
+      this.props.getUploads();
+    }
+  }
+
   componentWillUnmount() {
     clearInterval(this.polling);
   }

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -115,12 +115,6 @@ export default class VideoTrail extends React.Component {
     }
   }
 
-  componentDidReceiveProps(nextProps) {
-    if (nextProps.s3Upload.id === null && this.props.s3Upload.id !== null) {
-      this.props.getUploads();
-    }
-  }
-
   componentWillUnmount() {
     clearInterval(this.polling);
   }

--- a/public/video-ui/src/reducers/uploadsReducer.js
+++ b/public/video-ui/src/reducers/uploadsReducer.js
@@ -1,5 +1,17 @@
+import _ from 'lodash';
+
 export default function uploads(state = [], action) {
+  const id = action.upload.id;
+
   switch (action.type) {
+    case 'UPLOAD_STARTED':
+      if (!_.find(state, upload => upload.id === id)) {
+        const status = { id: id, status: 'Uploading', failed: false };
+        return [status, ...state];
+      }
+
+      return state;
+
     case 'RUNNING_UPLOADS':
       return action.uploads;
 

--- a/public/video-ui/src/reducers/uploadsReducer.js
+++ b/public/video-ui/src/reducers/uploadsReducer.js
@@ -1,16 +1,17 @@
 import _ from 'lodash';
 
 export default function uploads(state = [], action) {
-  const id = action.upload.id;
-
   switch (action.type) {
-    case 'UPLOAD_STARTED':
+    case 'UPLOAD_STARTED': {
+      const id = action.upload.id;
+
       if (!_.find(state, upload => upload.id === id)) {
         const status = { id: id, status: 'Uploading', failed: false };
         return [status, ...state];
       }
 
       return state;
+    }
 
     case 'RUNNING_UPLOADS':
       return action.uploads;


### PR DESCRIPTION
Fixes a problem where the upload would disappear because polling was not kicked off client-side. The solution is to add a placeholder upload to the Redux state when the upload is started.