### PR TITLE
Make pipeline introspection lazy

### DIFF
--- a/common/src/main/scala/com/gu/media/aws/UploadAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/UploadAccess.scala
@@ -12,7 +12,7 @@ trait UploadAccess { this: Settings with AwsAccess =>
   val userUploadRole: String = getMandatoryString("aws.upload.role")
 
   val pipelineName: String = s"VideoPipeline$stage"
-  val pipelineArn: String = getPipelineArn()
+  lazy val pipelineArn: String = getPipelineArn()
 
   lazy val uploadSTSClient = createUploadSTSClient()
 


### PR DESCRIPTION
Lambdas were failing to start because they didn't have permission to list state machines. This PR fixes it by making the setting lazy so it's not evaluated when running in Lambda.