### PR TITLE
Suppress YouTube 403 test failures

### DIFF
--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -1,7 +1,10 @@
 package model.commands
 
 import com.google.api.client.googleapis.json.{GoogleJsonError, GoogleJsonResponseException}
+import com.google.api.client.http.{HttpHeaders, HttpResponseException}
+import com.gu.media.logging.Logging
 import play.api.mvc.{Result, Results}
+import scala.collection.JavaConverters._
 
 case class CommandException(msg: String, responseCode: Int) extends RuntimeException(msg)
 
@@ -19,7 +22,6 @@ object CommandExceptions extends Results {
   def AssetNotFound = throw new CommandException("Asset not found", 404)
 
   def AssetNotFound(assetId: String) = throw new CommandException(s"Asset with id $assetId not found", 404)
-  def PosterImageUploadFailed(err: String) = throw new CommandException(s"Failed to update poster image (must be at least 1 image asset smaller than 2MB): $err", 400)
   def YoutubeException(err: String) = throw new CommandException(s"Exception when trying to reach YouTube: $err", 400)
   def AtomUpdateFailed(err: String) = throw new CommandException(s"Failed to update atom: $err", 500)
   def AtomPublishFailed(err: String) = throw new CommandException(s"Failed to publish atom: $err", 500)
@@ -32,22 +34,57 @@ object CommandExceptions extends Results {
     case CommandException(msg, 400) => BadRequest(msg)
     case CommandException(msg, 404) => NotFound(msg)
     case CommandException(msg, 500) => InternalServerError(msg)
-    case YouTubeBackendError(err) => ServiceUnavailable(s"YouTube backend error: ${err.getMessage}")
+    case YouTubeError(msg, true) => InternalServerError(msg)
+    case YouTubeError(msg, false) => InternalServerError(msg).withHeaders("X-No-Alerts" -> "true")
   }
 }
 
-object YouTubeBackendError {
-  def unapply(err: Throwable): Option[GoogleJsonError] = err match {
+object YouTubeError extends Logging {
+  def unapply(err: Throwable): Option[(String, Boolean)] = err match {
     case e: GoogleJsonResponseException =>
-      val code = e.getDetails.getCode
+      (e.getDetails.getCode, e.getMessage) match {
+        case (503, "Backend Error") =>
+          Some(noAlerts(e), false)
 
-      if(code >= 500 && code < 600) {
-        Some(e.getDetails)
-      } else {
-        None
+        case (403, "User Rate Limit Exceeded") =>
+          Some(noAlerts(e), false)
+
+        case (code, message) =>
+          Some((s"YouTube $code: $message", true)) // alerts
       }
 
     case _ =>
       None
+  }
+
+  // For testing
+  val rateLimitExceeded: GoogleJsonResponseException =
+    buildYouTubeException(403, "usageLimits", "User Rate Limit Exceeded", "userRateLimitExceeded")
+
+  val backendError: GoogleJsonResponseException =
+    buildYouTubeException(503, "global", "Backend Error", "backendError")
+
+  private def buildYouTubeException(code: Int, domain: String, message: String, reason: String): GoogleJsonResponseException = {
+    val info = new GoogleJsonError.ErrorInfo()
+    info.setDomain(domain)
+    info.setMessage(message)
+    info.setReason(reason)
+
+    val error = new GoogleJsonError()
+    error.setCode(code)
+    error.setErrors(List(info).asJava)
+    error.setMessage(message)
+
+    val builder = new HttpResponseException.Builder(503, null, new HttpHeaders())
+    builder.setMessage(message)
+
+    new GoogleJsonResponseException(builder, error)
+  }
+
+  private def noAlerts(e: GoogleJsonResponseException): String = {
+    val msg = s"YouTube ${e.getDetails.getCode} ${e.getDetails.getMessage}"
+    log.warn(msg, e) // to get stack trace in the logs
+
+    msg
   }
 }

--- a/integration-tests/int-test-runner.sh
+++ b/integration-tests/int-test-runner.sh
@@ -4,7 +4,7 @@
 ./sbt integrationTests/test
 export STATUS=$?
 
-if [[ $STATUS = 1 &&  ! -f NO_ALERTS ]]
+if [[ $STATUS = 1 ]]
 then
   if [ "$INT_TEST_TARGET" = "PROD" ]
   then
@@ -13,7 +13,5 @@ then
     curl -X POST --data-urlencode 'payload={"text": "Media Atom Maker integration tests have failed on CODE '${BUILD_URL}' "}' ${SLACK_URL}
   fi
 fi
-
-rm -f NO_ALERTS
 
 exit $STATUS

--- a/integration-tests/src/test/scala/AtomCreationTests.scala
+++ b/integration-tests/src/test/scala/AtomCreationTests.scala
@@ -58,8 +58,14 @@ class AtomCreationTests extends IntegrationTestBase with CancelAfterFailure {
       case 400 =>
         fail(s"Publishing atom returned 400: ${response.body().string()}")
 
-      case 503 if response.body().string().startsWith("YouTube") =>
-        failQuietly(s"YouTube backend error ${response.body().string()}")
+      case 500 =>
+        Option(response.header("X-No-Alerts")) match {
+          case Some("true") =>
+            cancel(s"Publishing atom returned 500: ${response.body().string()}")
+
+          case None =>
+            fail(s"Publishing atom returned 500: ${response.body().string()}")
+        }
     }
   }
 }

--- a/integration-tests/src/test/scala/IntegrationTestBase.scala
+++ b/integration-tests/src/test/scala/IntegrationTestBase.scala
@@ -82,13 +82,6 @@ class IntegrationTestBase extends FunSuite with Matchers with Eventually with In
     super.afterAll()
   }
 
-  def failQuietly(msg: String): Unit = {
-    val file = Paths.get("NO_ALERTS")
-    Files.write(file, "NO_ALERTS".getBytes(StandardCharsets.UTF_8), CREATE, WRITE)
-
-    fail(msg)
-  }
-
   private def youTubeClient(): YouTube = {
     val httpTransport = new NetHttpTransport()
     val jacksonFactory = new JacksonFactory()


### PR DESCRIPTION
🎺 🚨 🚨 🎺 

More attempts to stop the Slack spam caused by the integration tests periodically failing. 

There's two usual suspects:
- `503 Backend Error`
- `403 Rate Limit Exceeded`

I've amended `commandExceptionAsResult` to catch them explicitly and set a special `X-No-Alerts` header on the response. The test then checks for this header and if present it **cancels** rather than fails the test. 

A cancelled test doesn't fail the whole run. `int-test-runner.sh` no longer needs dodgy file checking to check whether Slack alerts should fire.

I've also added helper methods that generate the usual suspects, very helpful for testing!

Finally I removed the special poster image error so that it can be caught by the general YouTube exception handler.