### PR TITLE
add an icon to indicate atom usage on a video page

### DIFF
--- a/public/video-ui/src/components/Icon.js
+++ b/public/video-ui/src/components/Icon.js
@@ -66,6 +66,41 @@ export class ViewerIcon extends React.Component {
   }
 }
 
+export class ComposerVideoIcon extends React.Component {
+  render() {
+    return (
+      <span className="icon svg-icon">
+        <svg
+          version="1.1"
+          id="Layer_1"
+          xmlns="http://www.w3.org/2000/svg"
+          x="0px"
+          y="0px"
+          viewBox="0 0 595.3 595.3"
+        >
+          <path fill="#231F20" d="M456.9,534.8" />
+          <path
+            fill="#231F20"
+            d="M452.5,23.8C418.9,10.6,362.9,0,295.3,0C155.9,0,10.2,73.3,10.2,286c0,200.3,119.2,278.9,270.1,278.9
+              c16.4,0,31.6-0.5,45.6-1.3c-20.4-15.9-32.9-42.6-39.8-66.5c-0.5-1.7-0.1-3.2,0.8-4.3c-77.1-3.3-111.7-54.2-111.7-219.1
+              c0-145.6,38.8-200.3,115.6-200.3c26,0,47.2,6.6,62.7,13.2l35.3,84.7h68.9L452.5,23.8z"
+          />
+          <g>
+            <polygon
+              fill="#161616"
+              points="553.5,360.9 494.8,425.3 494.8,464 553.5,528.4 571.2,528.4 571.2,360.9     "
+            />
+            <polygon
+              fill="#161616"
+              points="312.6,380.2 312.6,509.1 336.1,534.8 471.3,534.8 471.3,354.4 336.1,354.4     "
+            />
+          </g>
+        </svg>
+      </span>
+    );
+  }
+}
+
 export default class Icon extends React.Component {
   renderText() {
     if (this.props.children) {

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -2,7 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { getStore } from '../../util/storeAccessor';
-import { FrontendIcon, ComposerIcon, ViewerIcon } from '../Icon';
+import {
+  FrontendIcon,
+  ComposerIcon,
+  ViewerIcon,
+  ComposerVideoIcon
+} from '../Icon';
 
 export default class VideoUsages extends React.Component {
   getComposerUrl = () => {
@@ -17,13 +22,20 @@ export default class VideoUsages extends React.Component {
     const composerLink = `${this.getComposerUrl()}/content/${usage.fields.internalComposerCode}`;
     const viewerLink = `${this.getViewerUrl()}/preview/${usage.id}`;
     const websiteLink = `https://www.theguardian.com/${usage.id}`;
+    const isVideoType = usage.type === 'video';
 
     const usageDateFromNow = moment(usage.fields.creationDate).fromNow();
 
-    //TODO add an icon to indicate atom usage on a video page
     return (
-      <li key={usage.id} className="detail__list__item">
-        {usage.fields.headline || usage.id}
+      <li
+        key={usage.id}
+        className={
+          isVideoType ? 'detail__list__item--video' : 'detail__list__item'
+        }
+      >
+        <div className="details-list__title">
+          {usage.fields.headline || usage.id}
+        </div>
         <div>
           Created:
           {' '}
@@ -44,7 +56,7 @@ export default class VideoUsages extends React.Component {
             target="_blank"
             rel="noopener noreferrer"
           >
-            <ComposerIcon />
+            {isVideoType ? <ComposerVideoIcon /> : <ComposerIcon />}
           </a>
           <a
             className="usage--platform-link"

--- a/public/video-ui/styles/components/_detail.scss
+++ b/public/video-ui/styles/components/_detail.scss
@@ -7,12 +7,17 @@
     margin: 0;
 
     &__item {
-      padding: 5px 10px;
+      padding: 0 10px 5px 10px;
       border-top: 1px solid $color600Grey;
       width: 100%;
       overflow: hidden;
       text-overflow: ellipsis;
       word-wrap: nowrap;
+      &--video {
+        border-top: 3px solid $slightDangerColor;
+        background: $color700Grey;
+        padding: 0 10px 5px 10px;
+      }
     }
   }
 }

--- a/public/video-ui/styles/layout/_icons.scss
+++ b/public/video-ui/styles/layout/_icons.scss
@@ -103,12 +103,13 @@
     height: $iconSize;
   }
 
-  path {
+  path, polygon {
     fill: $color600Grey;
   }
 
+
   &:hover {
-    path {
+    path, polygon {
       fill: $color300Grey;
     }
   }


### PR DESCRIPTION
NB: had to create the video icon in illustrator so might not be ideal.

Before:
![picture 1](https://user-images.githubusercontent.com/12876467/27598388-417cb54a-5b5d-11e7-8490-cd3422f01b8b.png)

After:
![image](https://user-images.githubusercontent.com/12876467/27598451-70af38d8-5b5d-11e7-9704-8846c544e0d5.png)

