### PR TITLE
Support self-hosted assets in the UI

### DIFF
--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -132,10 +132,13 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
 
   private def getRunning(job: ExecutionListItem): Option[ClientAsset] = {
     val events = stepFunctions.getEventsInReverseOrder(job)
-    val upload = stepFunctions.getUpload(events)
-    val error = stepFunctions.getError(events)
 
-    upload.map(ClientAsset(_, error))
+    val upload = stepFunctions.getTaskEntered(events)
+    val error = stepFunctions.getExecutionFailed(events)
+
+    upload.map { case(state, upload) =>
+      ClientAsset(state, upload, error)
+    }
   }
 }
 

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -36,7 +36,7 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
     val jobs = stepFunctions.getJobs(atomId)
     val running = jobs.flatMap(getRunning)
 
-    val assets = added ++ running
+    val assets = running ++ added
     Ok(Json.toJson(assets))
   }
 

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -2,13 +2,15 @@ package controllers
 
 import java.util.UUID
 
-import _root_.model.MediaAtom
+import _root_.model.{ClientAsset, MediaAtom}
 import _root_.model.commands.CommandExceptions._
+import com.amazonaws.services.stepfunctions.model.ExecutionListItem
 import com.gu.media.MediaAtomMakerPermissionsProvider
 import com.gu.media.logging.Logging
 import com.gu.media.model.{SelfHostedAsset, VideoSource}
 import com.gu.media.upload._
 import com.gu.media.upload.model._
+import com.gu.media.youtube.YouTubeVideos
 import com.gu.pandahmac.HMACAuthActions
 import com.gu.pandomainauth.model.User
 import controllers.UploadController.CreateRequest
@@ -18,7 +20,8 @@ import play.api.libs.json.{Format, Json}
 import util.{AWSConfig, CredentialsGenerator, StepFunctions}
 
 class UploadController(override val authActions: HMACAuthActions, awsConfig: AWSConfig, stepFunctions: StepFunctions,
-                       override val stores: DataStores, override val permissions: MediaAtomMakerPermissionsProvider)
+                       override val stores: DataStores, override val permissions: MediaAtomMakerPermissionsProvider,
+                       youTube: YouTubeVideos)
 
   extends AtomController with Logging with JsonRequestParsing with UnpackedDataStores {
 
@@ -27,10 +30,14 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
   private val credsGenerator = new CredentialsGenerator(awsConfig)
 
   def list(atomId: String) = APIAuthAction {
-    // Anyone can see the running uploads.
-    // Only users with permission can create/complete/delete them.
-    val running = stepFunctions.getStatus(atomId)
-    Ok(Json.toJson(running))
+    val atom = MediaAtom.fromThrift(getPreviewAtom(atomId))
+    val added = ClientAsset.byVersion(atom.assets, youTube)
+
+    val jobs = stepFunctions.getJobs(atomId)
+    val running = jobs.flatMap(getRunning)
+
+    val assets = added ++ running
+    Ok(Json.toJson(assets))
   }
 
   def create = LookupPermissions { implicit raw =>
@@ -122,6 +129,14 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
     upload <- stepFunctions.getById(id)
     part <- upload.parts.find(_.key == key)
   } yield part
+
+  private def getRunning(job: ExecutionListItem): Option[ClientAsset] = {
+    val events = stepFunctions.getEventsInReverseOrder(job)
+    val upload = stepFunctions.getUpload(events)
+    val error = stepFunctions.getError(events)
+
+    upload.map(ClientAsset(_, error))
+  }
 }
 
 object UploadController {

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -31,7 +31,7 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
 
   def list(atomId: String) = APIAuthAction {
     val atom = MediaAtom.fromThrift(getPreviewAtom(atomId))
-    val added = ClientAsset.byVersion(atom.assets, youTube)
+    val added = ClientAsset.byVersion(atom.assets, youTube.getProcessingStatus)
 
     val jobs = stepFunctions.getJobs(atomId)
     val running = jobs.flatMap(getRunning)

--- a/app/controllers/Youtube.scala
+++ b/app/controllers/Youtube.scala
@@ -22,11 +22,4 @@ class Youtube (val authActions: HMACAuthActions, youTube: YouTube, cache: CacheA
       youTube.channels}
     Ok(Json.toJson(channels))
   }
-
-  def processingStatus(csvIds: String) = AuthAction {
-    val videoIds = csvIds.split(",").map(_.trim).toList
-    val response = youTube.getProcessingStatus(videoIds)
-
-    Ok(Json.toJson(response))
-  }
 }

--- a/app/di.scala
+++ b/app/di.scala
@@ -55,7 +55,7 @@ class MediaAtomMaker(context: Context)
   private val api2 = new Api2(stores, configuration, hmacAuthActions, youTube, youTubeClaims, aws, permissions, capi)
 
   private val stepFunctions = new StepFunctions(aws)
-  private val uploads = new UploadController(hmacAuthActions, aws, stepFunctions, stores, permissions)
+  private val uploads = new UploadController(hmacAuthActions, aws, stepFunctions, stores, permissions, youTube)
 
   private val support = new Support(hmacAuthActions, capi)
   private val youTubeController = new controllers.Youtube(hmacAuthActions, youTube, defaultCacheApi)

--- a/app/model/ClientAsset.scala
+++ b/app/model/ClientAsset.scala
@@ -1,0 +1,102 @@
+package model
+
+import com.gu.media.model.{SelfHostedAsset, VideoAsset, VideoSource, YouTubeAsset}
+import com.gu.media.upload.model.Upload
+import com.gu.media.youtube.{YouTubeProcessingStatus, YouTubeVideos}
+import org.cvogt.play.json.Jsonx
+import play.api.libs.json.Format
+
+case class ClientAsset(id: String, asset: Option[VideoAsset], processing: Option[ClientAssetProcessing])
+case class ClientAssetProcessing(status: String, failed: Boolean, current: Option[Long], total: Option[Long])
+
+object ClientAsset {
+  implicit val format: Format[ClientAsset] = Jsonx.formatCaseClass[ClientAsset]
+
+  def apply(assets: List[Asset], youTube: YouTubeVideos): Option[ClientAsset] = {
+    assets.headOption.map { asset =>
+      asset.platform match {
+        case Platform.Url => selfHostedAsset(asset.version, assets)
+        case Platform.Youtube => youTubeAsset(asset.version, asset.id, youTube)
+        case other => throw new IllegalArgumentException(s"Unsupported platform ${other.name}")
+      }
+    }
+  }
+
+  def apply(upload: Upload, error: Option[String]): ClientAsset = {
+    if(upload.metadata.selfHost) {
+      selfHostedUpload(upload.id, error)
+    } else {
+      youTubeUpload(upload)
+    }
+  }
+
+  private def selfHostedAsset(version: Long, assets: List[Asset]): ClientAsset = {
+    val sources = assets.collect {
+      case Asset(_, _, id, _, Some(mimeType)) => VideoSource(id, mimeType)
+    }
+
+    ClientAsset(version.toString, asset = Some(SelfHostedAsset(sources)), processing = None)
+  }
+
+  private def selfHostedUpload(id: String, error: Option[String]): ClientAsset = {
+    ClientAsset(id, asset = None, processing = Some(ClientAssetProcessing(
+      status = error.getOrElse("Uploading"),
+      failed = error.isDefined,
+      current = None,
+      total = None
+    )))
+  }
+
+  private def youTubeAsset(version: Long, id: String, youTube: YouTubeVideos): ClientAsset = {
+    val processing = youTube
+      .getProcessingStatus(id)
+      .filterNot(_.status == "succeeded")
+      .map(ClientAssetProcessing(_))
+
+    val asset = processing match {
+      case Some(_) => None
+      case None => Some(YouTubeAsset(id))
+    }
+
+    ClientAsset(id = version.toString, asset, processing)
+  }
+
+  private def youTubeUpload(upload: Upload): ClientAsset = {
+    val fullyUploaded = upload.progress.fullyUploaded
+    val current = upload.progress.chunksInYouTube
+    val total = upload.parts.length
+
+    val processing = ClientAssetProcessing(
+      status = if(fullyUploaded) { "Uploading" } else { "Uploading to YouTube" },
+      failed = false,
+      current = if(fullyUploaded) { None } else { Some(current) },
+      total = if(fullyUploaded) { None } else { Some(total) }
+    )
+
+    ClientAsset(id = upload.id, asset = None, Some(processing))
+  }
+}
+
+object ClientAssetProcessing {
+  implicit val format: Format[ClientAssetProcessing] = Jsonx.formatCaseClass[ClientAssetProcessing]
+
+  def apply(status: YouTubeProcessingStatus): ClientAssetProcessing = {
+    ClientAssetProcessing(
+      status = getStatusText(status),
+      failed = status.failure.nonEmpty,
+      current = if(status.processed == 0) { None } else { Some(status.processed) },
+      total = if(status.total == 0) { None } else { Some(status.total) }
+    )
+  }
+
+  private def getStatusText(status: YouTubeProcessingStatus): String = status match {
+    case YouTubeProcessingStatus(_, "processing", _, _, 0, _) =>
+      "YouTube Processing"
+
+    case YouTubeProcessingStatus(_, "processing", _, _, timeLeftMs, _) =>
+      s"YouTube Processing (${timeLeftMs / 1000}s left)"
+
+    case _ =>
+      status.failure.getOrElse(status.status)
+  }
+}

--- a/app/model/ClientAsset.scala
+++ b/app/model/ClientAsset.scala
@@ -30,9 +30,9 @@ object ClientAsset {
     }
   }
 
-  def apply(upload: Upload, error: Option[String]): ClientAsset = {
+  def apply(state: String, upload: Upload, error: Option[String]): ClientAsset = {
     if(upload.metadata.selfHost) {
-      selfHostedUpload(upload.id, error)
+      selfHostedUpload(upload.id, state, error)
     } else {
       youTubeUpload(upload)
     }
@@ -46,9 +46,9 @@ object ClientAsset {
     ClientAsset(version.toString, asset = Some(SelfHostedAsset(sources)), processing = None)
   }
 
-  private def selfHostedUpload(id: String, error: Option[String]): ClientAsset = {
+  private def selfHostedUpload(id: String, state: String, error: Option[String]): ClientAsset = {
     ClientAsset(id, asset = None, processing = Some(ClientAssetProcessing(
-      status = error.getOrElse("Uploading"),
+      status = error.getOrElse(state),
       failed = error.isDefined,
       current = None,
       total = None

--- a/app/model/ClientAsset.scala
+++ b/app/model/ClientAsset.scala
@@ -12,6 +12,14 @@ case class ClientAssetProcessing(status: String, failed: Boolean, current: Optio
 object ClientAsset {
   implicit val format: Format[ClientAsset] = Jsonx.formatCaseClass[ClientAsset]
 
+  def byVersion(assets: List[Asset], youTube: YouTubeVideos): List[ClientAsset] = {
+    val versions = assets.map(_.version).distinct.sorted.reverse
+
+    versions.flatMap { version =>
+      ClientAsset(assets.filter(_.version == version), youTube)
+    }
+  }
+
   def apply(assets: List[Asset], youTube: YouTubeVideos): Option[ClientAsset] = {
     assets.headOption.map { asset =>
       asset.platform match {

--- a/app/model/commands/ActiveAssetCommand.scala
+++ b/app/model/commands/ActiveAssetCommand.scala
@@ -84,7 +84,7 @@ case class ActiveAssetCommand(atomId: String, params: ActivateAssetRequest, stor
   }
 
   private def getProcessingStatus(id: String): Option[String] = try {
-    youTube.getProcessingStatus(List(id)).headOption.map(_.status)
+    youTube.getProcessingStatus(id).map(_.status)
   } catch {
     case NonFatal(e) =>
       log.error(s"Cannot mark $id as the active asset in $atomId. Youtube error", e)

--- a/app/util/StepFunctions.scala
+++ b/app/util/StepFunctions.scala
@@ -32,13 +32,16 @@ class StepFunctions(awsConfig: AWSConfig) {
     runningJobs ++ failedJobs
   }
 
-  def getUpload(events: Iterable[HistoryEvent]): Option[Upload] = {
+  def getTaskEntered(events: Iterable[HistoryEvent]): Option[(String, Upload)] = {
     events.find(_.getType == "TaskStateEntered").map { event =>
-      Json.parse(event.getStateEnteredEventDetails.getInput).as[Upload]
+      val details = event.getStateEnteredEventDetails
+      val upload = Json.parse(details.getInput).as[Upload]
+
+      (details.getName, upload)
     }
   }
 
-  def getError(events: Iterable[HistoryEvent]): Option[String] = {
+  def getExecutionFailed(events: Iterable[HistoryEvent]): Option[String] = {
     events.find(_.getType == "ExecutionFailed").flatMap { event =>
       val cause = event.getExecutionFailedEventDetails.getCause
 

--- a/app/util/StepFunctions.scala
+++ b/app/util/StepFunctions.scala
@@ -25,14 +25,30 @@ class StepFunctions(awsConfig: AWSConfig) {
     }
   }
 
-  def getStatus(atomId: String): Iterable[UploadStatus] = {
+  def getJobs(atomId: String): Iterable[ExecutionListItem] = {
     val runningJobs = getExecutions(atomId, ExecutionStatus.RUNNING)
     val failedJobs = getExecutions(atomId, ExecutionStatus.FAILED).filter(lessThan10MinutesOld)
 
-    val running = runningJobs.map(getRunningStatus)
-    val failed = failedJobs.map(getFailedStatus)
+    runningJobs ++ failedJobs
+  }
 
-    running ++ failed
+  def getUpload(events: Iterable[HistoryEvent]): Option[Upload] = {
+    events.find(_.getType == "TaskStateEntered").map { event =>
+      Json.parse(event.getStateEnteredEventDetails.getInput).as[Upload]
+    }
+  }
+
+  def getError(events: Iterable[HistoryEvent]): Option[String] = {
+    events.find(_.getType == "ExecutionFailed").flatMap { event =>
+      val cause = event.getExecutionFailedEventDetails.getCause
+
+      try {
+        Some((Json.parse(cause) \ "errorMessage").as[String])
+      } catch {
+        case _: JsonParseException | _: JsResultException =>
+          None
+      }
+    }
   }
 
   def start(upload: Upload): Unit = {
@@ -42,6 +58,15 @@ class StepFunctions(awsConfig: AWSConfig) {
       .withInput(Json.stringify(Json.toJson(upload)))
 
     awsConfig.stepFunctionsClient.startExecution(stepFunctionsRequest)
+  }
+
+  def getEventsInReverseOrder(execution: ExecutionListItem): Iterable[HistoryEvent] = {
+    val request = new GetExecutionHistoryRequest()
+      .withExecutionArn(execution.getExecutionArn)
+      .withReverseOrder(true)
+      .withMaxResults(20)
+
+    awsConfig.stepFunctionsClient.getExecutionHistory(request).getEvents.asScala
   }
 
   private def getExecutions(atomId: String, filter: ExecutionStatus): Iterable[ExecutionListItem] = {
@@ -54,77 +79,10 @@ class StepFunctions(awsConfig: AWSConfig) {
     results.filter(_.getName.startsWith(atomId))
   }
 
-  private def getEvents(execution: ExecutionListItem): Iterable[HistoryEvent] = {
-    val request = new GetExecutionHistoryRequest()
-      .withExecutionArn(execution.getExecutionArn)
-      .withReverseOrder(true)
-      .withMaxResults(20)
-
-    awsConfig.stepFunctionsClient.getExecutionHistory(request).getEvents.asScala
-  }
-
-  private def getRunningStatus(execution: ExecutionListItem): UploadStatus = {
-    val id = execution.getName
-
-    getLastTask(execution) match {
-      case Some((state, upload)) =>
-        buildProgress(id, state, upload)
-
-      case None =>
-        UploadStatus.indeterminate(id, "Uploading")
-    }
-  }
-
-  private def getFailedStatus(execution: ExecutionListItem): UploadStatus = {
-    val id = execution.getName
-    val events = getEvents(execution)
-
-    val cause = events.find(_.getType == "ExecutionFailed") match {
-      case Some(event) =>
-        val cause = event.getExecutionFailedEventDetails.getCause
-
-        try {
-          (Json.parse(cause) \ "errorMessage").as[String]
-        } catch {
-          case _: JsonParseException | _: JsResultException =>
-            id
-        }
-
-      case None => "Failed (unknown error)"
-    }
-
-    UploadStatus.indeterminate(id, cause).copy(failed = true)
-  }
-
-  private def getLastTask(execution: ExecutionListItem): Option[(String, Upload)] = {
-    val events = getEvents(execution)
-    val taskEvent = events.find(_.getType == "TaskStateEntered")
-
-    taskEvent.map { event =>
-      val state = event.getStateEnteredEventDetails.getName
-      val upload = Json.parse(event.getStateEnteredEventDetails.getInput).as[Upload]
-
-      (state, upload)
-    }
-  }
-
   private def lessThan10MinutesOld(e: ExecutionListItem): Boolean = {
     val now = Instant.now().toEpochMilli
     val end = e.getStopDate.toInstant.toEpochMilli
 
     (now - end) < (1000 * 60 * 10)
-  }
-
-  private def buildProgress(id: String, state: String, upload: Upload): UploadStatus = {
-    val default = UploadStatus.indeterminate(id, state).copy(asset = upload.metadata.asset)
-
-    val current = upload.progress.chunksInYouTube
-    val total = upload.parts.length
-
-    if(upload.metadata.selfHost || current >= total) {
-      default
-    } else {
-      default.copy(status = "Uploading to YouTube", current = Some(current), total = Some(total))
-    }
   }
 }

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -20,14 +20,13 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
       .getItems.asScala.toList.headOption
   }
 
-  def getProcessingStatus(videoIds: List[String]): List[YouTubeProcessingStatus] = {
+  def getProcessingStatus(videoId: String): Option[YouTubeProcessingStatus] = {
     val request = client.videos()
       .list("status,processingDetails")
-      .setId(videoIds.mkString(","))
+      .setId(videoId)
       .setOnBehalfOfContentOwner(contentOwner)
 
-    val items = request.execute().getItems.asScala.toList
-    items.map(YouTubeProcessingStatus(_))
+    request.execute().getItems.asScala.headOption.map(YouTubeProcessingStatus(_))
   }
 
   def getDuration(youtubeId: String): Option[Long] = {

--- a/conf/routes
+++ b/conf/routes
@@ -49,7 +49,6 @@ GET     /api2/audits/:id                controllers.Api2.getAuditTrailForAtomId(
 
 GET     /api/youtube/categories         controllers.Youtube.listCategories()
 GET     /api/youtube/channels           controllers.Youtube.listChannels()
-GET     /api/youtube/processingStatus   controllers.Youtube.processingStatus(videoIds)
 
 GET     /api/transcoder/jobStatus       controllers.Transcoder.jobStatus
 

--- a/public/video-ui/src/actions/VideoActions/revertAsset.js
+++ b/public/video-ui/src/actions/VideoActions/revertAsset.js
@@ -27,10 +27,10 @@ function errorRevertAsset(error) {
   };
 }
 
-export function revertAsset(atomId, videoId, version) {
+export function revertAsset(atomId, version) {
   return dispatch => {
     dispatch(requestRevertAsset(version));
-    return VideosApi.revertAsset(atomId, videoId)
+    return VideosApi.revertAsset(atomId, version)
       .then(res => dispatch(receiveRevertAsset(res)))
       .catch(error => dispatch(errorRevertAsset(error)));
   };

--- a/public/video-ui/src/components/VideoPreview/VideoPreview.js
+++ b/public/video-ui/src/components/VideoPreview/VideoPreview.js
@@ -1,33 +1,25 @@
 import React from 'react';
+import { VideoEmbed } from '../utils/VideoEmbed';
 import { YouTubeEmbed } from '../utils/YouTubeEmbed';
 
 export default class VideoPreview extends React.Component {
-  getActiveAsset = () => {
-    if (!this.props.video.assets || !this.props.video.activeVersion) {
-      return false;
-    }
-
-    for (let i = 0; i < this.props.video.assets.length; i++) {
-      if (
-        this.props.video.activeVersion === this.props.video.assets[i].version
-      ) {
-        return this.props.video.assets[i];
-      }
-    }
-  };
-
   renderPreview() {
-    const activeAsset = this.getActiveAsset();
+    const { assets, activeVersion } = this.props.video;
+    const relevant = assets.filter(asset => asset.version === activeVersion);
 
-    if (!activeAsset) {
+    if (!assets || !activeVersion || relevant.length === 0) {
       return <div className="baseline-margin">No Active Video</div>;
     }
 
-    if (activeAsset.platform !== 'Youtube') {
-      <div className="baseline-margin">Unable to Preview</div>;
+    if (relevant.length === 1 && relevant[0].id) {
+      return <YouTubeEmbed id={relevant[0].id} className="baseline-margin" />;
     }
 
-    return <YouTubeEmbed id={activeAsset.id} className="baseline-margin" />;
+    const sources = relevant.map(asset => {
+      return { src: asset.id, mimeType: asset.mimeType };
+    });
+
+    return <VideoEmbed sources={sources} />;
   }
 
   render() {

--- a/public/video-ui/src/components/VideoPreview/VideoPreview.js
+++ b/public/video-ui/src/components/VideoPreview/VideoPreview.js
@@ -4,18 +4,19 @@ import { YouTubeEmbed } from '../utils/YouTubeEmbed';
 
 export default class VideoPreview extends React.Component {
   renderPreview() {
-    const { assets, activeVersion } = this.props.video;
-    const relevant = assets.filter(asset => asset.version === activeVersion);
+    const activeVersion = this.props.video.activeVersion;
+    const assets = this.props.video.assets || [];
+    const active = assets.filter(asset => asset.version === activeVersion);
 
-    if (!assets || !activeVersion || relevant.length === 0) {
+    if (active.length === 0) {
       return <div className="baseline-margin">No Active Video</div>;
     }
 
-    if (relevant.length === 1 && relevant[0].id) {
-      return <YouTubeEmbed id={relevant[0].id} className="baseline-margin" />;
+    if (active.length === 1 && active[0].id) {
+      return <YouTubeEmbed id={active[0].id} className="baseline-margin" />;
     }
 
-    const sources = relevant.map(asset => {
+    const sources = active.map(asset => {
       return { src: asset.id, mimeType: asset.mimeType };
     });
 

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.js
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import Icon from '../Icon';
+import { YouTubeEmbed } from '../utils/YouTubeEmbed';
+
+function Overlay({ active }) {
+  if (active === undefined) {
+    return false;
+  }
+
+  const statusClass = active
+    ? 'publish__label label__live label__frontpage__overlay'
+    : 'publish__label label__frontpage__novideo label__frontpage__overlay';
+
+  const status = active ? 'Live' : 'Not Live';
+
+  return (
+    <div className="grid__status__overlay">
+      <span className={statusClass}>{status}</span>
+    </div>
+  );
+}
+
+function AssetDescription({ title, href, activate }) {
+  const button = activate
+    ? <button className="button__secondary button__active" onClick={activate}>
+        Activate
+      </button>
+    : false;
+
+  const link = href
+    ? <a href={href}><Icon icon="open_in_new" className="icon__assets" /></a>
+    : false;
+
+  return (
+    <div className="grid__item__title">
+      {title}
+      {link}
+      {button}
+    </div>
+  );
+}
+
+export function Asset({ active, content, caption }) {
+  return (
+    <div className="grid__item">
+      <div className="upload__asset__video">
+        {content}
+      </div>
+      <Overlay active={active} />
+      <div className="grid__item__footer">
+        {caption}
+      </div>
+    </div>
+  );
+}
+
+export function YouTubeAsset({ id, activate }) {
+  const content = <YouTubeEmbed id={id} />;
+
+  const caption = (
+    <AssetDescription
+      title={`ID: ${id}`}
+      href={`https://www.youtube.com/watch?v=${id}`}
+      activate={activate}
+    />
+  );
+
+  return <Asset active={!activate} content={content} caption={caption} />;
+}
+
+export function SelfHostedAsset({ version, sources, activate }) {
+  const content = (
+    <video controls>
+      {sources.map(source => {
+        return (
+          <source key={source.src} src={source.src} type={source.mimeType} />
+        );
+      })}
+    </video>
+  );
+  const caption = (
+    <AssetDescription title={`Version ${version}`} activate={activate} />
+  );
+
+  return <Asset active={!activate} content={content} caption={caption} />;
+}

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.js
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Icon from '../Icon';
 import { YouTubeEmbed } from '../utils/YouTubeEmbed';
+import { VideoEmbed } from '../utils/VideoEmbed';
 
 const UPLOAD_FAILED_MSG = (
   <p>
@@ -34,7 +35,7 @@ function Overlay({ active }) {
   );
 }
 
-function AssetDescription({ title, href, activate }) {
+export function Asset({ content, title, href, active, activate }) {
   const button = activate
     ? <button className="button__secondary button__active" onClick={activate}>
         Activate
@@ -46,65 +47,44 @@ function AssetDescription({ title, href, activate }) {
     : false;
 
   return (
-    <div className="grid__item__title">
-      {title}
-      {link}
-      {button}
-    </div>
-  );
-}
-
-export function Asset({ active, content, caption }) {
-  return (
     <div className="grid__item">
       <div className="upload__asset__video">
         {content}
       </div>
       <Overlay active={active} />
       <div className="grid__item__footer">
-        {caption}
+        <div className="grid__item__title">
+          {title}
+          {link}
+          {button}
+        </div>
       </div>
     </div>
   );
 }
 
-export function YouTubeAsset({ id, activate }) {
-  const content = <YouTubeEmbed id={id} />;
-
-  const caption = (
-    <AssetDescription
-      title={`ID: ${id}`}
-      href={`https://www.youtube.com/watch?v=${id}`}
-      activate={activate}
-    />
-  );
-
-  return <Asset active={!activate} content={content} caption={caption} />;
-}
-
-export function SelfHostedAsset({ version, sources, activate }) {
-  const content = (
-    <video controls>
-      {sources.map(source => {
-        return (
-          <source key={source.src} src={source.src} type={source.mimeType} />
-        );
-      })}
-    </video>
-  );
-  const caption = (
-    <AssetDescription title={`Version ${version}`} activate={activate} />
-  );
-
-  return <Asset active={!activate} content={content} caption={caption} />;
-}
-
-export function ProcessingAsset({ status, failed, current, total }) {
-  const content = failed
-    ? UPLOAD_FAILED_MSG
-    : <ProgressBar current={current} total={total} />;
-
-  const caption = <AssetDescription title={status} />;
-
-  return <Asset content={content} caption={caption} />;
+export function assetProps(id, asset, processing, active, selectAsset) {
+  if (processing) {
+    return {
+      title: processing.status,
+      content: processing.failed
+        ? UPLOAD_FAILED_MSG
+        : <ProgressBar {...processing} />
+    };
+  } else if (asset.id) {
+    return {
+      title: `ID: ${asset.id}`,
+      active,
+      href: `https://www.youtube.com/watch?v=${asset.id}`,
+      content: <YouTubeEmbed id={asset.id} />,
+      activate: active ? false : () => selectAsset(Number(id))
+    };
+  } else {
+    return {
+      title: `Version ${id}`,
+      active,
+      content: <VideoEmbed sources={asset.sources} />,
+      activate: active ? false : () => selectAsset(Number(id))
+    };
+  }
 }

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.js
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.js
@@ -2,6 +2,20 @@ import React from 'react';
 import Icon from '../Icon';
 import { YouTubeEmbed } from '../utils/YouTubeEmbed';
 
+const UPLOAD_FAILED_MSG = (
+  <p>
+    <strong>Upload Failed</strong><br />
+    You may retry your upload.<br />
+    This message will disappear after 10 minutes.
+  </p>
+);
+
+function ProgressBar({ current, total }) {
+  return total !== undefined && current !== undefined
+    ? <progress className="progress" value={current} max={total} />
+    : <span className="loader" />;
+}
+
 function Overlay({ active }) {
   if (active === undefined) {
     return false;
@@ -83,4 +97,14 @@ export function SelfHostedAsset({ version, sources, activate }) {
   );
 
   return <Asset active={!activate} content={content} caption={caption} />;
+}
+
+export function ProcessingAsset({ status, failed, current, total }) {
+  const content = failed
+    ? UPLOAD_FAILED_MSG
+    : <ProgressBar current={current} total={total} />;
+
+  const caption = <AssetDescription title={status} />;
+
+  return <Asset content={content} caption={caption} />;
 }

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.js
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.js
@@ -35,9 +35,9 @@ function Overlay({ active }) {
   );
 }
 
-export function Asset({ content, title, href, active, activate }) {
-  const button = activate
-    ? <button className="button__secondary button__active" onClick={activate}>
+export function Asset({ content, title, href, active, activateFn }) {
+  const button = activateFn
+    ? <button className="button__secondary button__active" onClick={activateFn}>
         Activate
       </button>
     : false;
@@ -63,7 +63,7 @@ export function Asset({ content, title, href, active, activate }) {
   );
 }
 
-export function assetProps(id, asset, processing, active, selectAsset) {
+export function buildAssetProps(id, asset, processing, active, selectAsset) {
   if (processing) {
     return {
       title: processing.status,
@@ -77,14 +77,14 @@ export function assetProps(id, asset, processing, active, selectAsset) {
       active,
       href: `https://www.youtube.com/watch?v=${asset.id}`,
       content: <YouTubeEmbed id={asset.id} />,
-      activate: active ? false : () => selectAsset(Number(id))
+      activateFn: active ? null : () => selectAsset(Number(id))
     };
   } else {
     return {
       title: `Version ${id}`,
       active,
       content: <VideoEmbed sources={asset.sources} />,
-      activate: active ? false : () => selectAsset(Number(id))
+      activateFn: active ? null : () => selectAsset(Number(id))
     };
   }
 }

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -1,5 +1,10 @@
 import React from 'react';
-import { Asset, YouTubeAsset, SelfHostedAsset } from './VideoAsset';
+import {
+  Asset,
+  YouTubeAsset,
+  SelfHostedAsset,
+  ProcessingAsset
+} from './VideoAsset';
 
 export default class VideoTrail extends React.Component {
   polling = null;
@@ -54,7 +59,9 @@ export default class VideoTrail extends React.Component {
       const active = upload.id == this.props.activeVersion;
       const activate = active ? false : function() {};
 
-      if (upload.asset.id) {
+      if (upload.processing) {
+        return <ProcessingAsset key={upload.id} {...upload.processing} />;
+      } else if (upload.asset.id) {
         return (
           <YouTubeAsset
             key={upload.id}

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -1,127 +1,13 @@
 import React from 'react';
-import { YouTubeEmbed } from '../utils/YouTubeEmbed';
-import Icon from '../Icon';
-import { getProcessingStatus } from '../../services/YoutubeApi';
-import _ from 'lodash';
-
-function embed(assetId, platform) {
-  if (platform === 'Youtube') {
-    return <YouTubeEmbed id={assetId} />;
-  } else {
-    return false;
-  }
-}
-
-function youTubeLink(id) {
-  return (
-    <div>
-      <span>Video ID: {id}</span>
-      <a href={`https://www.youtube.com/watch?v=${id}`}>
-        <Icon icon="open_in_new" className="icon__assets" />
-      </a>
-    </div>
-  );
-}
-
-function ErrorAsset({ id, message }) {
-  const footer = id
-    ? <div className="grid__item__footer">
-        <span className="grid__item__title">{youTubeLink(id)}</span>
-      </div>
-    : false;
-
-  return (
-    <div className="grid__item">
-      <div className="upload__asset__video upload__asset__empty">
-        <span>{message}</span>
-      </div>
-      {footer}
-    </div>
-  );
-}
-
-function VideoAsset({ id, platform, version, active, selectAsset }) {
-  const statusClasses = active
-    ? 'publish__label label__live label__frontpage__overlay'
-    : 'publish__label label__frontpage__novideo label__frontpage__overlay';
-  const status = active ? 'Live' : 'Not Live';
-
-  const selector = !active
-    ? <button
-        className="button__secondary button__active"
-        onClick={() => selectAsset(id, version)}
-      >
-        Activate
-      </button>
-    : false;
-
-  return (
-    <div className="grid__item">
-      <div className="upload__asset__video">{embed(id, platform)}</div>
-      <div className="grid__status__overlay">
-        <span className={statusClasses}>{status}</span>
-      </div>
-      <div className="grid__item__footer">
-        <span className="grid__item__title">{youTubeLink(id)}</span>
-        {selector}
-      </div>
-    </div>
-  );
-}
-
-function UploadAsset({ message, total, progress }) {
-  const progressBar = total !== undefined && progress !== undefined
-    ? <progress className="progress" value={progress} max={total} />
-    : <span className="loader" />;
-
-  return (
-    <div className="grid__item">
-      <div className="upload__asset__video upload__asset__running">
-        {progressBar}
-      </div>
-      <div className="grid__item__footer">
-        <span className="grid__item__title">{message}</span>
-      </div>
-    </div>
-  );
-}
-
-function FailedUpload({ message }) {
-  return (
-    <div className="grid__item">
-      <div className="upload__asset__video">
-        <p>
-          <strong>Upload Failed</strong><br />
-          You may retry your upload.<br />
-          This message will disappear after 10 minutes.
-        </p>
-      </div>
-      <div className="grid__item__footer">
-        <span className="grid__item__title">
-          <small>
-            <code>{message}</code>
-          </small>
-        </span>
-      </div>
-    </div>
-  );
-}
+import { Asset, YouTubeAsset, SelfHostedAsset } from './VideoAsset';
 
 export default class VideoTrail extends React.Component {
   polling = null;
-  state = { status: [] };
 
   constructor(props) {
     super(props);
 
     this.polling = setInterval(() => this.pollIfRequired(), 5000);
-    this.enrichWithStatus(props.assets);
-  }
-
-  componentDidUpdate(prevProps) {
-    if (!_.isEqual(prevProps.assets, this.props.assets)) {
-      this.enrichWithStatus(this.props.assets);
-    }
   }
 
   componentWillUnmount() {
@@ -129,89 +15,31 @@ export default class VideoTrail extends React.Component {
   }
 
   pollIfRequired = () => {
-    const existingUploads = this.props.uploads.length > 0;
-    const missingUploads = this.props.s3Upload.id && !existingUploads;
-
-    if (existingUploads || missingUploads) {
-      this.props.getUploads();
-      this.props.getVideo();
-    }
-
-    if (_.some(this.state.status, entry => entry.status === 'processing')) {
-      this.enrichWithStatus(this.props.assets);
-    }
-  };
-
-  enrichWithStatus = assets => {
-    if (assets.length === 0) {
-      return;
-    }
-
-    const ids = assets.map(asset => asset.id);
-    getProcessingStatus(ids).then(resp => {
-      this.setState({ status: resp });
+    this.props.uploads.forEach(upload => {
+      if (upload.processing) {
+        this.props.getUploads();
+        return;
+      }
     });
   };
 
-  renderS3Upload = () => {
-    const total = this.props.s3Upload.total;
-    const progress = this.props.s3Upload.progress;
-
-    return (
-      <UploadAsset
-        key="s3Upload"
-        message="Uploading To S3"
-        total={total}
-        progress={progress}
-      />
-    );
-  };
-
-  renderAsset = asset => {
-    const processing = _.find(
-      this.state.status,
-      status => status.id === asset.id
-    );
-
-    if (processing && processing.status === 'processing') {
-      const message = processing.timeLeftMs === 0
-        ? 'YouTube Processing'
-        : `YouTube Processing (${processing.timeLeftMs / 1000}s left)`;
-
-      return <UploadAsset key={asset.id} id={asset.id} message={message} />;
-    } else if (processing && processing.status === 'failed') {
-      return (
-        <ErrorAsset key={asset.id} id={asset.id} message={processing.failure} />
-      );
-    } else {
-      const active = asset.version === this.props.activeVersion;
-      const selectable =
-        !active &&
-        processing &&
-        (processing.status === 'succeeded' ||
-          processing.status === 'terminated');
-
-      return (
-        <VideoAsset
-          key={asset.id}
-          active={active}
-          selectable={selectable}
-          selectAsset={this.props.selectAsset}
-          {...asset}
-        />
-      );
-    }
-  };
-
-  getUploads = () => {
+  getAssets = () => {
     const ret = [];
 
-    this.props.uploads.forEach(upload => {
-      const isLocalUpload = upload.id == this.props.s3Upload.id;
-      const assetId = upload.asset ? upload.asset.id : false;
-      const isAsset = this.props.assets.some(asset => asset.id === assetId);
+    if (this.props.s3Upload.total) {
+      ret.push({
+        id: 's3Upload',
+        processing: {
+          status: 'Uploading to S3',
+          failed: false,
+          current: this.props.s3Upload.progress,
+          total: this.props.s3Upload.total
+        }
+      });
+    }
 
-      if (!isLocalUpload && !isAsset) {
+    this.props.uploads.forEach(upload => {
+      if (upload.id !== this.props.s3Upload.id) {
         ret.push(upload);
       }
     });
@@ -220,32 +48,35 @@ export default class VideoTrail extends React.Component {
   };
 
   render() {
-    const blocks = [];
+    const assets = this.getAssets();
 
-    if (this.props.s3Upload.total) {
-      blocks.push(this.renderS3Upload());
-    }
+    const blocks = assets.map(upload => {
+      const active = upload.id == this.props.activeVersion;
+      const activate = active ? false : function() {};
 
-    const uploads = this.getUploads();
-
-    uploads.forEach(upload => {
-      blocks.push(
-        upload.failed
-          ? <FailedUpload key={upload.id} message={upload.status} />
-          : <UploadAsset
-              key={upload.id}
-              message={upload.status}
-              total={upload.total}
-              progress={upload.current}
-            />
-      );
+      if (upload.asset.id) {
+        return (
+          <YouTubeAsset
+            key={upload.id}
+            id={upload.asset.id}
+            activate={activate}
+          />
+        );
+      } else {
+        return (
+          <SelfHostedAsset
+            key={upload.id}
+            version={upload.id}
+            sources={upload.asset.sources}
+            activate={activate}
+          />
+        );
+      }
     });
-
-    blocks.push(...this.props.assets.map(this.renderAsset));
 
     const content = blocks.length > 0
       ? blocks
-      : <ErrorAsset message="No Assets Uploaded" />;
+      : <Asset content="No Assets Uploaded" />;
 
     return (
       <div className="video__detail__page__trail">

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Asset, assetProps } from './VideoAsset';
+import { Asset, buildAssetProps } from './VideoAsset';
 
 export default class VideoTrail extends React.Component {
   polling = null;
@@ -52,7 +52,7 @@ export default class VideoTrail extends React.Component {
 
     const blocks = assets.map(upload => {
       const active = upload.id == this.props.activeVersion;
-      const props = assetProps(
+      const props = buildAssetProps(
         upload.id,
         upload.asset,
         upload.processing,

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -57,7 +57,11 @@ export default class VideoTrail extends React.Component {
 
     const blocks = assets.map(upload => {
       const active = upload.id == this.props.activeVersion;
-      const activate = active ? false : function() {};
+      const activate = active
+        ? false
+        : () => {
+            this.props.selectAsset(Number(upload.id));
+          };
 
       if (upload.processing) {
         return <ProcessingAsset key={upload.id} {...upload.processing} />;

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  Asset,
-  YouTubeAsset,
-  SelfHostedAsset,
-  ProcessingAsset
-} from './VideoAsset';
+import { Asset, assetProps } from './VideoAsset';
 
 export default class VideoTrail extends React.Component {
   polling = null;
@@ -57,32 +52,15 @@ export default class VideoTrail extends React.Component {
 
     const blocks = assets.map(upload => {
       const active = upload.id == this.props.activeVersion;
-      const activate = active
-        ? false
-        : () => {
-            this.props.selectAsset(Number(upload.id));
-          };
+      const props = assetProps(
+        upload.id,
+        upload.asset,
+        upload.processing,
+        active,
+        this.props.selectAsset
+      );
 
-      if (upload.processing) {
-        return <ProcessingAsset key={upload.id} {...upload.processing} />;
-      } else if (upload.asset.id) {
-        return (
-          <YouTubeAsset
-            key={upload.id}
-            id={upload.asset.id}
-            activate={activate}
-          />
-        );
-      } else {
-        return (
-          <SelfHostedAsset
-            key={upload.id}
-            version={upload.id}
-            sources={upload.asset.sources}
-            activate={activate}
-          />
-        );
-      }
+      return <Asset key={upload.id} {...props} />;
     });
 
     const content = blocks.length > 0

--- a/public/video-ui/src/components/VideoUpload/VideoUpload.js
+++ b/public/video-ui/src/components/VideoUpload/VideoUpload.js
@@ -210,12 +210,8 @@ class VideoUpload extends React.Component {
     const uploading = this.props.s3Upload.total > 0;
     const activeVersion = this.props.video ? this.props.video.activeVersion : 0;
 
-    const selectAsset = (assetId, version) => {
-      this.props.videoActions.revertAsset(
-        this.props.video.id,
-        assetId,
-        version
-      );
+    const selectAsset = version => {
+      this.props.videoActions.revertAsset(this.props.video.id, version);
     };
 
     return (

--- a/public/video-ui/src/components/VideoUpload/VideoUpload.js
+++ b/public/video-ui/src/components/VideoUpload/VideoUpload.js
@@ -208,9 +208,7 @@ class VideoUpload extends React.Component {
 
   render() {
     const uploading = this.props.s3Upload.total > 0;
-
     const activeVersion = this.props.video ? this.props.video.activeVersion : 0;
-    const assets = this.props.video ? this.props.video.assets : [];
 
     const selectAsset = (assetId, version) => {
       this.props.videoActions.revertAsset(
@@ -230,12 +228,9 @@ class VideoUpload extends React.Component {
             </div>
             <VideoTrail
               activeVersion={activeVersion}
-              assets={assets}
               s3Upload={this.props.s3Upload}
               uploads={this.props.uploads}
               selectAsset={selectAsset}
-              getVideo={() =>
-                this.props.videoActions.getVideo(this.props.video.id)}
               getUploads={() =>
                 this.props.uploadActions.getUploads(this.props.video.id)}
             />

--- a/public/video-ui/src/components/utils/VideoEmbed.js
+++ b/public/video-ui/src/components/utils/VideoEmbed.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 export function VideoEmbed({ sources }) {
   return (
-    <video controls>
+    <video className="video-player" controls>
       {sources.map(source => {
         return (
           <source key={source.src} src={source.src} type={source.mimeType} />

--- a/public/video-ui/src/components/utils/VideoEmbed.js
+++ b/public/video-ui/src/components/utils/VideoEmbed.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export function VideoEmbed({ sources }) {
+  return (
+    <video controls>
+      {sources.map(source => {
+        return (
+          <source key={source.src} src={source.src} type={source.mimeType} />
+        );
+      })}
+    </video>
+  );
+}

--- a/public/video-ui/src/reducers/uploadsReducer.js
+++ b/public/video-ui/src/reducers/uploadsReducer.js
@@ -6,7 +6,12 @@ export default function uploads(state = [], action) {
       const id = action.upload.id;
 
       if (!_.find(state, upload => upload.id === id)) {
-        const status = { id: id, status: 'Uploading', failed: false };
+        const status = {
+          id,
+          failed: false,
+          processing: { status: 'Uploading' }
+        };
+
         return [status, ...state];
       }
 

--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -50,11 +50,11 @@ export default {
     });
   },
 
-  revertAsset: (atomId, videoId) => {
+  revertAsset: (atomId, version) => {
     return pandaReqwest({
       url: '/api2/atom/' + atomId + '/asset-active',
       method: 'put',
-      data: { youtubeId: videoId }
+      data: { version }
     });
   },
 

--- a/public/video-ui/styles/layout/_upload.scss
+++ b/public/video-ui/styles/layout/_upload.scss
@@ -62,10 +62,6 @@
       img {
         width: 100%;
       }
-
-      video {
-        height: inherit;
-      }
     }
 
     &__empty {

--- a/public/video-ui/styles/layout/_upload.scss
+++ b/public/video-ui/styles/layout/_upload.scss
@@ -62,6 +62,10 @@
       img {
         width: 100%;
       }
+
+      video {
+        height: inherit;
+      }
     }
 
     &__empty {
@@ -105,11 +109,6 @@
     padding: 8px 0 0;
   }
 }
-
-.upload__final{
-  z-index: 100px;
-}
-
 
 .loader {
     border: 5px solid $color700Grey;

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -102,3 +102,7 @@
 .video__load_more {
   margin: 0 auto;
 }
+
+.video-player {
+  max-width: 100%;
+}

--- a/test/model/ClientAssetTest.scala
+++ b/test/model/ClientAssetTest.scala
@@ -68,6 +68,22 @@ class ClientAssetTest extends FunSuite with MustMatchers {
     }
   }
 
+  test("Group assets by version (newest first)") {
+    withYouTubeStatus(processing = None) { youTube =>
+      val input = List(mp4.copy(version = 1), m3u8.copy(version = 1), ytAsset.copy(version = 2))
+      val output = ClientAsset.byVersion(input, youTube)
+
+      output match {
+        case first :: second :: Nil =>
+          first.asset.get mustBe a[YouTubeAsset]
+          second.asset.get mustBe a[SelfHostedAsset]
+
+        case _ =>
+          fail(s"Expected two entries, got $output")
+      }
+    }
+  }
+
   test("Self hosted upload") {
     val upload = Upload("test", List.empty, blank(selfHost = true), null)
     val processing = ClientAssetProcessing("Uploading", failed = false, None, None)

--- a/test/model/ClientAssetTest.scala
+++ b/test/model/ClientAssetTest.scala
@@ -164,21 +164,15 @@ class ClientAssetTest extends FunSuite with MustMatchers {
     UploadMetadata("", "", "", "", "", null, selfHost, None, None)
   }
 
-  private def withoutYouTubeStatus(fn: YouTubeVideos => Unit): Unit = {
-    fn(new YouTubeVideos with YouTubeAccess with Logging {
-      override def config: Config = ConfigFactory.load()
-      override def getProcessingStatus(videoId: String): Option[YouTubeProcessingStatus] = {
-        fail("Unexpected call to YouTube status")
-      }
+  private def withoutYouTubeStatus(fn: (String => Option[YouTubeProcessingStatus]) => Unit): Unit = {
+    fn((_: String) => {
+      fail("Unexpected call to YouTube status")
     })
   }
 
-  private def withYouTubeStatus(processing: Option[YouTubeProcessingStatus])(fn: YouTubeVideos => Unit): Unit = {
-    fn(new YouTubeVideos with YouTubeAccess with Logging {
-      override def config: Config = ConfigFactory.load()
-      override def getProcessingStatus(videoId: String): Option[YouTubeProcessingStatus] = {
-        processing
-      }
+  private def withYouTubeStatus(processing: Option[YouTubeProcessingStatus])(fn: (String => Option[YouTubeProcessingStatus]) => Unit): Unit = {
+    fn((_: String) => {
+      processing
     })
   }
 }

--- a/test/model/ClientAssetTest.scala
+++ b/test/model/ClientAssetTest.scala
@@ -86,10 +86,10 @@ class ClientAssetTest extends FunSuite with MustMatchers {
 
   test("Self hosted upload") {
     val upload = Upload("test", List.empty, blank(selfHost = true), null)
-    val processing = ClientAssetProcessing("Uploading", failed = false, None, None)
+    val processing = ClientAssetProcessing("Reticulating Splines", failed = false, None, None)
 
     val expected = ClientAsset("test", asset = None, Some(processing))
-    val actual = ClientAsset(upload, error = None)
+    val actual = ClientAsset("Reticulating Splines", upload, error = None)
 
     actual must be(expected)
   }
@@ -99,31 +99,31 @@ class ClientAssetTest extends FunSuite with MustMatchers {
     val processing = ClientAssetProcessing("Failed due to electric boogaloo", failed = true, None, None)
 
     val expected = ClientAsset("test", asset = None, Some(processing))
-    val actual = ClientAsset(upload, error = Some("Failed due to electric boogaloo"))
+    val actual = ClientAsset("test", upload, error = Some("Failed due to electric boogaloo"))
 
     actual must be(expected)
   }
 
-  test("YouTube upload") {
+  test("YouTube fully uploaded") {
     val progress = UploadProgress(chunksInS3 = 2, chunksInYouTube = 2, fullyUploaded = true, fullyTranscoded = false, retries = 0)
     val metadata = blank(selfHost = false).copy(asset = Some(YouTubeAsset("test")))
     val upload = Upload("test", parts, metadata, progress)
 
     val processing = ClientAssetProcessing("Uploading", failed = false, None, None)
     val expected = ClientAsset("test", asset = None, Some(processing))
-    val actual = ClientAsset(upload, error = None)
+    val actual = ClientAsset("test", upload, error = None)
 
     actual must be(expected)
   }
 
-  test("YouTube upload (processing)") {
+  test("YouTube partially uploaded") {
     val progress = UploadProgress(chunksInS3 = 2, chunksInYouTube = 1, fullyUploaded = false, fullyTranscoded = false, retries = 0)
     val metadata = blank(selfHost = false).copy(asset = Some(YouTubeAsset("test")))
     val upload = Upload("test", parts, metadata, progress)
 
     val processing = ClientAssetProcessing("Uploading to YouTube", failed = false, current = Some(1), total = Some(2))
     val expected = ClientAsset("test", asset = None, Some(processing))
-    val actual = ClientAsset(upload, error = None)
+    val actual = ClientAsset("test", upload, error = None)
 
     actual must be(expected)
   }

--- a/test/model/ClientAssetTest.scala
+++ b/test/model/ClientAssetTest.scala
@@ -1,0 +1,168 @@
+package model
+
+import com.gu.media.logging.Logging
+import com.gu.media.model.{SelfHostedAsset, VideoSource, YouTubeAsset}
+import com.gu.media.upload.model.{Upload, UploadMetadata, UploadPart, UploadProgress}
+import com.gu.media.youtube.{YouTubeAccess, YouTubeProcessingStatus, YouTubeVideos}
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.{FunSuite, MustMatchers}
+
+class ClientAssetTest extends FunSuite with MustMatchers {
+  val ytAsset = Asset(AssetType.Video, 1, "12345", Platform.Youtube, None)
+  val ytProcessing = YouTubeProcessingStatus("1", "processing", 0, 0, 0, None)
+
+  val mp4 = Asset(AssetType.Video, 1, "test.mp4", Platform.Url, Some("video/mp4"))
+  val m3u8 = Asset(AssetType.Video, 1, "test.m3u8", Platform.Url, Some("video/m3u8"))
+
+  val parts = List(UploadPart("1", 0, 10), UploadPart("2", 10, 20))
+
+  test("no assets") {
+    withoutYouTubeStatus { youTube =>
+      ClientAsset(List.empty, youTube) mustBe empty
+    }
+  }
+
+  test("self hosted asset") {
+    withoutYouTubeStatus { youTube =>
+      val asset = SelfHostedAsset(List(
+        VideoSource(mp4.id, mp4.mimeType.get), VideoSource(m3u8.id, m3u8.mimeType.get)
+      ))
+
+      val expected = ClientAsset(mp4.version.toString, Some(asset), processing = None)
+      val actual = ClientAsset(List(mp4, m3u8), youTube)
+
+      actual must contain(expected)
+    }
+  }
+
+  test("YouTube asset") {
+    withYouTubeStatus(processing = None) { youTube =>
+      val asset = YouTubeAsset(ytAsset.id)
+
+      val expected = ClientAsset(ytAsset.version.toString, Some(asset), processing = None)
+      val actual = ClientAsset(List(ytAsset), youTube)
+
+      actual must contain(expected)
+    }
+  }
+
+  test("YouTube asset (succeeded)") {
+    withYouTubeStatus(processing = Some(ytProcessing.copy(status = "succeeded"))) { youTube =>
+      val asset = YouTubeAsset(ytAsset.id)
+
+      val expected = ClientAsset(ytAsset.version.toString, Some(asset), processing = None)
+      val actual = ClientAsset(List(ytAsset), youTube)
+
+      actual must contain(expected)
+    }
+  }
+
+  test("YouTube asset (processing)") {
+    withYouTubeStatus(processing = Some(ytProcessing)) { youTube =>
+      val processing = ClientAssetProcessing("YouTube Processing", failed = false, None, None)
+
+      val expected = ClientAsset(ytAsset.version.toString, asset = None, Some(processing))
+      val actual = ClientAsset(List(ytAsset), youTube)
+
+      actual must contain(expected)
+    }
+  }
+
+  test("Self hosted upload") {
+    val upload = Upload("test", List.empty, blank(selfHost = true), null)
+    val processing = ClientAssetProcessing("Uploading", failed = false, None, None)
+
+    val expected = ClientAsset("test", asset = None, Some(processing))
+    val actual = ClientAsset(upload, error = None)
+
+    actual must be(expected)
+  }
+
+  test("Self hosted upload (error)") {
+    val upload = Upload("test", List.empty, blank(selfHost = true), null)
+    val processing = ClientAssetProcessing("Failed due to electric boogaloo", failed = true, None, None)
+
+    val expected = ClientAsset("test", asset = None, Some(processing))
+    val actual = ClientAsset(upload, error = Some("Failed due to electric boogaloo"))
+
+    actual must be(expected)
+  }
+
+  test("YouTube upload") {
+    val progress = UploadProgress(chunksInS3 = 2, chunksInYouTube = 2, fullyUploaded = true, fullyTranscoded = false, retries = 0)
+    val metadata = blank(selfHost = false).copy(asset = Some(YouTubeAsset("test")))
+    val upload = Upload("test", parts, metadata, progress)
+
+    val processing = ClientAssetProcessing("Uploading", failed = false, None, None)
+    val expected = ClientAsset("test", asset = None, Some(processing))
+    val actual = ClientAsset(upload, error = None)
+
+    actual must be(expected)
+  }
+
+  test("YouTube upload (processing)") {
+    val progress = UploadProgress(chunksInS3 = 2, chunksInYouTube = 1, fullyUploaded = false, fullyTranscoded = false, retries = 0)
+    val metadata = blank(selfHost = false).copy(asset = Some(YouTubeAsset("test")))
+    val upload = Upload("test", parts, metadata, progress)
+
+    val processing = ClientAssetProcessing("Uploading to YouTube", failed = false, current = Some(1), total = Some(2))
+    val expected = ClientAsset("test", asset = None, Some(processing))
+    val actual = ClientAsset(upload, error = None)
+
+    actual must be(expected)
+  }
+
+  test("YouTube processing (indeterminate)") {
+    val status = YouTubeProcessingStatus("", "processing", 0, 0, 0, None)
+    val expected = ClientAssetProcessing("YouTube Processing", failed = false, None, None)
+    val actual = ClientAssetProcessing(status)
+
+    actual must be(expected)
+  }
+
+  test("YouTube processing (time left)") {
+    val status = YouTubeProcessingStatus("", "processing", 10, 5, 10000, None)
+    val expected = ClientAssetProcessing("YouTube Processing (10s left)", failed = false, Some(5), Some(10))
+    val actual = ClientAssetProcessing(status)
+
+    actual must be(expected)
+  }
+
+  test("YouTube processing (error)") {
+    val status = YouTubeProcessingStatus("", "failed", 0, 0, 0, Some("burp"))
+    val expected = ClientAssetProcessing("burp", failed = true, None, None)
+    val actual = ClientAssetProcessing(status)
+
+    actual must be(expected)
+  }
+
+  test("YouTube processing (something else)") {
+    val status = YouTubeProcessingStatus("", "reticulating", 0, 0, 0, None)
+    val expected = ClientAssetProcessing("reticulating", failed = false, None, None)
+    val actual = ClientAssetProcessing(status)
+
+    actual must be(expected)
+  }
+
+  private def blank(selfHost: Boolean): UploadMetadata = {
+    UploadMetadata("", "", "", "", "", null, selfHost, None, None)
+  }
+
+  private def withoutYouTubeStatus(fn: YouTubeVideos => Unit): Unit = {
+    fn(new YouTubeVideos with YouTubeAccess with Logging {
+      override def config: Config = ConfigFactory.load()
+      override def getProcessingStatus(videoId: String): Option[YouTubeProcessingStatus] = {
+        fail("Unexpected call to YouTube status")
+      }
+    })
+  }
+
+  private def withYouTubeStatus(processing: Option[YouTubeProcessingStatus])(fn: YouTubeVideos => Unit): Unit = {
+    fn(new YouTubeVideos with YouTubeAccess with Logging {
+      override def config: Config = ConfigFactory.load()
+      override def getProcessingStatus(videoId: String): Option[YouTubeProcessingStatus] = {
+        processing
+      }
+    })
+  }
+}


### PR DESCRIPTION
You've seen how to [add them](https://github.com/guardian/media-atom-maker/pull/497), you've seen how to [activate them](https://github.com/guardian/media-atom-maker/pull/501), now do all that **and more** direct from the media-atom-maker UI!

<img width="1183" alt="7b0ea22f-3030-495e-93ab-46beaed59aca" src="https://user-images.githubusercontent.com/395805/27545002-9db75356-5a86-11e7-8ec8-4b765943fb94.png">

<img width="1061" alt="48906daf-06b2-4a9a-9da0-8f88741e28dc" src="https://user-images.githubusercontent.com/395805/27642218-07a088ba-5c16-11e7-8420-a99817500cd5.png">


Previously the UI would stitch together three pieces of info to form the video assets pages:

- Assets added to the atom
- Step function pipeline progress
- YouTube processing status

I found adding the additional work for self-hosted assets pushed the code over the edge of complexity. To fix this, I've introduced a new `ClientAsset` class that does the stitching server-side. The client is then free to simply render the asset or processing progress it is given.

See [ClientAssetTest](https://github.com/guardian/media-atom-maker/compare/mbarton/self-hosted-asset-ui-3?expand=1#diff-a8da3e10fead9a40fb874d1c574cc913) for all the combinations.
