### PR TITLE
Add youtube asset before pipeline complete

### DIFF
--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -63,12 +63,14 @@ function VideoAsset({ id, platform, version, active, selectAsset }) {
 }
 
 function UploadAsset({ message, total, progress }) {
+  const progressBar = total !== undefined && progress !== undefined
+    ? <progress className="progress" value={progress} max={total} />
+    : <span className="loader" />;
+
   return (
     <div className="grid__item">
       <div className="upload__asset__video upload__asset__running">
-        {progress && total
-          ? <progress className="progress" value={progress} max={total} />
-          : <span className="loader" />}
+        {progressBar}
       </div>
       <div className="grid__item__footer">
         <span className="grid__item__title">{message}</span>

--- a/uploader/src/main/resources/state-machine.json
+++ b/uploader/src/main/resources/state-machine.json
@@ -59,10 +59,26 @@
         {
           "Variable": "$.progress.fullyUploaded",
           "BooleanEquals": true,
-          "Next": "CreateCompleteVideoInS3"
+          "Next": "CheckYouTubeHosted"
         }
       ],
       "Default": "GetChunkFromS3"
+    },
+    "CheckYouTubeHosted": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.metadata.selfHost",
+          "BooleanEquals": false,
+          "Next": "AddAssetToAtom"
+        }
+      ],
+      "Default": "CreateCompleteVideoInS3"
+    },
+    "AddAssetToAtom": {
+      "Type": "Task",
+      "Resource": "${AddAssetToAtom.Arn}",
+      "Next": "CreateCompleteVideoInS3"
     },
     "CreateCompleteVideoInS3": {
       "Type": "Task",
@@ -94,7 +110,7 @@
           "Next": "SendToTranscoder"
         }
       ],
-      "Default": "AddAssetToAtom"
+      "Default": "Complete"
     },
     "SendToTranscoder": {
       "Type": "Task",
@@ -112,7 +128,7 @@
         {
           "Variable": "$.progress.fullyTranscoded",
           "BooleanEquals": true,
-          "Next": "AddAssetToAtom"
+          "Next": "Complete"
         }
       ],
       "Default": "WaitForTranscoder"
@@ -122,9 +138,8 @@
       "Seconds": 10,
       "Next": "GetTranscodingProgress"
     },
-    "AddAssetToAtom": {
-      "Type": "Task",
-      "Resource": "${AddAssetToAtom.Arn}",
+    "Complete": {
+      "Type": "Pass",
       "End": true
     }
   }


### PR DESCRIPTION
**Problem**

If a part of the pipeline fails (like S3 multipart copy) before the asset is added, the video remains on YouTube but is not on the atom. This is pretty confusing for users.

**Solution**

Move the add asset call to immediately after the upload (if going to YouTube). I've also filtered out the step functions pipeline that have added the asset to avoid duplicate blocks in the upload UI.