### PR TITLE
endpoint for Commercial diagnosis

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -22,7 +22,7 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class Api2 (override val stores: DataStores, conf: Configuration, override val authActions: HMACAuthActions,
-            youTube: YouTube, youTubeClaims: YouTubeClaims, awsConfig: AWSConfig,
+            youtube: YouTube, awsConfig: AWSConfig,
             override val permissions: MediaAtomMakerPermissionsProvider, capi: Capi)
 
   extends MediaAtomImplicits
@@ -68,7 +68,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
   }
 
   def publishMediaAtom(id: String) = APIAuthAction.async { implicit req =>
-      val command = PublishAtomCommand(id, stores, youTube, youTubeClaims, req.user, capi)
+      val command = PublishAtomCommand(id, stores, youtube, req.user, capi)
 
       val updatedAtom: Future[MediaAtom] = command.process()
 
@@ -108,7 +108,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
   def addAsset(atomId: String) = APIHMACAuthAction { implicit req =>
     implicit val readCommand: Reads[AddAssetCommand] =
       (JsPath \ "uri").read[String].map { videoUri =>
-        AddAssetCommand(atomId, videoUri, stores, youTube, req.user)
+        AddAssetCommand(atomId, videoUri, stores, youtube, req.user)
       }
 
     parse(req) { command: AddAssetCommand =>
@@ -122,7 +122,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
 
   def setActiveAsset(atomId: String) = APIHMACAuthAction { implicit req =>
     parse(req) { request: ActivateAssetRequest =>
-      val command = ActiveAssetCommand(atomId, request, stores, youTube, req.user)
+      val command = ActiveAssetCommand(atomId, request, stores, youtube, req.user)
       val atom = command.process()
 
       Ok(Json.toJson(atom))
@@ -147,7 +147,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
 
   def deleteAtom(id: String) = CanDeleteAtom { implicit req =>
     try {
-      DeleteCommand(id, stores, youTube).process()
+      DeleteCommand(id, stores, youtube).process()
       Ok(s"Atom $id deleted")
     }
     catch {

--- a/app/controllers/Youtube.scala
+++ b/app/controllers/Youtube.scala
@@ -4,6 +4,7 @@ import com.gu.pandahmac.HMACAuthActions
 import play.api.libs.json.Json
 import play.api.mvc.Controller
 import util.YouTube
+import model.commands.CommandExceptions._
 
 class Youtube (val authActions: HMACAuthActions, youTube: YouTube) extends Controller {
   import authActions.AuthAction
@@ -19,5 +20,13 @@ class Youtube (val authActions: HMACAuthActions, youTube: YouTube) extends Contr
     }
 
     Ok(Json.toJson(channels))
+  }
+
+  def commercialVideoInfo(id: String) = AuthAction {
+    try {
+      Ok(Json.toJson(youTube.getCommercialVideoInfo(id)))
+    } catch {
+      commandExceptionAsResult
+    }
   }
 }

--- a/app/di.scala
+++ b/app/di.scala
@@ -46,14 +46,12 @@ class MediaAtomMaker(context: Context)
 
   private val youTube = YouTube(config, defaultCacheApi, 1.hour)
 
-  private val youTubeClaims = new YouTubeClaims(config)
-
   private val uploaderMessageConsumer = PlutoMessageConsumer(stores, aws)
   uploaderMessageConsumer.start(actorSystem.scheduler)(actorSystem.dispatcher)
 
   private val api = new Api(stores, configuration, aws, hmacAuthActions, permissions)
 
-  private val api2 = new Api2(stores, configuration, hmacAuthActions, youTube, youTubeClaims, aws, permissions, capi)
+  private val api2 = new Api2(stores, configuration, hmacAuthActions, youTube, aws, permissions, capi)
 
   private val stepFunctions = new StepFunctions(aws)
   private val uploads = new UploadController(hmacAuthActions, aws, stepFunctions, stores, permissions, youTube)

--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -52,6 +52,10 @@ object YouTubeError extends Logging {
         case (403, Some("usageLimits")) =>
           Some((noAlerts(e), false))
 
+        case (400, Some("youtubePartner.videoAdvertisingOptions.get")) => {
+          Some((noAlerts(e), false))
+        }
+
         case (code, _) =>
           val message = Option(e.getDetails.getMessage).getOrElse("unknown")
 

--- a/app/util/YouTube.scala
+++ b/app/util/YouTube.scala
@@ -1,13 +1,13 @@
 package util
 
 import com.gu.media.logging.Logging
-import com.gu.media.youtube.{YouTubeAccess, YouTubeChannel, YouTubeVideoCategory, YouTubeVideos}
+import com.gu.media.youtube._
 import com.typesafe.config.Config
 import play.api.cache.CacheApi
 
 import scala.concurrent.duration.FiniteDuration
 
-trait YouTube extends Logging with YouTubeAccess with YouTubeVideos {
+trait YouTube extends Logging with YouTubeAccess with YouTubeVideos with YouTubeClaims {
   val cache: CacheApi
   val duration: FiniteDuration
 
@@ -17,6 +17,13 @@ trait YouTube extends Logging with YouTubeAccess with YouTubeVideos {
 
   override def channels: List[YouTubeChannel] = {
     cache.getOrElse("channels", duration) { super.channels }
+  }
+
+  def getCommercialVideoInfo(videoId: String) = {
+    getVideo(videoId, "snippet,contentDetails,status").map(video => {
+      val advertisingOptions = getAdvertisingOptions(videoId)
+      YouTubeVideoCommercialInfo.build(video, advertisingOptions)
+    })
   }
 }
 

--- a/common/src/main/scala/com/gu/media/util/JsonDate.scala
+++ b/common/src/main/scala/com/gu/media/util/JsonDate.scala
@@ -1,5 +1,7 @@
 package com.gu.media.util
 
+import java.time.Duration
+
 import org.joda.time.format.ISODateTimeFormat
 import play.api.libs.json._
 import org.joda.time.DateTime
@@ -15,5 +17,11 @@ object JsonDate {
         case _ => JsError("DateTime can only be extracted from a JsString")
       }
     }
+  }
+}
+
+object ISO8601Duration {
+  def toSeconds(iso8601Duration: String): Long = {
+    Duration.parse(iso8601Duration).toMillis / 1000 // seconds
   }
 }

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
@@ -3,11 +3,11 @@ package com.gu.media.youtube
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.http.javanet.NetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
-import com.google.api.services.youtube.{YouTube => YouTubeClient, YouTubeScopes}
+import com.google.api.services.youtube.{YouTubeScopes, YouTube => YouTubeClient}
 import com.google.api.services.youtubePartner.YouTubePartner
 import com.gu.media.Settings
-import scala.collection.JavaConversions._
 
+import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 
 trait YouTubeAccess extends Settings {

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeClaims.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeClaims.scala
@@ -3,14 +3,13 @@ package com.gu.media.youtube
 import com.google.api.services.youtubePartner.YouTubePartner
 import com.google.api.services.youtubePartner.model._
 import com.gu.media.logging.Logging
-import com.typesafe.config.Config
-import org.joda.time.DateTime
+
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 
 //This class contains functionality to add usage policies to published videos.
 //Videos are either tracked or monetized: https://support.google.com/youtube/answer/107383?hl=en-GB
-class YouTubeClaims(override val config: Config) extends YouTubeAccess with Logging {
+trait YouTubeClaims { this: YouTubeAccess with Logging =>
 
   private def createAsset(title: String, videoId: String, atomId: String): Asset = {
 
@@ -144,5 +143,9 @@ class YouTubeClaims(override val config: Config) extends YouTubeAccess with Logg
         throw e
       }
     }
+  }
+
+  def getAdvertisingOptions(videoId: String): VideoAdvertisingOption = {
+    partnerClient.videoAdvertisingOptions().get(videoId).execute()
   }
 }

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -2,11 +2,11 @@ package com.gu.media.youtube
 
 import java.io.BufferedInputStream
 import java.net.URL
-import java.time.Duration
 
 import com.google.api.client.http.InputStreamContent
 import com.google.api.services.youtube.model.{Video, VideoProcessingDetails, VideoSnippet}
 import com.gu.media.logging.Logging
+import com.gu.media.util.ISO8601Duration
 
 import scala.collection.JavaConverters._
 
@@ -39,8 +39,7 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
         // YouTube API returns duration is in ISO 8601 format
         // https://developers.google.com/youtube/v3/docs/videos#contentDetails.duration
         val iso8601Duration = video.getContentDetails.getDuration
-
-        Some(Duration.parse(iso8601Duration).toMillis / 1000) // seconds
+        Some(ISO8601Duration.toSeconds(iso8601Duration))
       }
       case None => None
     }

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -21,43 +21,7 @@ package object youtube {
       YouTubeVideoCategory(category.getId.toInt, category.getSnippet.getTitle)
     }
   }
-
-  case class YouTubeAdFormat(format: String, description: String)
-
-  object YouTubeAdFormat {
-    implicit val reads: Reads[YouTubeAdFormat] = Json.reads[YouTubeAdFormat]
-    implicit val writes: Writes[YouTubeAdFormat] = Json.writes[YouTubeAdFormat]
-
-    def build(format: String): YouTubeAdFormat = {
-      // definitions lifted from https://developers.google.com/youtube/partner/docs/v1/videoAdvertisingOptions#adFormats[]
-      val description = format match {
-        case "display"              => """Appears to the right of the feature video and above the video suggestions list
-                                      |on www.youtube.com. Not shown on O&O platforms."""
-        case "long"                 => """Long video ads which would be enabled to run for videos that can show standard
-                                      |in-stream ads. Requires standard_instream ads to be enabled."""
-        case "overlay"              => """An ad that is displayed in the video player during video playback.
-                                      |Overlay settings also govern YouTube's ability to display ads in a
-                                      |companion ad slot on the page."""
-        case "product_listing"      => """Ads that feature products related to or featured in the video content.
-                                      |These ads are sponsored cards that display during the video.
-                                      |The cards are added automatically by the ad system.
-                                      |Viewers see a teaser for the card for a few seconds and can also click the icon
-                                      |in the top right corner of the video to browse the video's cards."""
-        case "standard_instream"    => """Non-skippable video ads that play before during, or after the video content.
-                                      |While playing, in-stream ads are the only content displayed in the player."""
-        case "third_party"          => "Advertisements are served by a third-party ad server."
-        case "trueview_inslate"     => """The user has an option to choose one of several ads to run.
-                                      |Requires standard_instream ads to be enabled."""
-        case "trueview_instream"    => """Skippable video ads that run before video playback begins.
-                                      |Advertisers are charged only when a viewer has watched the ad for an agreed
-                                      |length of time or until it ends whichever comes first."""
-        case _                      => "Unknown... Make. It. Rain."
-      }
-
-      YouTubeAdFormat(format = format, description = description.stripMargin.replaceAll("\n", " "))
-    }
-  }
-
+  
   case class YouTubeChannel(id: String, title: String)
 
   object YouTubeChannel {
@@ -106,7 +70,7 @@ package object youtube {
     }
   }
 
-  case class YouTubeAdvertising(id: String, adFormats: Seq[YouTubeAdFormat], adBreaks: Seq[String])
+  case class YouTubeAdvertising(id: String, adFormats: Seq[String], adBreaks: Seq[String])
 
   object YouTubeAdvertising {
     implicit val reads: Reads[YouTubeAdvertising] = Json.reads[YouTubeAdvertising]
@@ -115,8 +79,8 @@ package object youtube {
     def build(videoAdvertisingOption: VideoAdvertisingOption): YouTubeAdvertising = {
       YouTubeAdvertising(
         id = videoAdvertisingOption.getId,
-        adFormats = videoAdvertisingOption.getAdFormats.asScala.toList.map(YouTubeAdFormat.build),
-        adBreaks = videoAdvertisingOption.getAdBreaks.asScala.toList.map(_.getPosition)
+        adFormats = videoAdvertisingOption.getAdFormats.asScala,
+        adBreaks = videoAdvertisingOption.getAdBreaks.asScala.map(_.getPosition)
       )
     }
   }

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -14,7 +14,7 @@ package object youtube {
   case class YouTubeVideoCategory(id: Int, title: String)
   case class YouTubeChannel(id: String, title: String)
   case class YouTubeVideo(id: String, title: String, duration: Long, publishedAt: DateTime, privacyStatus: String, tags: Seq[String], channel: YouTubeChannel)
-  case class YouTubeAdvertising(id: String, adFormats: Seq[String], adBreaks: Seq[String])
+  case class YouTubeAdvertising(id: String, adFormats: Seq[YouTubeAdFormat], adBreaks: Seq[String])
   case class YouTubeVideoCommercialInfo (video: YouTubeVideo, advertising: YouTubeAdvertising)
 
   object YouTubeVideoCategory {
@@ -23,6 +23,42 @@ package object youtube {
 
     def build(category: VideoCategory): YouTubeVideoCategory = {
       YouTubeVideoCategory(category.getId.toInt, category.getSnippet.getTitle)
+    }
+  }
+
+  case class YouTubeAdFormat(format: String, description: String)
+
+  object YouTubeAdFormat {
+    implicit val reads: Reads[YouTubeAdFormat] = Json.reads[YouTubeAdFormat]
+    implicit val writes: Writes[YouTubeAdFormat] = Json.writes[YouTubeAdFormat]
+
+    def build(format: String): YouTubeAdFormat = {
+      // definitions lifted from https://developers.google.com/youtube/partner/docs/v1/videoAdvertisingOptions#adFormats[]
+      val description = format match {
+        case "display"              => """Appears to the right of the feature video and above the video suggestions list
+                                      |on www.youtube.com. Not shown on O&O platforms."""
+        case "long"                 => """Long video ads which would be enabled to run for videos that can show standard
+                                      |in-stream ads. Requires standard_instream ads to be enabled."""
+        case "overlay"              => """An ad that is displayed in the video player during video playback.
+                                      |Overlay settings also govern YouTube's ability to display ads in a
+                                      |companion ad slot on the page."""
+        case "product_listing"      => """Ads that feature products related to or featured in the video content.
+                                      |These ads are sponsored cards that display during the video.
+                                      |The cards are added automatically by the ad system.
+                                      |Viewers see a teaser for the card for a few seconds and can also click the icon
+                                      |in the top right corner of the video to browse the video's cards."""
+        case "standard_instream"    => """Non-skippable video ads that play before during, or after the video content.
+                                      |While playing, in-stream ads are the only content displayed in the player."""
+        case "third_party"          => "Advertisements are served by a third-party ad server."
+        case "trueview_inslate"     => """The user has an option to choose one of several ads to run.
+                                      |Requires standard_instream ads to be enabled."""
+        case "trueview_instream"    => """Skippable video ads that run before video playback begins.
+                                      |Advertisers are charged only when a viewer has watched the ad for an agreed
+                                      |length of time or until it ends whichever comes first."""
+        case _                      => "Unknown... Make. It. Rain."
+      }
+
+      YouTubeAdFormat(format = format, description = description.stripMargin.replaceAll("\n", " "))
     }
   }
 
@@ -67,7 +103,7 @@ package object youtube {
     def build(videoAdvertisingOption: VideoAdvertisingOption): YouTubeAdvertising = {
       YouTubeAdvertising(
         id = videoAdvertisingOption.getId,
-        adFormats = videoAdvertisingOption.getAdFormats.asScala.toList,
+        adFormats = videoAdvertisingOption.getAdFormats.asScala.toList.map(YouTubeAdFormat.build),
         adBreaks = videoAdvertisingOption.getAdBreaks.asScala.toList.map(_.getPosition)
       )
     }

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -21,7 +21,7 @@ package object youtube {
       YouTubeVideoCategory(category.getId.toInt, category.getSnippet.getTitle)
     }
   }
-  
+
   case class YouTubeChannel(id: String, title: String)
 
   object YouTubeChannel {
@@ -36,7 +36,7 @@ package object youtube {
     }
   }
 
-  case class YouTubeVideo (
+  case class YouTubeVideoDetail(
      id: String,
      title: String,
      duration: Long,
@@ -47,17 +47,17 @@ package object youtube {
      channel: YouTubeChannel
   )
 
-  object YouTubeVideo {
-    implicit val reads: Reads[YouTubeVideo] = Json.reads[YouTubeVideo]
-    implicit val writes: Writes[YouTubeVideo] = Json.writes[YouTubeVideo]
+  object YouTubeVideoDetail {
+    implicit val reads: Reads[YouTubeVideoDetail] = Json.reads[YouTubeVideoDetail]
+    implicit val writes: Writes[YouTubeVideoDetail] = Json.writes[YouTubeVideoDetail]
 
-    def build(video: Video): YouTubeVideo = {
+    def build(video: Video): YouTubeVideoDetail = {
       val tags: Seq[String] = video.getSnippet.getTags match {
         case null => List()
         case t => t.asScala
       }
 
-      YouTubeVideo(
+      YouTubeVideoDetail(
         id = video.getId,
         title = video.getSnippet.getTitle,
         duration = ISO8601Duration.toSeconds(video.getContentDetails.getDuration),
@@ -85,7 +85,7 @@ package object youtube {
     }
   }
 
-  case class YouTubeVideoCommercialInfo (video: YouTubeVideo, advertising: YouTubeAdvertising)
+  case class YouTubeVideoCommercialInfo (video: YouTubeVideoDetail, advertising: YouTubeAdvertising)
 
   object YouTubeVideoCommercialInfo {
     implicit val reads: Reads[YouTubeVideoCommercialInfo] = Json.reads[YouTubeVideoCommercialInfo]
@@ -93,7 +93,7 @@ package object youtube {
 
     def build(video: Video, videoAdvertisingOption: VideoAdvertisingOption): YouTubeVideoCommercialInfo = {
       YouTubeVideoCommercialInfo (
-        video = YouTubeVideo.build(video),
+        video = YouTubeVideoDetail.build(video),
         advertising = YouTubeAdvertising.build(videoAdvertisingOption)
       )
     }

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -1,15 +1,11 @@
 package com.gu.media
 
-import java.net.URI
-
 import com.google.api.services.youtube.model.{Channel, Video, VideoCategory}
 import com.google.api.services.youtubePartner.model.VideoAdvertisingOption
-import com.gu.media.logging.Logging
 import com.gu.media.util.ISO8601Duration
-import com.typesafe.config.Config
-import org.cvogt.play.json.Jsonx
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+
 import scala.collection.JavaConverters._
 import org.joda.time.DateTime
 import com.gu.media.util.JsonDate._
@@ -47,13 +43,18 @@ package object youtube {
     implicit val writes: Writes[YouTubeVideo] = Json.writes[YouTubeVideo]
 
     def build(video: Video): YouTubeVideo = {
+      val tags: Seq[String] = video.getSnippet.getTags match {
+        case null => List()
+        case t => t.asScala
+      }
+
       YouTubeVideo(
         id = video.getId,
         title = video.getSnippet.getTitle,
         duration = ISO8601Duration.toSeconds(video.getContentDetails.getDuration),
         publishedAt = new DateTime(video.getSnippet.getPublishedAt.toString),
         privacyStatus = video.getStatus.getPrivacyStatus,
-        tags = video.getSnippet.getTags.asScala,
+        tags = tags,
         channel = YouTubeChannel(id = video.getSnippet.getChannelId, title = video.getSnippet.getChannelTitle)
       )
     }

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -12,10 +12,6 @@ import com.gu.media.util.JsonDate._
 
 package object youtube {
   case class YouTubeVideoCategory(id: Int, title: String)
-  case class YouTubeChannel(id: String, title: String)
-  case class YouTubeVideo(id: String, title: String, duration: Long, publishedAt: DateTime, privacyStatus: String, tags: Seq[String], channel: YouTubeChannel)
-  case class YouTubeAdvertising(id: String, adFormats: Seq[YouTubeAdFormat], adBreaks: Seq[String])
-  case class YouTubeVideoCommercialInfo (video: YouTubeVideo, advertising: YouTubeAdvertising)
 
   object YouTubeVideoCategory {
     implicit val reads: Reads[YouTubeVideoCategory] = Json.reads[YouTubeVideoCategory]
@@ -62,6 +58,8 @@ package object youtube {
     }
   }
 
+  case class YouTubeChannel(id: String, title: String)
+
   object YouTubeChannel {
     implicit val reads: Reads[YouTubeChannel] = Json.reads[YouTubeChannel]
     implicit val writes: Writes[YouTubeChannel] = Json.writes[YouTubeChannel]
@@ -73,6 +71,17 @@ package object youtube {
       )
     }
   }
+
+  case class YouTubeVideo (
+     id: String,
+     title: String,
+     duration: Long,
+     publishedAt: DateTime,
+     privacyStatus: String,
+     tags: Seq[String],
+     contentBundleTags: Seq[String],
+     channel: YouTubeChannel
+  )
 
   object YouTubeVideo {
     implicit val reads: Reads[YouTubeVideo] = Json.reads[YouTubeVideo]
@@ -91,10 +100,13 @@ package object youtube {
         publishedAt = new DateTime(video.getSnippet.getPublishedAt.toString),
         privacyStatus = video.getStatus.getPrivacyStatus,
         tags = tags,
+        contentBundleTags = tags.filter(t => t.startsWith("gdnpfp")),
         channel = YouTubeChannel(id = video.getSnippet.getChannelId, title = video.getSnippet.getChannelTitle)
       )
     }
   }
+
+  case class YouTubeAdvertising(id: String, adFormats: Seq[YouTubeAdFormat], adBreaks: Seq[String])
 
   object YouTubeAdvertising {
     implicit val reads: Reads[YouTubeAdvertising] = Json.reads[YouTubeAdvertising]
@@ -108,6 +120,8 @@ package object youtube {
       )
     }
   }
+
+  case class YouTubeVideoCommercialInfo (video: YouTubeVideo, advertising: YouTubeAdvertising)
 
   object YouTubeVideoCommercialInfo {
     implicit val reads: Reads[YouTubeVideoCommercialInfo] = Json.reads[YouTubeVideoCommercialInfo]

--- a/conf/routes
+++ b/conf/routes
@@ -49,6 +49,7 @@ GET     /api2/audits/:id                controllers.Api2.getAuditTrailForAtomId(
 
 GET     /api/youtube/categories         controllers.Youtube.listCategories()
 GET     /api/youtube/channels           controllers.Youtube.listChannels()
+GET     /api/youtube/video-info/:id     controllers.Youtube.commercialVideoInfo(id)
 
 GET     /api/transcoder/jobStatus       controllers.Transcoder.jobStatus
 

--- a/public/video-ui/src/components/Help/Help.js
+++ b/public/video-ui/src/components/Help/Help.js
@@ -17,6 +17,10 @@ export default class Help extends React.Component {
     {
       url: 'https://docs.google.com/document/d/1Ey9BcoeUsZSTnVomQCRnGwdlO7akVceJZUYJihPd4xk/edit#',
       text: 'HOW TO FIX - Media Atom Maker creating invalid Composer Pages'
+    },
+    {
+      url: 'https://docs.google.com/document/d/1jJuO09QO4GaYC0yirh8Mce2fOd2u0IdTXPF4OmtvD9M/edit#',
+      text: 'Commercial FAQs'
     }
   ];
 


### PR DESCRIPTION
As part of the Commercial training for selling YouTube, one of the troubleshooting topics is: "Why isn't this video showing in DfP?".

One way to answer that is to login to the YouTube CMS and find the video. However this requires adding users to the CMS. This endpoint will call the YouTube Partner API and display the advertising options for a video and error if the video isn't claimed or isn't owned by the content owner.

The endpoint is `/api/youtube/video-info/:id` and is Panda Authed.

As part of this, I've refactored YouTubeClaims as a trait, following the YouTubeVideos pattern. I've also simplified the `YouTubeChannel` case class, removing `logo` as its never used.

Example response:

```json
{
  "video": {
    "id": "cDoV2d4cMfI",
    "title": "Mohamed Salah: I joined Liverpool to win trophies",
    "duration": 41,
    "publishedAt": "2017-06-23T12:47:02.000+01:00",
    "privacyStatus": "public",
    "tags": [
      "Mohamed Salah",
      "Salah",
      "Liverpool",
      "Premier League",
      "Football",
      "gdnpfpsportfootball",
      "Sport"
    ],
    "contentBundleTags": [
      "gdnpfpsportfootball"
    ],
    "channel": {
      "id": "UCNHqb1IRxQ5WBsWtO53JL2g",
      "title": "Guardian Football"
    }
  },
  "advertising": {
    "id": "cDoV2d4cMfI",
    "adFormats": [
      "standard_instream",
      "trueview_instream",
      "product_listing",
      "display"
    ],
    "adBreaks": [
      "preroll"
    ]
  }
}
```