### PR TITLE
Stop slack alerts for YouTube backend errors

### DIFF
--- a/integration-tests/int-test-runner.sh
+++ b/integration-tests/int-test-runner.sh
@@ -2,7 +2,7 @@
 ./sbt integrationTests/test
 export STATUS=$?
 
-if [ $STATUS -eq 1 ]
+if [[ $STATUS = 1 &&  ! -f NO_ALERTS ]]
 then
   if [ "$INT_TEST_TARGET" = "PROD" ]
   then
@@ -11,4 +11,7 @@ then
     curl -X POST --data-urlencode 'payload={"text": "Media Atom Maker integration tests have failed on CODE '${BUILD_URL}' "}' ${SLACK_URL}
   fi
 fi
+
+rm -f NO_ALERTS
+
 exit $STATUS

--- a/integration-tests/src/test/scala/IntegrationTestBase.scala
+++ b/integration-tests/src/test/scala/IntegrationTestBase.scala
@@ -1,5 +1,8 @@
 package integration
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+import java.nio.file.StandardOpenOption._
 import java.time.Instant
 import java.util.UUID
 
@@ -77,6 +80,13 @@ class IntegrationTestBase extends FunSuite with Matchers with Eventually with In
     }
 
     super.afterAll()
+  }
+
+  def failQuietly(msg: String): Unit = {
+    val file = Paths.get("NO_ALERTS")
+    Files.write(file, "NO_ALERTS".getBytes(StandardCharsets.UTF_8), CREATE, WRITE)
+
+    fail(msg)
   }
 
   private def youTubeClient(): YouTube = {


### PR DESCRIPTION
YouTube can sometimes throw a wobbly and return 5XX errors from their API. This has made our integration tests fail sometimes and is annoying to have to investigate.

We're not going to add some kind of retry to the main app for this since we've never seen it happen to an actual user - only to automated tests. Even if it did happen to a real request, the user can press the Publish button again manually.

This PR translates the back-end errors into 503 responses and then suppresses slack notifications. I've also stopped the tests retrying 'publish' on failure, since this was pushing us over our API usage limit for no benefit.