### PR TITLE
Mark inactive YouTube assets as unlisted

### DIFF
--- a/app/model/commands/DeleteCommand.scala
+++ b/app/model/commands/DeleteCommand.scala
@@ -32,6 +32,6 @@ case class DeleteCommand(id: String, override val stores: DataStores, youTube: Y
   private def makeYouTubeVideosPrivate(assets: List[Asset]): Unit = assets.collect {
     case Asset(_, _, videoId, Youtube, _) =>
       log.info(s"Marking $videoId as private as parent atom $id is being deleted")
-      youTube.setStatusToPrivate(videoId)
+      youTube.setStatus(videoId, "Private")
   }
 }

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -87,12 +87,12 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
       case _ => None
     }
 
-  def setStatusToPrivate(id: String): Unit = {
+  def setStatus(id: String, status: String): Unit = {
     getVideo(id, "snippet,status") match {
       case Some(video) => {
         protectAgainstMistakesInDev(video)
 
-        video.getStatus.setPrivacyStatus("Private")
+        video.getStatus.setPrivacyStatus(status)
 
         try {
           Some(client.videos()
@@ -100,11 +100,11 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
             .setOnBehalfOfContentOwner(contentOwner)
             .execute())
 
-          log.info(s"marked asset=$id as private")
+          log.info(s"marked asset=$id as $status")
         }
         catch {
           case e: Throwable =>
-            log.warn(s"unable to mark asset=$id as private", e)
+            log.warn(s"unable to mark asset=$id as $status", e)
         }
       }
       case _ =>

--- a/expirer/src/main/scala/com/gu/media/expirer/ExpirerLambda.scala
+++ b/expirer/src/main/scala/com/gu/media/expirer/ExpirerLambda.scala
@@ -29,7 +29,7 @@ class ExpirerLambda extends RequestHandler[Unit, Unit]
 
     toExpire.foreach { video =>
       try {
-        setStatusToPrivate(video)
+        setStatus(video, "Private")
       } catch {
         case NonFatal(err) =>
           log.error(s"Unable to expire $video", err)

--- a/expirer/src/test/scala/com/gu/media/ExpirerLambdaTest.scala
+++ b/expirer/src/test/scala/com/gu/media/ExpirerLambdaTest.scala
@@ -51,7 +51,8 @@ class ExpirerLambdaTest extends FunSuite with MustMatchers {
       Json.parse(ret)
     }
 
-    override def setStatusToPrivate(id: String): Unit = {
+    override def setStatus(id: String, status: String): Unit = {
+      status must be("Private")
       madePrivate :+= id
     }
   }


### PR DESCRIPTION
YouTube videos that were not the active asset were made private by the tool the next time the atom was published. This is slightly dangerous since the change to the atom can take a while to propagate through the site and could lead to users being unable to play the video on a front etc.

This PR changes the behaviour to make them unlisted (ie still playable but not appearing in native YouTube search)