### PR TITLE
More atom fields can be added on create

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -11,7 +11,7 @@ import _root_.util.{ActivateAssetRequest, YouTube}
 import data.DataStores
 import model.commands.CommandExceptions._
 import model.commands._
-import model.{MediaAtom, WorkflowMediaAtom}
+import model.{MediaAtom, WorkflowMediaAtom, MediaAtomBeforeCreation}
 import play.api.Configuration
 import util.{AWSConfig, CORSable}
 import util.atom.MediaAtomImplicits
@@ -78,7 +78,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
   }
 
   def createMediaAtom = APIAuthAction { implicit req =>
-    parse(req) { data: CreateAtomCommandData =>
+    parse(req) { data: MediaAtomBeforeCreation =>
       val command = CreateAtomCommand(data, stores, req.user)
       val atom = command.process()
 

--- a/public/video-ui/src/constants/blankVideoData.js
+++ b/public/video-ui/src/constants/blankVideoData.js
@@ -8,5 +8,10 @@ export const blankVideoData = {
   privacyStatus: 'Unlisted',
   assets: [],
   trailText: '',
-  tags: []
+  tags: [],
+  byline: [],
+  keywords: [],
+  commentsEnabled: false,
+  commissioningDesks: [],
+  blockAds: false
 };


### PR DESCRIPTION
- Previously, on atom creation, the request data for creating an atom was parsed into its own class. New atom fields had not been added to this class so some fields could not be added on create
- This change creates a new `MediaAtomBeforeCreation` class that is related to the the `MediaAtom` class. Thrift serialisers are now in one file as well. 
- I'm not sure if this is the neatest way of doing this. The simplest solution would have been to just add new fields to the `CreateAtomCommandData` class and to the subsequent thrift serialisation but it is easy to miss this step and introduce more similar bugs. 