### PR TITLE
allow calls to Partner API to be stopped based on config value

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -96,10 +96,11 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youtu
   private def updateYouTube(previewAtom: MediaAtom, asset: Asset): Future[MediaAtom] = {
     previewAtom.channelId match {
       case Some(channel) if youtube.allowedChannels.contains(channel) =>
+        if (youtube.usePartnerApi) {
+          createOrUpdateYoutubeClaim(previewAtom, asset)
+        }
         updateYoutubeMetadata(previewAtom, asset)
         updateYoutubeThumbnail(previewAtom, asset)
-        createOrUpdateYoutubeClaim(previewAtom, asset)
-
       case Some(_) =>
         // third party YouTube video that we do not have permission to edit
         Future.successful(previewAtom)

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
@@ -15,6 +15,7 @@ trait YouTubeAccess extends Settings {
   def contentOwner: String = getMandatoryString("youtube.contentOwner")
   val allowedChannels: List[String] = getStringList("youtube.allowedChannels")
   val disallowedVideos: List[String] = getStringList("youtube.disallowedVideos")
+  val usePartnerApi: Boolean = getString("youtube.usePartnerApi").forall(_.toBoolean)
 
   def clientId = getMandatoryString("youtube.clientId")
   def clientSecret = getMandatoryString("youtube.clientSecret")


### PR DESCRIPTION
defaulting to `true`

useful for the tools training session