### PR TITLE
add help page

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -77,6 +77,7 @@ GET /videos/pluto-list                  controllers.VideoUIApp.index(id = "")
 GET /videos/:id                         controllers.VideoUIApp.index(id)
 GET /videos/:id/audit                   controllers.VideoUIApp.index(id)
 GET /videos/:id/upload                  controllers.VideoUIApp.index(id)
+GET /help                               controllers.VideoUIApp.index(id = "")
 
 #Support
 GET /support/previewCapi/*path          controllers.Support.capiProxy(path: String, queryLive: Boolean ?= false)

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -74,17 +74,12 @@ export default class Header extends React.Component {
     );
   }
 
-  renderFeedback() {
+  renderHelpLink() {
     return (
       <nav className="topbar__nav-link">
-        <a
-          className="button__secondary"
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://goo.gl/forms/0KoeGOW64584Bydm2"
-        >
-          <Icon icon="bug_report">Feedback</Icon>
-        </a>
+        <Link className="button__secondary" to="/help">
+          <Icon icon="live_help">Help</Icon>
+        </Link>
       </nav>
     );
   }
@@ -100,21 +95,6 @@ export default class Header extends React.Component {
         >
           View audit trail
         </Link>
-      </nav>
-    );
-  }
-
-  renderHowTo() {
-    return (
-      <nav className="topbar__nav-link">
-        <a
-          className="button__secondary"
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://docs.google.com/a/guardian.co.uk/document/d/1pqRpgIAAlcUMafbA3T7ZHg54kEs2E9XeANzRoNrwTrE/edit?usp=sharing"
-        >
-          <Icon icon="live_help">How To</Icon>
-        </a>
       </nav>
     );
   }
@@ -163,11 +143,7 @@ export default class Header extends React.Component {
 
           <div className="flex-container">
             {this.renderCreateVideo()}
-          </div>
-
-          <div className="flex-container">
-            {this.renderFeedback()}
-            {this.renderHowTo()}
+            {this.renderHelpLink()}
           </div>
 
         </header>
@@ -204,6 +180,7 @@ export default class Header extends React.Component {
           />
           <div className="flex-container">
             {this.renderAuditLink()}
+            {this.renderHelpLink()}
           </div>
 
         </header>

--- a/public/video-ui/src/components/Help/Help.js
+++ b/public/video-ui/src/components/Help/Help.js
@@ -1,0 +1,45 @@
+import React from 'react';
+
+export default class Help extends React.Component {
+  renderHowTo() {
+    return (
+      <a
+        className="button__secondary"
+        target="_blank"
+        rel="noopener noreferrer"
+        href="https://goo.gl/vzTc3s"
+      >
+        How to use this Tool
+      </a>
+    );
+  }
+
+  renderFeedback() {
+    return (
+      <a
+        className="button__secondary"
+        target="_blank"
+        rel="noopener noreferrer"
+        href="https://goo.gl/forms/0KoeGOW64584Bydm2"
+      >
+        Contact the Team
+      </a>
+    );
+  }
+
+  render() {
+    return (
+      <div className="container">
+        <h1>Help</h1>
+        <ul>
+          <li>
+            {this.renderHowTo()}
+          </li>
+          <li>
+            {this.renderFeedback()}
+          </li>
+        </ul>
+      </div>
+    );
+  }
+}

--- a/public/video-ui/src/components/Help/Help.js
+++ b/public/video-ui/src/components/Help/Help.js
@@ -1,28 +1,15 @@
 import React from 'react';
 
 export default class Help extends React.Component {
-  renderHowTo() {
+  getLink({ url, text }) {
     return (
       <a
         className="button__secondary"
         target="_blank"
         rel="noopener noreferrer"
-        href="https://goo.gl/vzTc3s"
+        href={url}
       >
-        How to use this Tool
-      </a>
-    );
-  }
-
-  renderFeedback() {
-    return (
-      <a
-        className="button__secondary"
-        target="_blank"
-        rel="noopener noreferrer"
-        href="https://goo.gl/forms/0KoeGOW64584Bydm2"
-      >
-        Contact the Team
+        {text}
       </a>
     );
   }
@@ -33,10 +20,22 @@ export default class Help extends React.Component {
         <h1>Help</h1>
         <ul>
           <li>
-            {this.renderHowTo()}
+            {this.getLink({
+              url: 'https://goo.gl/vzTc3s',
+              text: 'How to use this Tool'
+            })}
           </li>
           <li>
-            {this.renderFeedback()}
+            {this.getLink({
+              url: 'https://goo.gl/forms/0KoeGOW64584Bydm2',
+              text: 'Contact the Team'
+            })}
+          </li>
+          <li>
+            {this.getLink({
+              url: 'https://goo.gl/g2FUxn',
+              text: 'Publishing without Pluto'
+            })}
           </li>
         </ul>
       </div>

--- a/public/video-ui/src/components/Help/Help.js
+++ b/public/video-ui/src/components/Help/Help.js
@@ -1,7 +1,22 @@
 import React from 'react';
 
 export default class Help extends React.Component {
-  getLink({ url, text }) {
+  helpPages = [
+    {
+      url: 'https://goo.gl/vzTc3s',
+      text: 'How to use this Tool'
+    },
+    {
+      url: 'https://goo.gl/forms/0KoeGOW64584Bydm2',
+      text: 'Contact the Team'
+    },
+    {
+      url: 'https://goo.gl/g2FUxn',
+      text: 'Publishing without Pluto'
+    }
+  ];
+
+  renderLink({ url, text }) {
     return (
       <a
         className="button__secondary"
@@ -14,30 +29,21 @@ export default class Help extends React.Component {
     );
   }
 
+  renderLinkList() {
+    return (
+      <ul>
+        {this.helpPages.map(page => (
+          <li key={page.url}>{this.renderLink(page)}</li>
+        ))}
+      </ul>
+    );
+  }
+
   render() {
     return (
       <div className="container">
         <h1>Help</h1>
-        <ul>
-          <li>
-            {this.getLink({
-              url: 'https://goo.gl/vzTc3s',
-              text: 'How to use this Tool'
-            })}
-          </li>
-          <li>
-            {this.getLink({
-              url: 'https://goo.gl/forms/0KoeGOW64584Bydm2',
-              text: 'Contact the Team'
-            })}
-          </li>
-          <li>
-            {this.getLink({
-              url: 'https://goo.gl/g2FUxn',
-              text: 'Publishing without Pluto'
-            })}
-          </li>
-        </ul>
+        {this.renderLinkList()}
       </div>
     );
   }

--- a/public/video-ui/src/routes.js
+++ b/public/video-ui/src/routes.js
@@ -7,6 +7,7 @@ import VideoCreate from './components/Video/Create';
 import VideoAuditTrail from './components/VideoAuditTrail/VideoAuditTrail';
 import VideoUpload from './components/VideoUpload/VideoUpload';
 import VideoPlutoList from './components/VideoPluto/VideoPlutoList';
+import Help from './components/Help/Help';
 import ReactApp from './components/ReactApp';
 
 export const routes = (
@@ -19,6 +20,7 @@ export const routes = (
       <Route path="/videos/:id" component={VideoDisplay} />
       <Route path="/videos/:id/audit" component={VideoAuditTrail} />
       <Route path="/videos/:id/upload" component={VideoUpload} />
+      <Route path="/help" component={Help} />
     </Route>
   </Router>
 );


### PR DESCRIPTION
`/help` will be an index of useful documentation we have created. We're currently searching Google Drive each time which is time consuming...

The `Help` button is on every page now too; previously the VideoDisplay page didn't have it because the buttons took too much space.

The intention of this is to have a goto place for help rather than searching email or Google Drive or even IMing the developers on the weekend!

![image](https://cloud.githubusercontent.com/assets/836140/26793096/98681ab6-4a14-11e7-9c5a-088a4eb1253e.png)

