### PR TITLE
Third party YouTube video atoms

### DIFF
--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -86,9 +86,9 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
       bucket = awsConfig.userUploadBucket,
       region = awsConfig.region.getName,
       title = atom.title,
-      channel = atom.channelId.getOrElse { AtomMissingYouTubeChannel },
       pluto = plutoData,
       selfHost = selfHosted,
+      runtime = getRuntimeMetadata(selfHosted, atom.channelId),
       asset = getAsset(selfHosted, atom.title, uploadId)
     )
 
@@ -115,6 +115,12 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
 
       Some(SelfHostedAsset(List(mp4Source)))
     }
+  }
+
+  private def getRuntimeMetadata(selfHosted: Boolean, atomChannel: Option[String]) = atomChannel match {
+    case _ if selfHosted => SelfHostedUploadMetadata(List.empty)
+    case Some(channel) => YouTubeUploadMetadata(channel, uri = None)
+    case None => AtomMissingYouTubeChannel
   }
 
   private def chunk(uploadId: String, size: Long): List[UploadPart] = {

--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -24,8 +24,9 @@ object CommandExceptions extends Results {
   def AtomUpdateFailed(err: String) = throw new CommandException(s"Failed to update atom: $err", 500)
   def AtomPublishFailed(err: String) = throw new CommandException(s"Failed to publish atom: $err", 500)
 
-  def NotGuardianYoutubeVideo = throw new CommandException("YouTube video is not in the Guardian's account", 400)
   def AtomMissingYouTubeChannel = throw new CommandException("Atom is missing YouTube channel", 400)
+  def YouTubeVideoDoesNotExist(id: String) = throw new CommandException(s"YouTube video $id does not exist", 400)
+  def IncorrectYouTubeChannel = throw new CommandException(s"New video is not on the same YouTube channel", 400)
 
   // Add exceptions here as required
   def commandExceptionAsResult: PartialFunction[Throwable, Result] = {

--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -15,7 +15,6 @@ object CommandExceptions extends Results {
   def NotYoutubeAsset = throw new CommandException("Asset is not a youtube video", 400)
   def AssetVersionConflict = throw new CommandException("Asset version conflict", 400)
   def AssetParseFailed = throw new CommandException("Failed to parse asset", 400)
-  def AssetEncodingInProgress(state: String) = throw CommandException(s"Asset encoding in progress. Current state $state", 400)
   def AssetNotFound = throw new CommandException("Asset not found", 404)
 
   def AssetNotFound(assetId: String) = throw new CommandException(s"Asset with id $assetId not found", 404)

--- a/app/model/commands/DeleteCommand.scala
+++ b/app/model/commands/DeleteCommand.scala
@@ -30,7 +30,7 @@ case class DeleteCommand(id: String, override val stores: DataStores, youTube: Y
   }
 
   private def makeYouTubeVideosPrivate(assets: List[Asset]): Unit = assets.collect {
-    case Asset(_, _, videoId, Youtube, _) =>
+    case Asset(_, _, videoId, Youtube, _) if youTube.isMyVideo(videoId) =>
       log.info(s"Marking $videoId as private as parent atom $id is being deleted")
       youTube.setStatus(videoId, "Private")
   }

--- a/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
@@ -9,11 +9,10 @@ case class UploadMetadata(
   bucket: String,
   region: String,
   title: String,
-  channel: String,
   pluto: PlutoSyncMetadata,
   selfHost: Boolean = false,
-  asset: Option[VideoAsset] = None,
-  runtime: Option[RuntimeUploadMetadata] = None
+  runtime: RuntimeUploadMetadata,
+  asset: Option[VideoAsset] = None
 )
 
 case class PlutoSyncMetadata (
@@ -25,7 +24,7 @@ case class PlutoSyncMetadata (
 )
 
 sealed abstract class RuntimeUploadMetadata
-case class YouTubeUploadMetadata(uri: String) extends RuntimeUploadMetadata
+case class YouTubeUploadMetadata(channel: String, uri: Option[String]) extends RuntimeUploadMetadata
 case class SelfHostedUploadMetadata(jobs: List[String]) extends RuntimeUploadMetadata
 
 object UploadMetadata {

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -42,21 +42,6 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
     }
   }
 
-  def isMyVideo(youtubeId: String): Boolean = {
-    // HACK Listing `fileDetails` of a video requires authentication and an exception is thrown if not authorized,
-    // so we can say the video is not ours.
-    //
-    // A cleaner way to do this would be to check the channel id of the video is one of ours,
-    // however this involves an extra API call.
-    // TODO cache YouTube channels in a store and query against that.
-    try {
-      getVideo(youtubeId, "fileDetails").nonEmpty
-    }
-    catch {
-      case _: Throwable => false
-    }
-  }
-
   def updateMetadata(id: String, metadata: YouTubeMetadataUpdate): Option[Video] =
     getVideo(id, "snippet, status") match {
       case Some(video) =>

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -113,6 +113,17 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
     }
   }
 
+  def isMyVideo(youtubeId: String): Boolean = {
+    getVideo(youtubeId, "snippet") match {
+      case Some(video) =>
+        val channel = video.getSnippet.getChannelId
+        allowedChannels.contains(channel)
+
+      case None =>
+        false
+    }
+  }
+
   private def protectAgainstMistakesInDev(video: Video) = {
     val videoChannelId = video.getSnippet.getChannelId
 

--- a/expirer/src/main/scala/com/gu/media/expirer/ExpirerLambda.scala
+++ b/expirer/src/main/scala/com/gu/media/expirer/ExpirerLambda.scala
@@ -23,7 +23,7 @@ class ExpirerLambda extends RequestHandler[Unit, Unit]
 
   override def handleRequest(input: Unit, context: Context): Unit = {
     val epochMillis = Instant.now().toEpochMilli
-    val assets = getVideosFromExpiredAtoms(100, 1, epochMillis, Set.empty)
+    val assets = getVideosFromExpiredAtoms(100, 1, epochMillis, Set.empty).filter(isMyVideo)
 
     val toExpire = if(expireInParallel) { assets.par } else { assets }
 

--- a/public/video-ui/src/constants/videoCategories.js
+++ b/public/video-ui/src/constants/videoCategories.js
@@ -1,14 +1,9 @@
-// TODO add `Hosted` category.
-// Although `Hosted` is a valid category, the APIs driving the React frontend perform authenticated calls to YT.
-// These only work with content that we own. `Hosted` can have third-party assets so the API calls will fail.
-// Add `Hosted` once the UI is smarter and removes features when category is `Hosted`.
-
 export const videoCategories = [
   'News',
   'Documentary',
   'Explainer',
-  'Feature'
-  // 'Hosted'
+  'Feature',
+  'Hosted'
 ].map(cat => {
   return { id: cat, title: cat };
 });

--- a/test/model/ClientAssetTest.scala
+++ b/test/model/ClientAssetTest.scala
@@ -2,7 +2,7 @@ package model
 
 import com.gu.media.logging.Logging
 import com.gu.media.model.{SelfHostedAsset, VideoSource, YouTubeAsset}
-import com.gu.media.upload.model.{Upload, UploadMetadata, UploadPart, UploadProgress}
+import com.gu.media.upload.model._
 import com.gu.media.youtube.{YouTubeAccess, YouTubeProcessingStatus, YouTubeVideos}
 import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.{FunSuite, MustMatchers}
@@ -161,7 +161,7 @@ class ClientAssetTest extends FunSuite with MustMatchers {
   }
 
   private def blank(selfHost: Boolean): UploadMetadata = {
-    UploadMetadata("", "", "", "", "", null, selfHost, None, None)
+    UploadMetadata("", "", "", "", null, selfHost, null, None)
   }
 
   private def withoutYouTubeStatus(fn: (String => Option[YouTubeProcessingStatus]) => Unit): Unit = {

--- a/uploader/src/main/scala/com/gu/media/upload/GetTranscodingProgress.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/GetTranscodingProgress.scala
@@ -11,7 +11,7 @@ import scala.collection.JavaConverters._
 class GetTranscodingProgress extends LambdaWithParams[Upload, Upload] with ElasticTranscodeAccess with Logging {
   override def handle(upload: Upload): Upload = {
     upload.metadata.runtime match {
-      case Some(SelfHostedUploadMetadata(ids)) =>
+      case SelfHostedUploadMetadata(ids) =>
         val jobs = ids.map(getJob)
         val progress = upload.progress
 

--- a/uploader/src/main/scala/com/gu/media/upload/SendToTranscoder.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/SendToTranscoder.scala
@@ -19,7 +19,7 @@ class SendToTranscoder extends LambdaWithParams[Upload, Upload]
         val outputs = getOutputs(sources)
         val jobs = outputs.map { case(output, preset) => sendToTranscoder(input, output, preset) }
 
-        val metadata = upload.metadata.copy(runtime = Some(SelfHostedUploadMetadata(jobs)))
+        val metadata = upload.metadata.copy(runtime = SelfHostedUploadMetadata(jobs))
         upload.copy(metadata = metadata)
 
       case other =>


### PR DESCRIPTION
Allows the addition of any YouTube video to an atom via the "Add Asset to URL" text box. If the channel is not the same as that already attached to the atom, it will reject the add.

NB: this behaviour should be restricted to Hosted atoms. The UI changes for that will be in a follow up PR.

I've also made `RuntimeUploadMetadata` not optional and moved the channel into `YouTubeUploadMetadata` since it is not required for self-hosted assets.