### PR TITLE
smaller web assets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,8 @@ lazy val app = (project in file("."))
     debianPackageDependencies := Seq("openjdk-8-jre-headless"),
     maintainer := "Digital CMS <digitalcms.dev@guardian.co.uk>",
     packageSummary := "media-atom-maker",
-    packageDescription := """making media atoms"""
+    packageDescription := """making media atoms""",
+    pipelineStages := Seq(digest, gzip)
   )
 
 lazy val uploader = (project in file("uploader"))

--- a/conf/routes
+++ b/conf/routes
@@ -61,7 +61,7 @@ GET     /reindex-preview                com.gu.atom.play.ReindexController.previ
 GET     /reindex-publish                com.gu.atom.play.ReindexController.publishedReindexJobStatus()
 
 #static assets
-GET  /assets/*file                      controllers.Assets.versioned(path="/public", file)
+GET  /assets/*file                      controllers.Assets.versioned(path="/public", file: Asset)
 
 # Auth
 GET  /reauth                            controllers.VideoUIApp.reauth


### PR DESCRIPTION
use digest for hashing and gzip for compression

this gets the js down from ~2mb to ~400kb

TODO:
- [x] make sure the angular app still works