### PR TITLE
Single template for atom defaultHtml

### DIFF
--- a/app/model/MediaAtom.scala
+++ b/app/model/MediaAtom.scala
@@ -35,56 +35,45 @@ case class MediaAtom(
   expiryDate: Option[Long] = None,
   blockAds: Option[Boolean]) {
 
-  def asThrift = ThriftAtom(
+  def asThrift = {
+    val data = ThriftMediaAtom(
+      assets = assets.map(_.asThrift),
+      activeVersion = activeVersion,
+      title = title,
+      category = category.asThrift,
+      duration = duration,
+      source = source,
+      posterUrl = posterImage.flatMap(_.master).map(_.file),
+      description = description,
+      trailText = trailText,
+      posterImage = posterImage.map(_.asThrift),
+      byline = Some(byline),
+      metadata = Some(ThriftMetadata(
+        tags = Some(tags),
+        categoryId = youtubeCategoryId,
+        license = license,
+        commentsEnabled = Some(commentsEnabled),
+        channelId = channelId,
+        privacyStatus = privacyStatus.flatMap(_.asThrift),
+        expiryDate = expiryDate,
+        pluto = plutoData.map(_.asThrift)
+      ))
+    )
+
+    ThriftAtom(
       id = id,
       atomType = ThriftAtomType.Media,
       labels = List(),
-      defaultHtml = generateHtml(),
+      defaultHtml = MediaAtomImplicits.defaultMediaHtml(data),
       title = Some(title),
-      data = AtomData.Media(ThriftMediaAtom(
-        assets = assets.map(_.asThrift),
-        activeVersion = activeVersion,
-        title = title,
-        category = category.asThrift,
-        duration = duration,
-        source = source,
-        posterUrl = posterImage.flatMap(_.master).map(_.file),
-        description = description,
-        trailText = trailText,
-        posterImage = posterImage.map(_.asThrift),
-        byline = Some(byline),
-        metadata = Some(ThriftMetadata(
-          tags = Some(tags),
-          categoryId = youtubeCategoryId,
-          license = license,
-          commentsEnabled = Some(commentsEnabled),
-          channelId = channelId,
-          privacyStatus = privacyStatus.flatMap(_.asThrift),
-          expiryDate = expiryDate,
-          pluto = plutoData.map(_.asThrift)
-          ))
-        )),
+      data = AtomData.Media(data),
       contentChangeDetails = contentChangeDetails.asThrift,
       flags = Some(ThriftFlags(
         legallySensitive = legallySensitive,
         blockAds = blockAds,
         sensitive = sensitive
       ))
-  )
-
-  def getActiveAsset = this.assets.find(_.version == this.activeVersion.get)
-
-  private def generateHtml(): String = {
-    val activeAssets = assets filter (asset => activeVersion.contains(asset.version))
-    if (activeAssets.nonEmpty && activeAssets.forall(_.platform == Platform.Url)) {
-      views.html.MediaAtom.embedUrlAssets2(posterImage.flatMap(_.master).map(_.file).getOrElse(""), activeAssets).toString
-    } else {
-      activeAssets.headOption match {
-        case Some(activeAsset) if activeAsset.platform == Platform.Youtube =>
-          views.html.MediaAtom.embedYoutubeAsset2(activeAsset).toString
-        case _ => "<div></div>"
-      }
-    }
+    )
   }
 }
 

--- a/app/views/MediaAtom/defaultEmbed.scala.html
+++ b/app/views/MediaAtom/defaultEmbed.scala.html
@@ -1,8 +1,7 @@
 @import com.gu.media.model.{VideoAsset, YouTubeAsset, SelfHostedAsset}
-
 @(asset: Option[VideoAsset], posterUrl: Option[String])
 
-@(asset, posterUrl) match {
+@defining((asset, posterUrl)) {
   case (None, Some(poster)) => {
     <img src="@poster"/>
   }
@@ -12,13 +11,14 @@
   }
 
   case (Some(SelfHostedAsset(sources)), Some(poster)) => {
-    <video controls="controls" poster="@{poster}">
+    <video controls="controls" poster="@poster">
     @for(source <- sources) {
-      <source type="@{source.mimeType}" src="@{source.src}" />
+      <source type="@source.mimeType" src="@source.src" />
     }
     </video>
   }
 
-  case _ =>
+  case _ => {
     <div />
+  }
 }

--- a/app/views/MediaAtom/defaultEmbed.scala.html
+++ b/app/views/MediaAtom/defaultEmbed.scala.html
@@ -11,7 +11,7 @@
   }
 
   case (Some(SelfHostedAsset(sources)), Some(poster)) => {
-    <video controls="controls" poster="@poster">
+    <video controls="controls" poster="@poster" preload="metadata">
     @for(source <- sources) {
       <source type="@source.mimeType" src="@source.src" />
     }

--- a/app/views/MediaAtom/defaultEmbed.scala.html
+++ b/app/views/MediaAtom/defaultEmbed.scala.html
@@ -1,0 +1,24 @@
+@import com.gu.media.model.{VideoAsset, YouTubeAsset, SelfHostedAsset}
+
+@(asset: Option[VideoAsset], posterUrl: Option[String])
+
+@(asset, posterUrl) match {
+  case (None, Some(poster)) => {
+    <img src="@poster"/>
+  }
+
+  case (Some(YouTubeAsset(id)), _) => {
+    <iframe frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/@id"></iframe>
+  }
+
+  case (Some(SelfHostedAsset(sources)), Some(poster)) => {
+    <video controls="controls" poster="@{poster}">
+    @for(source <- sources) {
+      <source type="@{source.mimeType}" src="@{source.src}" />
+    }
+    </video>
+  }
+
+  case _ =>
+    <div />
+}

--- a/app/views/MediaAtom/embedUrlAssets.scala.html
+++ b/app/views/MediaAtom/embedUrlAssets.scala.html
@@ -1,5 +1,0 @@
-@(atom: com.gu.contentatom.thrift.atom.media.MediaAtom, activeAssets: Seq[com.gu.contentatom.thrift.atom.media.Asset])
-
-<video controls="controls" poster="@{atom.posterUrl}">
-    @for(asset <- activeAssets) {<source type="@{asset.mimeType}" src="@{asset.id}" />}
-</video>

--- a/app/views/MediaAtom/embedUrlAssets2.scala.html
+++ b/app/views/MediaAtom/embedUrlAssets2.scala.html
@@ -1,5 +1,0 @@
-@(posterUrl: String, activeAssets: Seq[model.Asset])
-
-<video controls="controls" poster="@{posterUrl}">
-    @for(asset <- activeAssets) {<source type="@{asset.mimeType}" src="@{asset.id}" />}
-</video>

--- a/app/views/MediaAtom/embedYoutubeAsset.scala.html
+++ b/app/views/MediaAtom/embedYoutubeAsset.scala.html
@@ -1,6 +1,0 @@
-@import com.gu.contentatom.thrift.atom.media.Asset
-@(asset: Asset)
-<iframe width="420" height="315"
-        src="https://www.youtube.com/embed/@asset.id" frameborder="0"
-        allowfullscreen="">
-</iframe>

--- a/app/views/MediaAtom/embedYoutubeAsset2.scala.html
+++ b/app/views/MediaAtom/embedYoutubeAsset2.scala.html
@@ -1,5 +1,0 @@
-@(asset: model.Asset)
-<iframe width="420" height="315"
-        src="https://www.youtube.com/embed/@asset.id" frameborder="0"
-        allowfullscreen="">
-</iframe>

--- a/test/ThriftUtilSpec.scala
+++ b/test/ThriftUtilSpec.scala
@@ -2,6 +2,7 @@ package test
 
 import com.gu.contentatom.thrift._
 import com.gu.contentatom.thrift.atom.media._
+import org.jsoup.Jsoup
 import org.scalatest.{FunSpec, Inside, Matchers}
 import util.ThriftUtil
 
@@ -58,9 +59,9 @@ class ThriftUtilSpec extends FunSpec
               changeDetails should matchPattern {
                 case ContentChangeDetails(None, None, None, 1L, None) =>
               }
-              XML.loadString(defaultHtml) should matchPattern {
-                case <iframe>{_}</iframe> =>
-              }
+
+              val iframe = Jsoup.parse(defaultHtml).getElementsByTag("iframe")
+              iframe.attr("src") should be(s"https://www.youtube.com/embed/$youtubeId")
           }
       }
     }


### PR DESCRIPTION
I wanted to remove the fixed `width` and `height` on the YouTube `iframe` in `defaultHtml`. This is so we can use the `defaultHtml` to display a preview in Workflow and Composer.

I then noticed we had duplicate templates for each embed, so I brought them together into a single one.

I also made the `defaultHtml` for an asset with no video be the poster image, which is what frontend was already doing.