### PR TITLE
Activate asset by version

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -7,6 +7,7 @@ import com.gu.media.upload.model.PlutoSyncMetadata
 import com.gu.media.youtube.{YouTube, YouTubeClaims}
 import com.gu.media.Capi
 import com.gu.pandahmac.HMACAuthActions
+import _root_.util.ActivateAssetRequest
 import data.DataStores
 import model.commands.CommandExceptions._
 import model.commands._
@@ -120,13 +121,10 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
   private def atomUrl(id: String) = s"/atom/$id"
 
   def setActiveAsset(atomId: String) = APIHMACAuthAction { implicit req =>
-    implicit val readCommand: Reads[ActiveAssetCommand] =
-      (JsPath \ "youtubeId").read[String].map { videoUri =>
-        ActiveAssetCommand(atomId, videoUri, stores, youTube, req.user)
-      }
-
-    parse(req) { command: ActiveAssetCommand =>
+    parse(req) { request: ActivateAssetRequest =>
+      val command = ActiveAssetCommand(atomId, request, stores, youTube, req.user)
       val atom = command.process()
+
       Ok(Json.toJson(atom))
     }
   }

--- a/app/model/commands/ActiveAssetCommand.scala
+++ b/app/model/commands/ActiveAssetCommand.scala
@@ -1,89 +1,93 @@
 package model.commands
 
-import com.gu.contentatom.thrift.atom.media.Asset
 import com.gu.media.logging.Logging
 import com.gu.media.youtube.YouTube
 import com.gu.pandomainauth.model.{User => PandaUser}
+import com.twitter.util.NonFatal
 import data.DataStores
 import model.MediaAtom
+import model.Platform.Youtube
 import model.commands.CommandExceptions._
 import util._
 import util.atom.MediaAtomImplicits
 
-case class ActiveAssetCommand(atomId: String, youtubeId: String, stores: DataStores,
+case class ActiveAssetCommand(atomId: String, params: ActivateAssetRequest, stores: DataStores,
                               youTube: YouTube, user: PandaUser)
   extends Command
-  with MediaAtomImplicits
-  with Logging {
+    with MediaAtomImplicits
+    with Logging {
 
   type T = MediaAtom
 
-  def getVideoStatus(youtubeId: String): YoutubeResponse = {
-    try {
-      val status = youTube.getProcessingStatus(List(youtubeId)).headOption.map(_.status)
-      new SuccesfulYoutubeResponse(status)
-    }
-    catch {
-      case e: Throwable => new YoutubeException(e)
-    }
-  }
+  def process(): T = {
+    log.info(s"Request to $params in $atomId")
 
-  def markAssetAsActive(): MediaAtom = {
     val atom = getPreviewAtom(atomId)
+    val mediaAtom = MediaAtom.fromThrift(atom)
 
-    val mediaAtom = atom.tdata
-    val atomAssets: Seq[Asset] = mediaAtom.assets
+    getVersion(mediaAtom) match {
+      case Some(version) =>
+        validateYouTubeProcessed(version, mediaAtom)
 
-    atomAssets.find(asset => asset.id == youtubeId) match {
-      case Some(newActiveAsset) =>
+        val duration = getYouTubeId(version, mediaAtom).flatMap(youTube.getDuration)
+        val updatedAtom = mediaAtom.copy(activeVersion = Some(version), duration = duration)
 
-        val ytAssetDuration = youTube.getDuration(newActiveAsset.id)
-
-        val updatedAtom = atom
-          .withData(mediaAtom.copy(
-            activeVersion = Some(newActiveAsset.version),
-            duration = ytAssetDuration
-          ))
-
-        log.info(s"Marking $youtubeId as the active asset in $atomId")
-        UpdateAtomCommand(atomId, MediaAtom.fromThrift(updatedAtom), stores, user).process()
+        log.info(s"$params in $atomId")
+        UpdateAtomCommand(atomId, updatedAtom, stores, user).process()
 
       case None =>
-        log.info(s"Cannot mark $youtubeId as the active asset in $atomId. No asset has that id")
-        AssetNotFound
+        log.info(s"Cannot $params. No asset has that version")
+        AssetVersionConflict
     }
   }
 
+  private def getVersion(atom: MediaAtom): Option[Long] = params match {
+    case ActivateAssetByVersion(version) =>
+      atom.assets.collectFirst {
+        case asset if asset.version == version =>
+          version
+      }
 
-  def process(): T = {
-    log.info(s"Request to mark $youtubeId as the active asset in $atomId")
+    case ActivateYouTubeAssetById(id) =>
+      atom.assets.collectFirst {
+        case asset if asset.platform == Youtube && asset.id == id =>
+          asset.version
+      }
+  }
 
-    getVideoStatus(youtubeId) match {
-      case response: SuccesfulYoutubeResponse =>
-        val videoStatus = response.status
+  private def validateYouTubeProcessed(version: Long, atom: MediaAtom): Unit = {
+    for {
+      id <- getYouTubeId(version, atom)
+      status <- getProcessingStatus(id)
+    } yield {
+      /** Processing status:
+        * failed – Video processing has failed.
+        * processing – Video is currently being processed.
+        * succeeded – Video has been successfully processed.
+        * terminated – Processing information is no longer available.
+        * */
+      status match {
+        case "succeeded" | "terminated" =>
+        // all good
 
-        /** Processing status:
-          * failed – Video processing has failed.
-          * processing – Video is currently being processed.
-          * succeeded – Video has been successfully processed.
-          * terminated – Processing information is no longer available.
-          **/
-        videoStatus match {
-          case Some(status) if status == "succeeded" || status == "terminated" =>
-            markAssetAsActive()
-
-          case Some(other) =>
-            log.info(s"Cannot mark $youtubeId as the active asset in $atomId. Unexpected processing state $other")
-            AssetEncodingInProgress(other)
-
-          case None =>
-            log.info(s"Cannot mark $youtubeId as the active asset in $atomId. No youtube video has that id")
-            NotYoutubeAsset
-        }
-
-      case e: YoutubeException =>
-        log.error(s"Cannot mark $youtubeId as the active asset in $atomId. Youtube error", e.exception)
-        YouTubeConnectionIssue
+        case other =>
+          log.info (s"Cannot mark $id as the active asset in $atomId. Unexpected processing state $other")
+          AssetEncodingInProgress (other)
+      }
     }
+  }
+
+  private def getYouTubeId(version: Long, atom: MediaAtom): Option[String] = {
+    atom.assets
+      .find(_.version == version)
+      .map(_.id)
+  }
+
+  private def getProcessingStatus(id: String): Option[String] = try {
+    youTube.getProcessingStatus(List(id)).headOption.map(_.status)
+  } catch {
+    case NonFatal(e) =>
+      log.error(s"Cannot mark $id as the active asset in $atomId. Youtube error", e)
+      YouTubeConnectionIssue
   }
 }

--- a/app/util/ActivateAssetRequest.scala
+++ b/app/util/ActivateAssetRequest.scala
@@ -1,0 +1,29 @@
+package util
+
+import play.api.libs.json._
+
+sealed abstract class ActivateAssetRequest
+case class ActivateAssetByVersion(version: Long) extends ActivateAssetRequest
+case class ActivateYouTubeAssetById(id: String) extends ActivateAssetRequest
+
+object ActivateAssetRequest {
+  implicit val reads: Reads[ActivateAssetRequest] = Reads(apply)
+
+  def apply(json: JsValue): JsResult[ActivateAssetRequest] = for {
+    version <- (json \ "version").validateOpt[Long]
+    youTubeId <- (json \ "youtubeId").validateOpt[String]
+    request <- parse(version, youTubeId)
+  } yield {
+    request
+  }
+
+  private def parse(version: Option[Long], youTubeId: Option[String]): JsResult[ActivateAssetRequest] = {
+    val versionRequest = version.map(ActivateAssetByVersion)
+    val youTubeIdRequest = youTubeId.map(ActivateYouTubeAssetById)
+
+    versionRequest orElse youTubeIdRequest match {
+      case Some(request) => JsSuccess(request)
+      case None => JsError("Missing version or youTubeId")
+    }
+  }
+}

--- a/test/util/ActivateAssetRequestTest.scala
+++ b/test/util/ActivateAssetRequestTest.scala
@@ -1,0 +1,22 @@
+package util
+
+import org.scalatest.{FunSuite, MustMatchers}
+import play.api.libs.json.Json
+
+class ActivateAssetRequestTest extends FunSuite with MustMatchers {
+  test("activate by version") {
+    val input = """ { "version": 5 }"""
+    val request = ActivateAssetRequest(Json.parse(input)).get
+
+    request mustBe an [ActivateAssetByVersion]
+    request.asInstanceOf[ActivateAssetByVersion].version must be(5)
+  }
+
+  test("activate by id") {
+    val input = """ { "youtubeId": "https://www.youtube.com/watch?v=QRplDNMsS4U" }"""
+    val request = ActivateAssetRequest(Json.parse(input)).get
+
+    request mustBe an [ActivateYouTubeAssetById]
+    request.asInstanceOf[ActivateYouTubeAssetById].id must be("https://www.youtube.com/watch?v=QRplDNMsS4U")
+  }
+}


### PR DESCRIPTION
Add support for activating an asset by version:

`PUT /api2/atom/:id/asset-active` 

```json
 { "version": 5 }
```

This is required in order to activate self hosted assets, which in reality are multiple assets with the same version number. We maintain compatibility of activating a YT asset by ID since CDS still uses it.

Coming up on next week's exciting episode of "uploading video to the internet":

- UI support for self-hosted assets