### PR TITLE
remove margin

### DIFF
--- a/public/video-ui/src/components/FormFields/ScribeEditor.js
+++ b/public/video-ui/src/components/FormFields/ScribeEditor.js
@@ -109,7 +109,7 @@ export default class ScribeEditorField extends React.Component {
       }
       return (
         <div
-          className="details-list__field "
+          className="details-list__field details-list__field--scribe"
           dangerouslySetInnerHTML={{ __html: this.props.fieldValue }}
         />
       );

--- a/public/video-ui/styles/components/_details-list.scss
+++ b/public/video-ui/styles/components/_details-list.scss
@@ -14,6 +14,10 @@
   padding: 0px;
 }
 
+.details-list__field--scribe > p,ul {
+  margin: 0;
+}
+
 .details-list__labeled-filter {
   display: flex;
 }


### PR DESCRIPTION
The `<ul>` and `<p>` tags in the html generated by scribe were adding ugly margins on byline and trail text added to mam. This gets rid of those margins.