### PR TITLE
min duration for ads

### DIFF
--- a/app/controllers/VideoUIApp.scala
+++ b/app/controllers/VideoUIApp.scala
@@ -3,6 +3,7 @@ package controllers
 
 import com.gu.media.MediaAtomMakerPermissionsProvider
 import com.gu.media.logging.Logging
+import com.gu.media.youtube.YouTubeAccess
 import com.gu.pandahmac.HMACAuthActions
 import com.gu.pandomainauth.model.User
 import model.{ClientConfig, Presence}
@@ -13,7 +14,7 @@ import play.api.mvc.Controller
 import util.AWSConfig
 
 class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfig: AWSConfig,
-                 permissions: MediaAtomMakerPermissionsProvider) extends Controller with Logging {
+                 permissions: MediaAtomMakerPermissionsProvider, youtube: YouTubeAccess) extends Controller with Logging {
   import authActions.AuthAction
 
   def index(id: String = "") = AuthAction.async { req =>
@@ -48,7 +49,8 @@ class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfi
         ravenUrl = conf.getString("raven.url").get,
         stage = conf.getString("stage").get,
         viewerUrl = awsConfig.viewerUrl,
-        permissions
+        permissions,
+        minDurationForAds = youtube.minDurationForAds
       )
 
       Ok(views.html.VideoUIApp.app(

--- a/app/di.scala
+++ b/app/di.scala
@@ -65,7 +65,7 @@ class MediaAtomMaker(context: Context)
   private val transcoderController = new controllers.Transcoder(hmacAuthActions, transcoder)
 
   private val mainApp = new MainApp(stores, wsClient, configuration, hmacAuthActions, permissions, aws)
-  private val videoApp = new VideoUIApp(hmacAuthActions, configuration, aws, permissions)
+  private val videoApp = new VideoUIApp(hmacAuthActions, configuration, aws, permissions, youTube)
 
   private val assets = new controllers.Assets(httpErrorHandler)
 

--- a/app/model/ClientConfig.scala
+++ b/app/model/ClientConfig.scala
@@ -24,7 +24,8 @@ case class ClientConfig(presence: Option[Presence],
                         stage: String,
                         viewerUrl: String,
                         // permissions also validated server-side on every request
-                        permissions: Permissions
+                        permissions: Permissions,
+                        minDurationForAds: Long
                        )
 
 object ClientConfig {

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -40,8 +40,11 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youtu
 
     getActiveAsset(previewAtom) match {
       case Some(asset) if asset.platform == Youtube =>
-        val atomWithDuration = previewAtom.copy(duration = youtube.getDuration(asset.id))
-        updateYouTube(atomWithDuration, asset).map(atomWithYoutubeUpdates => {
+        val duration = youtube.getDuration(asset.id)
+        val blockAds = if (duration.getOrElse(0L) < youtube.minDurationForAds) false else previewAtom.blockAds
+
+        val updatedPreviewAtom = previewAtom.copy(duration = duration, blockAds = blockAds)
+        updateYouTube(updatedPreviewAtom, asset).map(atomWithYoutubeUpdates => {
           publish(atomWithYoutubeUpdates, user)
         })
 

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
@@ -23,6 +23,8 @@ trait YouTubeAccess extends Settings {
   def monetizationPolicyId = getMandatoryString("youtube.monetizationPolicyId")
   def trackingPolicyId = getMandatoryString("youtube.trackingPolicyId")
 
+  def minDurationForAds: Long = getString("youtube.minDurationForAds").getOrElse("30").toLong
+
   private val httpTransport = new NetHttpTransport()
   private val jacksonFactory = new JacksonFactory()
 

--- a/public/video-ui/src/components/FormFields/CheckBox.js
+++ b/public/video-ui/src/components/FormFields/CheckBox.js
@@ -22,7 +22,7 @@ export default class CheckBox extends React.Component {
 
   render() {
     return (
-      <div>
+      <div data-tip={this.props.tooltip}>
         <p className="details-list__title">{this.props.fieldName}</p>
         <div className="details-list__labeled-filter">
           {this.renderCheckbox()}

--- a/public/video-ui/src/components/ManagedForm/ManagedField.js
+++ b/public/video-ui/src/components/ManagedForm/ManagedField.js
@@ -25,7 +25,8 @@ export class ManagedField extends React.Component {
     maxLength: PropTypes.number,
     fieldDetails: PropTypes.string,
     tagType: PropTypes.string,
-    inputPlaceholder: PropTypes.string
+    inputPlaceholder: PropTypes.string,
+    tooltip: PropTypes.string
   };
 
   state = {
@@ -138,7 +139,8 @@ export class ManagedField extends React.Component {
         derivedFrom: this.props.derivedFrom,
         maxCharLength: this.props.maxCharLength,
         tagType: this.props.tagType,
-        inputPlaceholder: this.props.inputPlaceholder
+        inputPlaceholder: this.props.inputPlaceholder,
+        tooltip: this.props.tooltip
       });
     });
     return <div className={className}>{hydratedChildren}</div>;

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -11,6 +11,7 @@ import { fieldLengths } from '../../constants/videoEditValidation';
 import { videoCategories } from '../../constants/videoCategories';
 import { privacyStates } from '../../constants/privacyStates';
 import { channelAllowed } from '../../util/channelAllowed';
+import { getStore } from '../../util/storeAccessor';
 
 class VideoData extends React.Component {
   hasCategories = () => this.props.youtube.categories.length !== 0;
@@ -132,6 +133,7 @@ class VideoData extends React.Component {
               name="Block ads"
               fieldDetails="Ads will not be displayed with this video"
               disabled={notOnManagedChannel}
+              tooltip={`Videos less than ${getStore().getState().config.minDurationForAds} seconds will automatically have ads blocked`}
             >
               <CheckBox />
             </ManagedField>


### PR DESCRIPTION
As requested by Commercial, automatically block ads when a video is less than 30 seconds.

We only do this on Publish rather than on Update and Publish so as to keep interaction with an external API to a minimum, thus keeping Update fast.

Displays a tooltip too, for clarity to the User.

![image](https://user-images.githubusercontent.com/836140/28498177-96d2b8f4-6f90-11e7-9e80-16ef36599967.png)
