### PR TITLE
Video poster size

### DIFF
--- a/public/video-ui/src/components/VideoPreview/VideoPreview.js
+++ b/public/video-ui/src/components/VideoPreview/VideoPreview.js
@@ -24,7 +24,7 @@ export default class VideoPreview extends React.Component {
     }
 
     if (active.length === 1 && active[0].platform === 'Youtube') {
-      return <YouTubeEmbed id={active[0].id} className="baseline-margin" />;
+      return <YouTubeEmbed id={active[0].id} className="video__preview__player" />;
     }
 
     const sources = active.map(asset => {
@@ -37,7 +37,9 @@ export default class VideoPreview extends React.Component {
   render() {
     return (
       <div className="video-preview">
+      <div className="video__preview__container">
         {this.renderPreview()}
+      </div>
         <div className="video__detailbox">
           <div className="video__detailbox__header__container">
             <header className="video__detailbox__header">

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -28,6 +28,22 @@
   &__header {
     display: block;
   }
+  padding: 10px;
+}
+
+.video__preview__player {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+}
+
+.video__preview__container {
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-bottom: 57.5%;
 }
 
 .video-assets__show-btn {


### PR DESCRIPTION
Fixes the video poster ratio to 16 * 9. 

Not sure if using viewport could cause problems later, but I set the width of the poster image container as well so that they always have the same width. 

I didn't want to use jquery and other approaches suggested [here](https://stackoverflow.com/questions/5445491/height-equal-to-dynamic-width-css-fluid-layout) caused the whole player to disappear. 
<img width="1408" alt="screen shot 2017-07-18 at 08 47 58" src="https://user-images.githubusercontent.com/3066534/28306074-dae08462-6b95-11e7-9585-4d5817b2f2ab.png">
