### PR TITLE
Add bash shebang

### DIFF
--- a/integration-tests/int-test-runner.sh
+++ b/integration-tests/int-test-runner.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Only use this runner when wanting to alert to Slack
 ./sbt integrationTests/test
 export STATUS=$?


### PR DESCRIPTION
#492 caused the following error when run on TeamCity:

```
./integration-tests/int-test-runner.sh: 5: ./integration-tests/int-test-runner.sh: [[: not found
```

I believe this will be fixed by forcing the use of `bash`