### PR TITLE
Byline fixes

### DIFF
--- a/public/video-ui/src/components/FormFields/ComposerTagPicker.js
+++ b/public/video-ui/src/components/FormFields/ComposerTagPicker.js
@@ -63,7 +63,8 @@ export default class ComposerTagPicker extends React.Component {
   };
 
   updateInput = e => {
-    if (this.state.lastAction === UserActions.space) {
+    const onlyWhitespace = !/\S/.test(this.state.inputString);
+    if (this.state.lastAction === UserActions.space && !onlyWhitespace) {
       const newFieldValue = this.state.tagValue.concat([
         this.state.inputString
       ]);

--- a/public/video-ui/src/components/FormFields/ComposerTagPicker.js
+++ b/public/video-ui/src/components/FormFields/ComposerTagPicker.js
@@ -270,6 +270,16 @@ export default class ComposerTagPicker extends React.Component {
     );
   }
 
+  renderBylineInstructions() {
+    if (this.props.tagType === 'contributor') {
+      return (
+        <span className="form__field__instructions">
+          Press space to add byline as text
+        </span>
+      );
+    }
+  }
+
   render() {
     if (!this.props.editable) {
       if (!this.state.tagValue || this.state.tagValue.length === 0) {
@@ -301,6 +311,7 @@ export default class ComposerTagPicker extends React.Component {
 
         <div className="form__label__layout">
           <label className="form__label">{this.props.fieldName}</label>
+          {this.renderBylineInstructions()}
         </div>
         {this.renderCapiUnavailable()}
 

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -260,9 +260,10 @@
   display: block;
   border-top: 1px solid $color400Grey;
   width: 100%;
-  padding: 5px 5px;
+  padding: 7px 5px;
   cursor: pointer;
-  border-top: 12px solid $color650Grey;
+  overflow: auto;
+  max-height: 250px;
 }
 
 .form__field__tag__display {

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -255,6 +255,10 @@
   }
 }
 
+.form__field__instructions {
+  font-size: 12px;
+}
+
 .form__field__tags {
   border: 1px solid $color400Grey;
   display: block;


### PR DESCRIPTION
A few fixes to the byline picker

- Don't allow empty strings as input to bylines
- Add a scrollbar to tag list and improve its appearance
- Add instructions on how to add text input to byline. Initially I wanted to change this so that you would not have to press space to actually get text input added to the byline. I 
<img width="852" alt="screen shot 2017-06-29 at 15 12 48" src="https://user-images.githubusercontent.com/3066534/27692275-2f43cdfa-5cde-11e7-9e0e-218f817bd908.png">
thought it is too easy to forget to do this. I then realised that this might become confusing with the other tag pickers that allow for entering text on the input field but this text does not get saved. So I've added a little reminder to press space to add text input instead. 