### PR TITLE
Fix upload for atoms with quotes in the title

### DIFF
--- a/test/model/ClientAssetTest.scala
+++ b/test/model/ClientAssetTest.scala
@@ -128,6 +128,17 @@ class ClientAssetTest extends FunSuite with MustMatchers {
     actual must be(expected)
   }
 
+  test("YouTube upload (error)") {
+    val metadata = blank(selfHost = false).copy(asset = Some(YouTubeAsset("test")))
+    val upload = Upload("test", parts, metadata, null)
+
+    val processing = ClientAssetProcessing("It Didn't Work!", failed = true, current = None, total = None)
+    val expected = ClientAsset("test", asset = None, Some(processing))
+    val actual = ClientAsset("test", upload, error = Some("It Didn't Work!"))
+
+    actual must be(expected)
+  }
+
   test("YouTube processing (indeterminate)") {
     val status = YouTubeProcessingStatus("", "processing", 0, 0, 0, None)
     val expected = ClientAssetProcessing("YouTube Processing", failed = false, None, None)


### PR DESCRIPTION
Ronseal. Quotes in the title broke direct upload. Now they don't.

I also noticed that #502 broke reporting of errors from Step Functions when uploading to YouTube so I fixed that too:

<img width="1059" alt="3b4fcc6a-caac-46f7-8ae0-284f60e6411d" src="https://user-images.githubusercontent.com/395805/27921653-4a48406c-6270-11e7-892f-8f8b4bb6594a.png">

TODO

- [ ] get in touch with editorial once merged to let them know it's fixed