### PR TITLE
Match on YouTube error domain rather than message

### DIFF
--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -44,12 +44,15 @@ object YouTubeError extends Logging {
     case e: GoogleJsonResponseException =>
       (e.getDetails.getCode, e.getMessage) match {
         case (503, "Backend Error") =>
-          Some(noAlerts(e), false)
+          Some((noAlerts(e), false))
 
         case (403, "User Rate Limit Exceeded") =>
-          Some(noAlerts(e), false)
+          Some((noAlerts(e), false))
 
         case (code, message) =>
+          // TODO MRB: add logging to check match
+          log.warn(s"YouTube failure. Code: $code. Message: $message")
+
           Some((s"YouTube $code: $message", true)) // alerts
       }
 

--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -49,9 +49,9 @@ object YouTubeError extends Logging {
         case (403, Some("usageLimits")) =>
           Some((noAlerts(e), false))
 
-        case (code, maybeMessage) =>
-          val message = maybeMessage.getOrElse("unknown")
-          
+        case (code, _) =>
+          val message = Option(e.getDetails.getMessage).getOrElse("unknown")
+
           log.warn(s"YouTube failure. Code: $code. Message: $message")
           Some((s"YouTube $code: $message", true)) // alerts
       }

--- a/integration-tests/src/test/scala/AtomCreationTests.scala
+++ b/integration-tests/src/test/scala/AtomCreationTests.scala
@@ -60,7 +60,7 @@ class AtomCreationTests extends IntegrationTestBase with CancelAfterFailure {
 
       case 500 =>
         Option(response.header("X-No-Alerts")) match {
-          case Some("true") =>
+          case Some(_) =>
             cancel(s"Publishing atom returned 500: ${response.body().string()}")
 
           case None =>


### PR DESCRIPTION
So....

there was a field in the error JSON called `message`...

but `getMessage` on the exception didn't return that message, rather a completely different one...

that was silly, so I now use the error `domain` to decide whether or not to suppress Slack alerts...

I love integration tests

PS also fixed a warning, hence the `Some(_)` change