### PR TITLE
Show details of YouTube upload failure

### DIFF
--- a/common/src/main/scala/com/gu/media/upload/model/UploadStatus.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadStatus.scala
@@ -3,15 +3,15 @@ package com.gu.media.upload.model
 import org.cvogt.play.json.Jsonx
 import play.api.libs.json.Format
 
-case class UploadStatus(id: String, status: String, current: Option[Int], total: Option[Int], failed: Boolean)
+case class UploadStatus(id: String, status: String, current: Option[Int], total: Option[Int], failed: Boolean, assetAdded: Boolean)
 
 object UploadStatus {
-  def apply(id: String, status: String, current: Int, total: Int, failed: Boolean = false): UploadStatus = {
-    UploadStatus(id, status, current = Some(current), total = Some(total), failed)
+  def apply(id: String, status: String, current: Int, total: Int, failed: Boolean = false, assetAdded: Boolean = false): UploadStatus = {
+    UploadStatus(id, status, current = Some(current), total = Some(total), failed, assetAdded)
   }
 
-  def indeterminate(id: String, status: String, failed: Boolean = false): UploadStatus = {
-    UploadStatus(id, status, current = None, total = None, failed)
+  def indeterminate(id: String, status: String, failed: Boolean = false, assetAdded: Boolean = false): UploadStatus = {
+    UploadStatus(id, status, current = None, total = None, failed, assetAdded)
   }
 
   implicit val format: Format[UploadStatus] = Jsonx.formatCaseClass[UploadStatus]

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeProcessingStatus.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeProcessingStatus.scala
@@ -1,0 +1,77 @@
+package com.gu.media.youtube
+
+import com.google.api.services.youtube.model.{Video, VideoProcessingDetails}
+import org.cvogt.play.json.Jsonx
+import play.api.libs.json.Format
+
+// failure only set is status is "failed"
+case class YouTubeProcessingStatus(id: String, status: String, total: Long, processed: Long,
+                                   timeLeftMs: Long, failure: Option[String])
+
+object YouTubeProcessingStatus {
+  implicit val format: Format[YouTubeProcessingStatus] = Jsonx.formatCaseClass[YouTubeProcessingStatus]
+
+  def apply(video: Video): YouTubeProcessingStatus = {
+    val base = YouTubeProcessingStatus(video.getId, status = "", total = 0, processed = 0, timeLeftMs = 0, failure = None)
+
+    val summary = video.getStatus
+
+    summary.getUploadStatus match {
+      case "uploaded" => parseProcessingStatus(base, video.getProcessingDetails)
+      case "failed" => base.copy(status = "failed", failure = Option(summary.getFailureReason).map(humanizeFailureReason))
+
+      case "rejected" =>
+        base.copy(status = "failed", failure = Option(summary.getRejectionReason).map(humanizeRejectionReason))
+
+      case "processed" =>
+        base.copy(status = "succeeded")
+
+      case other =>
+        base.copy(status = other)
+    }
+  }
+
+  private def parseProcessingStatus(base: YouTubeProcessingStatus, details: VideoProcessingDetails): YouTubeProcessingStatus = {
+    // progress may be null
+    (details.getProcessingStatus, Option(details.getProcessingProgress)) match {
+      case ("processing", Some(progress)) =>
+        base.copy(
+          status = "processing",
+          total = progress.getPartsTotal.longValue(),
+          processed = progress.getPartsProcessed.longValue(),
+          timeLeftMs = progress.getTimeLeftMs.longValue()
+        )
+
+      case ("failed", _) =>
+        base.copy(
+          status = "failed",
+          failure = Some(details.getProcessingFailureReason).map(humanizeProcessingFailureReason)
+        )
+
+      case (other, _) =>
+        base.copy(status = other)
+    }
+  }
+
+  private def humanizeFailureReason(reason: String) = reason match {
+    case "codec" | "invalidFile" => "The file format is unsupported by YouTube. Perhaps it wasn't a video?"
+    case "conversion" => "YouTube was unable to convert the file. Perhaps it wasn't a video?"
+    case _ => reason
+  }
+
+  private def humanizeRejectionReason(reason: String) = reason match {
+    case "claim" | "copyright" => "YouTube has rejected the video for copyright reasons"
+    case "duplicate" => "Duplicate of an existing video"
+    case "inappropriate" => "YouTube has rejected the video for being inappropriate"
+    case "legal" => "YouTube has rejected the video for legal reasons"
+    case "length" => "The video is longer than the YouTube maximum"
+    case "termsOfUse" => "YouTube has rejected the video for violating terms of service"
+    case "trademark" => "YouTube has rejected the video for trademark violation"
+    case reason => reason
+  }
+
+  private def humanizeProcessingFailureReason(reason: String) = reason match {
+    case "transcodeFailed" => "YouTube was unable to transcode the file. Perhaps it wasn't a video?"
+    case _ => reason
+  }
+}

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -22,7 +22,7 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
 
   def getProcessingStatus(videoIds: List[String]): List[YouTubeProcessingStatus] = {
     val request = client.videos()
-      .list("processingDetails")
+      .list("status,processingDetails")
       .setId(videoIds.mkString(","))
       .setOnBehalfOfContentOwner(contentOwner)
 
@@ -130,26 +130,43 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
   }
 
   private def convertProcessingStatus(video: Video): YouTubeProcessingStatus = {
-    val status = video.getProcessingDetails.getProcessingStatus
-    val maybeProgress = Option(video.getProcessingDetails.getProcessingProgress) // may be null
     val base = YouTubeProcessingStatus(video.getId, status = "", total = 0, processed = 0, timeLeftMs = 0, failure = None)
+    val summary = video.getStatus
 
-    (status, maybeProgress) match {
-      case ("processing", Some(progress)) =>
-        base.copy(
-          status = "processing",
-          total = progress.getPartsTotal.longValue(),
-          processed = progress.getPartsProcessed.longValue(),
-          timeLeftMs = progress.getTimeLeftMs.longValue()
-        )
+    summary.getUploadStatus match {
+      case "uploaded" =>
+        val processingStatus = video.getProcessingDetails.getProcessingStatus
+        val maybeProgress = Option(video.getProcessingDetails.getProcessingProgress) // may be null
 
-      case ("failed", _) =>
-        base.copy(
-          status = "failed",
-          failure = Some(video.getProcessingDetails.getProcessingFailureReason)
-        )
+        (processingStatus, maybeProgress) match {
+          case ("processing", Some(progress)) =>
+            base.copy(
+              status = "processing",
+              total = progress.getPartsTotal.longValue(),
+              processed = progress.getPartsProcessed.longValue(),
+              timeLeftMs = progress.getTimeLeftMs.longValue()
+            )
 
-      case (other, _) =>
+          case ("failed", _) =>
+            base.copy(
+              status = "failed",
+              failure = Some(video.getProcessingDetails.getProcessingFailureReason)
+            )
+
+          case (other, _) =>
+            base.copy(status = other)
+        }
+
+      case "failed" =>
+        base.copy(status = "failed", failure = Option(summary.getFailureReason))
+
+      case "rejected" =>
+        base.copy(status = "failed", failure = Option(summary.getRejectionReason))
+
+      case "processed" =>
+        base.copy(status = "succeeded")
+
+      case other =>
         base.copy(status = other)
     }
   }

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -5,7 +5,7 @@ import java.net.URL
 import java.time.Duration
 
 import com.google.api.client.http.InputStreamContent
-import com.google.api.services.youtube.model.{Video, VideoSnippet}
+import com.google.api.services.youtube.model.{Video, VideoProcessingDetails, VideoSnippet}
 import com.gu.media.logging.Logging
 
 import scala.collection.JavaConverters._
@@ -27,7 +27,7 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
       .setOnBehalfOfContentOwner(contentOwner)
 
     val items = request.execute().getItems.asScala.toList
-    items.map(convertProcessingStatus)
+    items.map(YouTubeProcessingStatus(_))
   }
 
   def getDuration(youtubeId: String): Option[Long] = {
@@ -126,48 +126,6 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
         Some(video)
       }
       case _ => None
-    }
-  }
-
-  private def convertProcessingStatus(video: Video): YouTubeProcessingStatus = {
-    val base = YouTubeProcessingStatus(video.getId, status = "", total = 0, processed = 0, timeLeftMs = 0, failure = None)
-    val summary = video.getStatus
-
-    summary.getUploadStatus match {
-      case "uploaded" =>
-        val processingStatus = video.getProcessingDetails.getProcessingStatus
-        val maybeProgress = Option(video.getProcessingDetails.getProcessingProgress) // may be null
-
-        (processingStatus, maybeProgress) match {
-          case ("processing", Some(progress)) =>
-            base.copy(
-              status = "processing",
-              total = progress.getPartsTotal.longValue(),
-              processed = progress.getPartsProcessed.longValue(),
-              timeLeftMs = progress.getTimeLeftMs.longValue()
-            )
-
-          case ("failed", _) =>
-            base.copy(
-              status = "failed",
-              failure = Some(video.getProcessingDetails.getProcessingFailureReason)
-            )
-
-          case (other, _) =>
-            base.copy(status = other)
-        }
-
-      case "failed" =>
-        base.copy(status = "failed", failure = Option(summary.getFailureReason))
-
-      case "rejected" =>
-        base.copy(status = "failed", failure = Option(summary.getRejectionReason))
-
-      case "processed" =>
-        base.copy(status = "succeeded")
-
-      case other =>
-        base.copy(status = other)
     }
   }
 

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -17,12 +17,6 @@ package object youtube {
   case class YouTubeVideoCategory(id: Int, title: String)
   case class YouTubeChannel(title: String, logo: URI, id: String)
 
-  // failure only set is status is "failed"
-  case class YouTubeProcessingStatus(id: String, status: String, total: Long, processed: Long,
-                                     timeLeftMs: Long, failure: Option[String])
-
-  implicit val format: Format[YouTubeProcessingStatus] = Jsonx.formatCaseClass[YouTubeProcessingStatus]
-
   object YouTubeVideoCategory {
     implicit val reads: Reads[YouTubeVideoCategory] = Json.reads[YouTubeVideoCategory]
     implicit val writes: Writes[YouTubeVideoCategory] = Json.writes[YouTubeVideoCategory]

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -33,7 +33,7 @@ function ErrorAsset({ id, message }) {
   return (
     <div className="grid__item">
       <div className="upload__asset__video upload__asset__empty">
-        <span>Failed: {message}</span>
+        <span>{message}</span>
       </div>
       {footer}
     </div>

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -33,7 +33,7 @@ function ErrorAsset({ id, message }) {
   return (
     <div className="grid__item">
       <div className="upload__asset__video upload__asset__empty">
-        <span>{message}</span>
+        <span>Failed: {message}</span>
       </div>
       {footer}
     </div>
@@ -211,7 +211,7 @@ export default class VideoTrail extends React.Component {
     }
 
     const uploads = this.props.uploads.filter(
-      upload => upload.id !== this.props.s3Upload.id
+      upload => upload.id !== this.props.s3Upload.id && !upload.assetAdded
     );
 
     uploads.forEach(upload => {

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -23,12 +23,19 @@ function youTubeLink(id) {
   );
 }
 
-function ErrorAsset({ message }) {
+function ErrorAsset({ id, message }) {
+  const footer = id
+    ? <div className="grid__item__footer">
+        <span className="grid__item__title">{youTubeLink(id)}</span>
+      </div>
+    : false;
+
   return (
     <div className="grid__item">
       <div className="upload__asset__video upload__asset__empty">
         <span>{message}</span>
       </div>
+      {footer}
     </div>
   );
 }
@@ -173,7 +180,9 @@ export default class VideoTrail extends React.Component {
 
       return <UploadAsset key={asset.id} id={asset.id} message={message} />;
     } else if (processing && processing.status === 'failed') {
-      return <ErrorAsset key={asset.id} message={processing.failure} />;
+      return (
+        <ErrorAsset key={asset.id} id={asset.id} message={processing.failure} />
+      );
     } else {
       const active = asset.version === this.props.activeVersion;
       const selectable =

--- a/public/video-ui/styles/layout/_upload.scss
+++ b/public/video-ui/styles/layout/_upload.scss
@@ -69,6 +69,7 @@
     &__empty {
       background-color: $color900Grey;
       height: 140px;
+      text-align: center;
     }
 
     &__running {


### PR DESCRIPTION
Adds a description of why the upload failed and removes the Activate link on the failed asset.

<img width="685" alt="2951270c-16bd-4b9d-8a24-d3822a43d6dc" src="https://user-images.githubusercontent.com/395805/27137288-6f984130-5115-11e7-90b5-8af1d100d612.png">

Also fixes a race condition introduced by #478 by filtering uploads client side (based on a new `assetAdded` field) rather than server side. 