### PR TITLE
send requests to new expiry endpoint

### DIFF
--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -97,7 +97,7 @@ export default {
     ) {
       const rightsExpiryPayload = getRightsPayload(video);
       const rightsRequest = pandaReqwest({
-        url: `${composerUrlBase}/api/content/${id}/expiry/rights`,
+        url: `${composerUrlBase}/api/content/${id}/atom-expiry/rights`,
         method: 'post',
         crossOrigin: true,
         withCredentials: true,


### PR DESCRIPTION
To an expiry endpoint in flex that does not require permissions: https://github.com/guardian/flexible-content/pull/2851