### PR TITLE
fix integration tests

### DIFF
--- a/integration-tests/src/test/scala/services/TestAtomJsonGenerator.scala
+++ b/integration-tests/src/test/scala/services/TestAtomJsonGenerator.scala
@@ -14,6 +14,12 @@ trait TestAtomJsonGenerator {
       "youtubeCategory": "$youtubeCategoryId",
       "youtubeChannel": "$channelId",
       "expiryDate": $expiryDate,
+      "tags": [],
+      "byline": [],
+      "commissioningDesks": [],
+      "keywords": [],
+      "commentsEnabled": false,
+      "blockAds": false,
       "posterImage": {
         "assets": [
           {


### PR DESCRIPTION
The json blob we were POSTing wasn't deserialising to the new `MediaAtomBeforeCreation` case class so the tests were failing. Adding the missing fields and we're winning!