### PR TITLE
Update capi.js

### DIFF
--- a/public/video-ui/src/services/capi.js
+++ b/public/video-ui/src/services/capi.js
@@ -43,7 +43,7 @@ export default class ContentApi {
     }
     const encodedQuery = encodeURIComponent(query);
     return pandaReqwest({
-      url: `${ContentApi.proxyUrl}/tags?page-size=100&type=${type}&q=${encodedQuery}` //TODO this is likely to change based on CAPI work to search by prefix on webTitle
+      url: `${ContentApi.proxyUrl}/tags?page-size=100&type=${type}&web-title=${encodedQuery}`
     });
   }
 }


### PR DESCRIPTION
Search CAPI for tags using `web-title`, performing more of a "starts with" search which provides more accurate results.

For example, searching `Tour de Fran`:
Previously
https://content.guardianapis.com/tags?page-size=100&type=keyword&q=Tour%20de%20Fran&api-key=test

Total: 96 and (incorrectly) includes `sport/tour-de-yorkshire`.

Now
https://content.guardianapis.com/tags?page-size=100&type=keyword&web-title=Tour%20de%20Fran&api-key=test

Total: 20 and (correctly) omits `sport/tour-de-yorkshire`.