### PR TITLE
Remove unused lambda parameters from step functions

### DIFF
--- a/uploader/src/main/resources/cfn-template.yaml
+++ b/uploader/src/main/resources/cfn-template.yaml
@@ -26,9 +26,6 @@ Parameters:
   UploadBucketName:
     Description: "The S3 bucket where videos are uploaded to"
     Type: "String"
-  UploadTrackingTable:
-    Description: "The Dynamo table to store progress"
-    Type: "String"
   ManualPlutoTable:
     Description: "The Dynamo table to store videos that must be manually synced with Pluto"
     Type: "String"
@@ -76,7 +73,6 @@ Resources:
               - Effect: "Allow"
                 Action: ["dynamodb:*"]
                 Resource:
-                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${UploadTrackingTable}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ManualPlutoTable}"
               - Effect: "Allow"
                 Action: ["elastictranscoder:CreateJob"]

--- a/uploader/src/main/resources/cfn-template.yaml
+++ b/uploader/src/main/resources/cfn-template.yaml
@@ -36,7 +36,6 @@ Parameters:
   AlertWebhook:
     Description: "Where CloudWatch alerts are sent"
     Type: "String"
-    # Optional in DEV/CODE (just fill in with a dummy string)
 
 Conditions:
   CreateProdResources: !Equals [!Ref "Stage", "PROD"]

--- a/uploader/src/main/resources/cfn-template.yaml
+++ b/uploader/src/main/resources/cfn-template.yaml
@@ -39,7 +39,7 @@ Parameters:
   AlertWebhook:
     Description: "Where CloudWatch alerts are sent"
     Type: "String"
-    Default: ""
+    # Optional in DEV/CODE (just fill in with a dummy string)
 
 Conditions:
   CreateProdResources: !Equals [!Ref "Stage", "PROD"]

--- a/uploader/src/main/resources/lambda-template.yaml
+++ b/uploader/src/main/resources/lambda-template.yaml
@@ -19,7 +19,6 @@
         CONFIG_KEY: !Sub
           - "${Stage}/media-atom-maker.private.conf"
           - { Stage: !Ref Stage }
-        UPLOAD_TRACKING_TABLE_NAME: !Ref 'UploadTrackingTable'
         PLUTO_TABLE_NAME: !Ref 'ManualPlutoTable'
     MemorySize: 512
     Role: !GetAtt LambdaExecutionRole.Arn


### PR DESCRIPTION
Further to #487, removing the references to the old upload table from the step functions lambda.

I've also made the `AlertWebhook` parameter non-optional since it was breaking RiffRaff deploys. It's fine to set it to the blank string in DEV and CODE since it's not used anyway (due to conditional creation in the template).