### PR TITLE
Fix checkboxes

### DIFF
--- a/public/video-ui/src/components/FormFields/CheckBox.js
+++ b/public/video-ui/src/components/FormFields/CheckBox.js
@@ -2,13 +2,16 @@ import React from 'react';
 
 export default class CheckBox extends React.Component {
   renderCheckbox() {
+    const checked =
+      this.props.fieldValue && this.props.fieldValue !== this.props.placeholder;
+
     return (
       <div>
         <input
           id={this.props.fieldLocation}
           type="checkbox"
           disabled={!this.props.editable}
-          checked={this.props.fieldValue}
+          checked={checked}
           onChange={e => {
             this.props.onUpdateField(e.target.checked);
           }}


### PR DESCRIPTION
Post #507 checkboxes were displaying as always enabled unless you were in edit mode. This is because they were interpreting their placeholder as truthy enabled.

My fix is to compare the value against the placeholder.