### PR TITLE
Tag picker fixes

### DIFF
--- a/public/video-ui/src/components/CapiSearch/CapiSearch.js
+++ b/public/video-ui/src/components/CapiSearch/CapiSearch.js
@@ -1,0 +1,44 @@
+ import React from 'react';
+import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
+
+export default class CapiSearch extends React.Component {
+
+  renderTags(tag) {
+    const addTag = () => {
+
+      const valueWithoutStringDupes = this.props.removeDupes(
+        tag,
+        this.props.tagValue
+      );
+
+      const newFieldValue = valueWithoutStringDupes.concat([tag]);
+
+      this.props.selectNewTag(newFieldValue);
+
+    };
+
+    return (
+      <a
+        className="form__field__tags"
+        key={tag.id}
+        title={tag.id}
+        onClick={addTag}
+      >
+        {' '}{tag.webTitle}{' '}
+      </a>
+    );
+  }
+
+  render() {
+
+    if (this.props.capiTags.length !== 0 && this.props.showTags) {
+      return (
+        <div className="form__field__tags" onMouseDown={this.props.tagsToVisible}>
+          {this.props.capiTags.map(tag => this.renderTags(tag))}
+        </div>
+      );
+    }
+
+    return null;
+  }
+}

--- a/public/video-ui/src/components/CapiSearch/CapiSearch.js
+++ b/public/video-ui/src/components/CapiSearch/CapiSearch.js
@@ -7,7 +7,10 @@ export default class CapiSearch extends React.Component {
     if (this.props.selectedTagIndex !== nextProps.selectedTagIndex && nextProps.selectedTagIndex !== null) {
       const selectedTag = this.props.capiTags[nextProps.selectedTagIndex];
       const listNode = this.refs.list;
-      listNode.scrollTop = 35 * (nextProps.selectedTagIndex === 0 ? 0 : nextProps.selectedTagIndex - 1)
+      const elementHeight = listNode.children[0].offsetHeight;
+      if (listNode) {
+        listNode.scrollTop = elementHeight * (nextProps.selectedTagIndex === 0 ? 0 : nextProps.selectedTagIndex - 1)
+      }
     }
   }
 

--- a/public/video-ui/src/components/CapiSearch/CapiSearch.js
+++ b/public/video-ui/src/components/CapiSearch/CapiSearch.js
@@ -17,10 +17,9 @@ export default class CapiSearch extends React.Component {
   renderTags(tag, index) {
 
     const getTagClassName = () => {
-      const name = "form__field__tags" + (index === this.props.selectedTagIndex ? " form__field__tags--selected" : "");
-
       return "form__field__tags" + (index === this.props.selectedTagIndex ? " form__field__tags--selected" : "");
     }
+
     const addTag = () => {
 
       const valueWithoutStringDupes = this.props.removeDupes(
@@ -35,14 +34,14 @@ export default class CapiSearch extends React.Component {
     };
 
     return (
-      <a
+      <li
         className={getTagClassName()}
         key={tag.id}
         title={tag.id}
         onClick={addTag}
       >
         {' '}{tag.webTitle}{' '}
-      </a>
+      </li>
     );
   }
 
@@ -50,9 +49,9 @@ export default class CapiSearch extends React.Component {
 
     if (this.props.capiTags.length !== 0 && this.props.showTags) {
       return (
-        <div ref="list" className="form__field__tags" onMouseDown={this.props.tagsToVisible}>
+        <ul ref="list" className="form__field__tags" onMouseDown={this.props.tagsToVisible}>
           {this.props.capiTags.map((tag, index) => this.renderTags(tag, index))}
-        </div>
+        </ul>
       );
     }
 

--- a/public/video-ui/src/components/CapiSearch/CapiSearch.js
+++ b/public/video-ui/src/components/CapiSearch/CapiSearch.js
@@ -3,7 +3,13 @@ import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
 
 export default class CapiSearch extends React.Component {
 
-  renderTags(tag) {
+  renderTags(tag, index) {
+
+    const getTagClassName = () => {
+      const name = "form__field__tags" + (index === this.props.selectedTagIndex ? " form__field__tags--selected" : "");
+
+      return "form__field__tags" + (index === this.props.selectedTagIndex ? " form__field__tags--selected" : "");
+    }
     const addTag = () => {
 
       const valueWithoutStringDupes = this.props.removeDupes(
@@ -19,7 +25,7 @@ export default class CapiSearch extends React.Component {
 
     return (
       <a
-        className="form__field__tags"
+        className={getTagClassName()}
         key={tag.id}
         title={tag.id}
         onClick={addTag}
@@ -34,7 +40,7 @@ export default class CapiSearch extends React.Component {
     if (this.props.capiTags.length !== 0 && this.props.showTags) {
       return (
         <div className="form__field__tags" onMouseDown={this.props.tagsToVisible}>
-          {this.props.capiTags.map(tag => this.renderTags(tag))}
+          {this.props.capiTags.map((tag, index) => this.renderTags(tag, index))}
         </div>
       );
     }

--- a/public/video-ui/src/components/CapiSearch/CapiSearch.js
+++ b/public/video-ui/src/components/CapiSearch/CapiSearch.js
@@ -1,7 +1,15 @@
- import React from 'react';
+import React from 'react';
 import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
 
 export default class CapiSearch extends React.Component {
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.selectedTagIndex !== nextProps.selectedTagIndex && nextProps.selectedTagIndex !== null) {
+      const selectedTag = this.props.capiTags[nextProps.selectedTagIndex];
+      const listNode = this.refs.list;
+      listNode.scrollTop = 35 * (nextProps.selectedTagIndex === 0 ? 0 : nextProps.selectedTagIndex - 1)
+    }
+  }
 
   renderTags(tag, index) {
 
@@ -39,7 +47,7 @@ export default class CapiSearch extends React.Component {
 
     if (this.props.capiTags.length !== 0 && this.props.showTags) {
       return (
-        <div className="form__field__tags" onMouseDown={this.props.tagsToVisible}>
+        <div ref="list" className="form__field__tags" onMouseDown={this.props.tagsToVisible}>
           {this.props.capiTags.map((tag, index) => this.renderTags(tag, index))}
         </div>
       );

--- a/public/video-ui/src/components/CapiSearch/CapiSearch.js
+++ b/public/video-ui/src/components/CapiSearch/CapiSearch.js
@@ -4,7 +4,7 @@ import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
 export default class CapiSearch extends React.Component {
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.selectedTagIndex !== nextProps.selectedTagIndex && nextProps.selectedTagIndex !== null) {
+    if (nextProps.selectedTagIndex !== null && this.props.selectedTagIndex !== nextProps.selectedTagIndex) {
       const selectedTag = this.props.capiTags[nextProps.selectedTagIndex];
       const listNode = this.refs.list;
       const elementHeight = listNode.children[0].offsetHeight;

--- a/public/video-ui/src/components/CapiSearch/CapiUnavailable.js
+++ b/public/video-ui/src/components/CapiSearch/CapiUnavailable.js
@@ -5,9 +5,9 @@
   render() {
     if (this.props.capiUnavailable) {
       return (
-        <span className="form__field--external__error">
+        <div className="form__field--external__error">
           Tags are currently unavailable
-        </span>
+        </div>
       );
     }
 

--- a/public/video-ui/src/components/CapiSearch/CapiUnavailable.js
+++ b/public/video-ui/src/components/CapiSearch/CapiUnavailable.js
@@ -1,0 +1,17 @@
+ import React from 'react';
+
+ export default class CapiUnavailable extends React.Component {
+
+  render() {
+    if (this.props.capiUnavailable) {
+      return (
+        <span className="form__field--external__error">
+          Tags are currently unavailable
+        </span>
+      );
+    }
+
+    return null;
+  }
+
+ }

--- a/public/video-ui/src/components/CapiSearch/CapiUnavailable.js
+++ b/public/video-ui/src/components/CapiSearch/CapiUnavailable.js
@@ -5,7 +5,7 @@
   render() {
     if (this.props.capiUnavailable) {
       return (
-        <div className="form__field--external__error">
+        <div className="form__field--external-error">
           Tags are currently unavailable
         </div>
       );

--- a/public/video-ui/src/components/FormFields/PureTagPicker.js
+++ b/public/video-ui/src/components/FormFields/PureTagPicker.js
@@ -19,30 +19,14 @@ export default class PureTagPicker extends React.Component {
     });
   }
 
+  removeFn = () => {
+    const newFieldValue = this.props.tagValue.filter(oldField => {
+      return tag.id !== oldField.id;
+    });
 
-  renderSelectedTags = (tag, index) => {
+    this.props.onUpdate(newFieldValue);
+  };
 
-    const removeFn = () => {
-      const newFieldValue = this.props.tagValue.filter(oldField => {
-        return tag.id !== oldField.id;
-      });
-
-      this.props.onUpdate(newFieldValue);
-    };
-
-    return (
-      <div
-        key={`${tag.id}-${index}`}
-        className="form__field__selected__tag"
-      >
-        <span>
-          {tag.webTitle}
-        </span>
-        <span className="form__field__tag__remove"
-        onClick={removeFn}></span>
-      </div>
-    );
-  }
 
   selectNewTag = (newFieldValue) => {
 
@@ -90,9 +74,6 @@ export default class PureTagPicker extends React.Component {
           removeDupes={removeStringTagDuplicates}
         />
 
-        {this.props.tagValue.map(tag => {
-          return this.renderSelectedTags(tag);
-        })}
       </div>
     );
   }

--- a/public/video-ui/src/components/FormFields/PureTagPicker.js
+++ b/public/video-ui/src/components/FormFields/PureTagPicker.js
@@ -2,7 +2,7 @@ import React from 'react';
 import TagTypes from '../../constants/TagTypes';
 import DragSortableList from 'react-drag-sortable';
 import CapiSearch from '../CapiSearch/Capisearch';
-import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
+import removeTagDuplicates from '../../util/removeTagDuplicates';
 
 export default class PureTagPicker extends React.Component {
 
@@ -71,7 +71,7 @@ export default class PureTagPicker extends React.Component {
           tagsToVisible={this.props.tagsToVisible}
           selectNewTag={this.selectNewTag}
           tagValue={this.props.tagValue}
-          removeDupes={removeStringTagDuplicates}
+          removeDupes={removeTagDuplicates}
         />
 
       </div>

--- a/public/video-ui/src/components/FormFields/PureTagPicker.js
+++ b/public/video-ui/src/components/FormFields/PureTagPicker.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import TagTypes from '../../constants/TagTypes';
 import DragSortableList from 'react-drag-sortable';
-import CapiSearch from '../CapiSearch/Capisearch';
+import CapiSearch from '../CapiSearch/CapiSearch';
 import removeTagDuplicates from '../../util/removeTagDuplicates';
 
 export default class PureTagPicker extends React.Component {

--- a/public/video-ui/src/components/FormFields/PureTagPicker.js
+++ b/public/video-ui/src/components/FormFields/PureTagPicker.js
@@ -7,7 +7,7 @@ import removeTagDuplicates from '../../util/removeTagDuplicates';
 export default class PureTagPicker extends React.Component {
 
   state = {
-    inputString: ''
+    inputString: '',
   };
 
   updateInput = e => {
@@ -38,15 +38,7 @@ export default class PureTagPicker extends React.Component {
     };
 
     return (
-      <div className="form__row"
-        onBlur={this.props.hideTagResults}
-        onMouseDown={this.props.showTagResults}
-      >
-
-        <div className="form__label__layout">
-          <label className="form__label">{this.props.fieldName}</label>
-        </div>
-
+      <div>
         <input
           type="text"
           className="form__field"
@@ -63,6 +55,7 @@ export default class PureTagPicker extends React.Component {
           selectNewTag={this.selectNewTag}
           tagValue={this.props.tagValue}
           removeDupes={removeTagDuplicates}
+          selectedTagIndex={this.props.selectedTagIndex}
         />
 
       </div>

--- a/public/video-ui/src/components/FormFields/PureTagPicker.js
+++ b/public/video-ui/src/components/FormFields/PureTagPicker.js
@@ -38,20 +38,13 @@ export default class PureTagPicker extends React.Component {
 
   render() {
 
-    const getInputPlaceholder = () => {
-      if (!this.props.fieldValue || this.props.fieldValue.length === 0) {
-        return this.props.inputPlaceholder;
-      }
-      return '';
-    };
-
     return (
       <div>
         <input
           type="text"
           className="form__field"
           onChange={this.updateInput}
-          placeholder={getInputPlaceholder()}
+          placeholder={this.props.inputPlaceholder}
           value={this.state.inputString}
         />
 

--- a/public/video-ui/src/components/FormFields/PureTagPicker.js
+++ b/public/video-ui/src/components/FormFields/PureTagPicker.js
@@ -19,15 +19,6 @@ export default class PureTagPicker extends React.Component {
     });
   }
 
-  removeFn = () => {
-    const newFieldValue = this.props.tagValue.filter(oldField => {
-      return tag.id !== oldField.id;
-    });
-
-    this.props.onUpdate(newFieldValue);
-  };
-
-
   selectNewTag = (newFieldValue) => {
 
       this.setState({

--- a/public/video-ui/src/components/FormFields/PureTagPicker.js
+++ b/public/video-ui/src/components/FormFields/PureTagPicker.js
@@ -1,10 +1,25 @@
 import React from 'react';
+import { PropTypes } from 'prop-types';
 import TagTypes from '../../constants/TagTypes';
 import DragSortableList from 'react-drag-sortable';
 import CapiSearch from '../CapiSearch/CapiSearch';
 import removeTagDuplicates from '../../util/removeTagDuplicates';
 
 export default class PureTagPicker extends React.Component {
+
+  static propTypes = {
+    tagValue: PropTypes.array.isRequired,
+    onUpdate: PropTypes.func.isRequired,
+    fetchTags: PropTypes.func.isRequired,
+    onUpdate: PropTypes.func.isRequired,
+    capiTags: PropTypes.array.isRequired,
+    tagsToVisible: PropTypes.func.isRequired,
+    showTags: PropTypes.bool.isRequired,
+    hideTagResults: PropTypes.func.isRequired,
+    selectedTagIndex: PropTypes.number,
+    inputClearCount: PropTypes.number.isRequired,
+    inputPlaceholder: PropTypes.string.isRequired
+  }
 
   state = {
     inputString: '',

--- a/public/video-ui/src/components/FormFields/PureTagPicker.js
+++ b/public/video-ui/src/components/FormFields/PureTagPicker.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import TagTypes from '../../constants/TagTypes';
+import DragSortableList from 'react-drag-sortable';
+import CapiSearch from '../CapiSearch/Capisearch';
+import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
+
+export default class PureTagPicker extends React.Component {
+
+  state = {
+    inputString: ''
+  };
+
+  updateInput = e => {
+
+    const searchText = e.target.value;
+    this.props.fetchTags(searchText);
+    this.setState({
+      inputString: searchText
+    });
+  }
+
+
+  renderSelectedTags = (tag, index) => {
+
+    const removeFn = () => {
+      const newFieldValue = this.props.tagValue.filter(oldField => {
+        return tag.id !== oldField.id;
+      });
+
+      this.props.onUpdate(newFieldValue);
+    };
+
+    return (
+      <div
+        key={`${tag.id}-${index}`}
+        className="form__field__selected__tag"
+      >
+        <span>
+          {tag.webTitle}
+        </span>
+        <span className="form__field__tag__remove"
+        onClick={removeFn}></span>
+      </div>
+    );
+  }
+
+  selectNewTag = (newFieldValue) => {
+
+      this.setState({
+        inputString: ''
+      });
+
+      this.props.onUpdate(newFieldValue);
+  }
+
+  render() {
+
+    const getInputPlaceholder = () => {
+      if (!this.props.fieldValue || this.props.fieldValue.length === 0) {
+        return this.props.inputPlaceholder;
+      }
+      return '';
+    };
+
+    return (
+      <div className="form__row"
+        onBlur={this.props.hideTagResults}
+        onMouseDown={this.props.showTagResults}
+      >
+
+        <div className="form__label__layout">
+          <label className="form__label">{this.props.fieldName}</label>
+        </div>
+
+        <input
+          type="text"
+          className="form__field"
+          onChange={this.updateInput}
+          placeholder={getInputPlaceholder()}
+          value={this.state.inputString}
+        />
+
+
+        <CapiSearch
+          capiTags={this.props.capiTags}
+          showTags={this.props.showTags}
+          tagsToVisible={this.props.tagsToVisible}
+          selectNewTag={this.selectNewTag}
+          tagValue={this.props.tagValue}
+          removeDupes={removeStringTagDuplicates}
+        />
+
+        {this.props.tagValue.map(tag => {
+          return this.renderSelectedTags(tag);
+        })}
+      </div>
+    );
+  }
+};

--- a/public/video-ui/src/components/FormFields/PureTagPicker.js
+++ b/public/video-ui/src/components/FormFields/PureTagPicker.js
@@ -10,6 +10,14 @@ export default class PureTagPicker extends React.Component {
     inputString: '',
   };
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.inputClearCount !== nextProps.inputClearCount) {
+      this.setState({
+        inputString: '',
+      });
+    }
+  }
+
   updateInput = e => {
 
     const searchText = e.target.value;

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -139,8 +139,8 @@ export default class TagPicker extends React.Component {
           placeholder={<span></span>}
         />
     );
-
   }
+
   renderTag = (tag, index) => {
     return (
       <div
@@ -156,10 +156,58 @@ export default class TagPicker extends React.Component {
         </span>
       </div>
     );
-
   }
 
+  renderTagPicker() {
 
+    if (this.props.tagType === TagTypes.contributor ||
+        this.props.tagType === TagTypes.youtube) {
+      return (
+          <TextInputTagPicker
+            tagValue={this.state.tagValue}
+            onUpdate={this.onUpdate}
+            fetchTags={this.fetchTags}
+            capiTags={this.state.capiTags}
+            tagsToVisible={this.tagsToVisible}
+            showTagResults={this.showTagResults}
+            showTags={this.state.showTags}
+            hideTagResults={this.hideTagResults}
+
+            {...this.props}
+          />
+
+      );
+
+    }
+
+    return (
+      <PureTagPicker
+        tagValue={this.state.tagValue}
+        onUpdate={this.onUpdate}
+        fetchTags={this.fetchTags}
+        capiTags={this.state.capiTags}
+        tagsToVisible={this.tagsToVisible}
+        showTagResults={this.showTagResults}
+        showTags={this.state.showTags}
+        hideTagResults={this.hideTagResults}
+
+        {...this.props}
+      />
+    );
+  }
+
+  renderAddedTags() {
+    if (this.props.tagType === TagTypes.contributor) {
+      return (
+        <TagFieldValue tagValue={this.state.tagValue}/>
+      );
+
+    }
+    return (
+      this.renderSelectedTags()
+    );
+
+  }
 
   render() {
 
@@ -185,42 +233,11 @@ export default class TagPicker extends React.Component {
       );
     }
 
-    if (this.props.tagType === TagTypes.contributor || this.props.tagType === TagTypes.youtube) {
-      return (
-        <div>
-          <CapiUnavailable capiUnavailable={this.state.capiUnavailable} />
-          <TextInputTagPicker
-            tagValue={this.state.tagValue}
-            onUpdate={this.onUpdate}
-            fetchTags={this.fetchTags}
-            capiTags={this.state.capiTags}
-            tagsToVisible={this.tagsToVisible}
-            showTagResults={this.showTagResults}
-            showTags={this.state.showTags}
-            hideTagResults={this.hideTagResults}
-
-            {...this.props}
-          />
-        </div>
-      );
-    }
-
     return (
       <div>
         <CapiUnavailable capiUnavailable={this.state.capiUnavailable} />
-        <PureTagPicker
-          tagValue={this.state.tagValue}
-          onUpdate={this.onUpdate}
-          fetchTags={this.fetchTags}
-          capiTags={this.state.capiTags}
-          tagsToVisible={this.tagsToVisible}
-          showTagResults={this.showTagResults}
-          showTags={this.state.showTags}
-          hideTagResults={this.hideTagResults}
-
-          {...this.props}
-        />
-        {this.renderSelectedTags()}
+        {this.renderTagPicker()}
+        {this.renderAddedTags()}
       </div>
     );
   }

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -271,7 +271,9 @@ export default class TagPicker extends React.Component {
 
     }
     return (
-      this.renderSelectedTags()
+      <div className="form__field__tag__list">
+        {this.renderSelectedTags()}
+      </div>
     );
 
   }

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import ContentApi from '../../services/capi';
 import { tagsFromStringList, tagsToStringList } from '../../util/tagParsers';
-import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
 import { keyCodes } from '../../constants/keyCodes';
 import UserActions from '../../constants/UserActions';
 import TagTypes from '../../constants/TagTypes';
 import DragSortableList from 'react-drag-sortable';
+import CapiSearch from '../CapiSearch/Capisearch';
+import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
 
 export default class TagPicker extends React.Component {
   state = {
@@ -65,6 +66,18 @@ export default class TagPicker extends React.Component {
     });
     this.props.onUpdateField(tagsToStringList(newValue));
   };
+
+  selectNewTag = (newFieldValue) => {
+
+      this.setState({
+        inputString: ''
+      });
+
+      this.onUpdate(newFieldValue);
+      this.setState({
+        capiTags: []
+      });
+  }
 
   getYoutubeInputValue = () => {
     if (
@@ -181,36 +194,6 @@ export default class TagPicker extends React.Component {
     }
   }
 
-  renderTags(tag) {
-    const addTag = () => {
-      const valueWithoutStringDupes = removeStringTagDuplicates(
-        tag,
-        this.state.tagValue
-      );
-      const newFieldValue = valueWithoutStringDupes.concat([tag]);
-
-      this.setState({
-        inputString: ''
-      });
-
-      this.onUpdate(newFieldValue);
-      this.setState({
-        capiTags: []
-      });
-    };
-
-    return (
-      <a
-        className="form__field__tags"
-        key={tag.id}
-        title={tag.id}
-        onClick={addTag}
-      >
-        {' '}{tag.webTitle}{' '}
-      </a>
-    );
-  }
-
   renderValue = (field, i) => {
     const removeFn = () => {
       const newFieldValue = this.state.tagValue.filter(oldField => {
@@ -292,7 +275,7 @@ export default class TagPicker extends React.Component {
           className="form__field__tag--input"
           id={this.props.fieldName}
           onKeyDown={this.processTagInput}
-          onChange={this.updateInput}
+r         onChange={this.updateInput}
           value={this.state.inputString}
           placeholder={getInputPlaceholder()}
         />
@@ -411,6 +394,11 @@ export default class TagPicker extends React.Component {
     });
   }
 
+  tagsToVisible = () => {
+    this.setState({
+      tagsVisible: true
+    });
+  }
 
   render() {
     if (!this.props.editable) {
@@ -451,11 +439,14 @@ export default class TagPicker extends React.Component {
 
         {this.renderInputElements()}
 
-        {(this.state.capiTags.length !== 0 && this.state.showTags)
-          ? <div className="form__field__tags" onMouseDown={() => this.setState({tagsVisible: true})}>
-              {this.state.capiTags.map(tag => this.renderTags(tag))}
-            </div>
-          : ''}
+        <CapiSearch
+          capiTags={this.state.capiTags}
+          showTags={this.state.showTags}
+          tagsToVisible={this.tagsToVisible}
+          selectNewTag={this.selectNewTag}
+          tagValue={this.state.tagValue}
+          removeDupes={removeStringTagDuplicates}
+        />
 
         {this.state.tagValue.map(this.renderFieldValue)}
 

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -21,7 +21,8 @@ export default class TagPicker extends React.Component {
     capiUnavailable: false,
     showTags: true,
     tagsVisible: false,
-    selectedTagIndex: null
+    selectedTagIndex: null,
+    inputClearCount: 0
   };
 
   componentDidMount() {
@@ -150,7 +151,8 @@ export default class TagPicker extends React.Component {
       const newFieldValue = valueWithoutDupes.concat([newTag]);
 
       this.setState({
-        selectedTagIndex: null
+        selectedTagIndex: null,
+        inputClearCount: this.state.inputClearCount + 1
       });
 
       this.onUpdate(newFieldValue);
@@ -233,6 +235,7 @@ export default class TagPicker extends React.Component {
             hideTagResults={this.hideTagResults}
             removeFn={this.removeFn}
             selectedTagIndex={this.state.selectedTagIndex}
+            inputClearCount={this.state.inputClearCount}
 
             {...this.props}
           />
@@ -252,6 +255,7 @@ export default class TagPicker extends React.Component {
         showTags={this.state.showTags}
         hideTagResults={this.hideTagResults}
         selectedTagIndex={this.state.selectedTagIndex}
+        inputClearCount={this.state.inputClearCount}
 
         {...this.props}
       />

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -270,18 +270,22 @@ export default class TagPicker extends React.Component {
   }
 
   renderAddedTags() {
-    if (this.props.tagType === TagTypes.contributor ||
-        this.props.tagType === TagTypes.youtube) {
-      return (
-        <TagFieldValue tagValue={this.state.tagValue}/>
-      );
 
+    if (this.state.tagValue.length !== 0) {
+      if (this.props.tagType === TagTypes.contributor ||
+          this.props.tagType === TagTypes.youtube) {
+        return (
+          <TagFieldValue tagValue={this.state.tagValue}/>
+        );
+
+      }
+      return (
+        <div className="form__field__tag__list">
+          {this.renderSelectedTags()}
+        </div>
+      );
     }
-    return (
-      <div className="form__field__tag__list">
-        {this.renderSelectedTags()}
-      </div>
-    );
+    return null;
 
   }
 

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -112,6 +112,10 @@ export default class TagPicker extends React.Component {
         tagsVisible: false
       });
     }
+
+    this.setState({
+      inputClearCount: this.state.inputClearCount + 1
+    });
   }
 
   tagsToVisible = () => {

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -6,6 +6,7 @@ import UserActions from '../../constants/UserActions';
 import TagTypes from '../../constants/TagTypes';
 import getTagDisplayNames from '../../util/getTagDisplayNames';
 import TextInputTagPicker from './TextInputTagPicker';
+import PureTagPicker from './PureTagPicker';
 import TagFieldValue from '../Tags/TagFieldValue';
 import CapiUnavailable from '../CapiSearch/CapiUnavailable';
 
@@ -122,10 +123,30 @@ export default class TagPicker extends React.Component {
       );
     }
 
+    if (this.props.tagType === TagTypes.contributor || this.props.tagType === TagTypes.youtube) {
+      return (
+        <div>
+          <CapiUnavailable capiUnavailable={this.state.capiUnavailable} />
+          <TextInputTagPicker
+            tagValue={this.state.tagValue}
+            onUpdate={this.onUpdate}
+            fetchTags={this.fetchTags}
+            capiTags={this.state.capiTags}
+            tagsToVisible={this.tagsToVisible}
+            showTagResults={this.showTagResults}
+            showTags={this.state.showTags}
+            hideTagResults={this.hideTagResults}
+
+            {...this.props}
+          />
+        </div>
+      );
+    }
+
     return (
       <div>
         <CapiUnavailable capiUnavailable={this.state.capiUnavailable} />
-        <TextInputTagPicker
+        <PureTagPicker
           tagValue={this.state.tagValue}
           onUpdate={this.onUpdate}
           fetchTags={this.fetchTags}

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -8,6 +8,7 @@ import getTagDisplayNames from '../../util/getTagDisplayNames';
 import TextInputTagPicker from './TextInputTagPicker';
 
 export default class TagPicker extends React.Component {
+
   state = {
     capiTags: [],
     inputString: '',
@@ -65,6 +66,41 @@ export default class TagPicker extends React.Component {
     });
   };
 
+  hideTagResults = (e) => {
+
+    // For each tag picker component, there is a tagsVisible state variable.
+    // The onBlur event attached to the tag picker gets fired when
+    // any of its children are clicked. This variable is used to check if the event
+    // was fired by clicking on one of the child elements and makes sure that this
+    // does not hide the tag search results.
+
+    const tagsVisible = this.state.tagsVisible;
+
+    if (!tagsVisible) {
+      this.setState({
+        showTags: false,
+        inputString: '',
+      });
+    } else {
+      this.setState({
+        tagsVisible: false
+      });
+    }
+  }
+
+  showTagResults = () => {
+    this.setState({
+      showTags: true
+    });
+  }
+
+  tagsToVisible = () => {
+    this.setState({
+      tagsVisible: true
+    });
+  }
+
+
   render() {
 
     return (
@@ -74,7 +110,11 @@ export default class TagPicker extends React.Component {
         onUpdate={this.onUpdate}
         fetchTags={this.fetchTags}
         capiTags={this.state.capiTags}
-        selectNewTag={this.selectNewTag}
+        tagsToVisible={this.tagsToVisible}
+        showTagResults={this.showTagResults}
+        showTags={this.state.showTags}
+        hideTagResults={this.hideTagResults}
+
         {...this.props}
       />
     );

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -4,16 +4,13 @@ import { tagsFromStringList, tagsToStringList } from '../../util/tagParsers';
 import { keyCodes } from '../../constants/keyCodes';
 import UserActions from '../../constants/UserActions';
 import TagTypes from '../../constants/TagTypes';
-import DragSortableList from 'react-drag-sortable';
-import CapiSearch from '../CapiSearch/Capisearch';
-import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
 import getTagDisplayNames from '../../util/getTagDisplayNames';
+import TextInputTagPicker from './TextInputTagPicker';
 
 export default class TagPicker extends React.Component {
   state = {
     capiTags: [],
     inputString: '',
-    lastAction: UserActions.other,
     tagValue: [],
     capiUnavailable: false,
     showTags: true,
@@ -38,397 +35,48 @@ export default class TagPicker extends React.Component {
     }
   }
 
+  fetchTags = searchText => {
+    ContentApi.getTagsByType(searchText, this.props.tagType)
+      .then(capiResponse => {
+        const tags = getTagDisplayNames(capiResponse.response.results, this.props.tagType);
+        this.setState({
+          capiTags: tags
+        });
+      })
+      .catch(() => {
+        this.setState({
+          capiTags: [],
+          capiUnavailable: true
+        });
+      });
+  }
+
   onUpdate = newValue => {
     this.setState({
       tagValue: newValue
     });
     this.props.onUpdateField(tagsToStringList(newValue));
-  };
 
-  selectNewTag = (newFieldValue) => {
-
-      this.setState({
-        inputString: ''
-      });
-
-      this.onUpdate(newFieldValue);
-      this.setState({
-        capiTags: []
-      });
-  }
-
-  getYoutubeInputValue = () => {
-    if (
-      this.state.tagValue.every(value => {
-        return value.id !== this.state.inputString;
-      })
-    ) {
-      return {
-        id: this.state.inputString,
-        webTitle: this.state.inputString
-      };
-    }
-    return [];
-  };
-
-  updateInput = e => {
-      // If the user did not add new text input, we update the tag search
-    if (this.state.lastAction === UserActions.delete) {
-      const length = this.state.tagValue.length;
-      const lastInput = this.state.tagValue[length - 1];
-
-      this.setState({
-        inputString: lastInput,
-        lastAction: UserActions.other
-      });
-
-      const newValue = this.state.tagValue.slice(
-        0,
-        this.state.tagValue.length - 1
-      );
-      this.onUpdate(newValue);
-    } else {
-      this.setState({
-        inputString: e.target.value
-      });
-
-      if (!this.props.disableCapiTags) {
-        const searchText = e.target.value;
-
-        ContentApi.getTagsByType(searchText, this.props.tagType)
-          .then(capiResponse => {
-            const tags = getTagDisplayNames(capiResponse.response.results, this.props.tagType);
-            this.setState({
-              capiTags: tags
-            });
-
-            // Because the keyword tag input field is inside
-            // a component that makes the keywords sortable,
-            // we need to refocus to the input field to keep
-            // typing.
-            if (this.props.tagType === TagTypes.keyword) {
-              this.refs.keywordInput.focus()
-            }
-          })
-          .catch(() => {
-            this.setState({
-              capiTags: [],
-              capiUnavailable: true
-            });
-          });
-      }
-    }
-  };
-
-  processTagInput = e => {
-    if (e.keyCode === keyCodes.enter) {
-      const onlyWhitespace = !/\S/.test(this.state.inputString);
-      if (!onlyWhitespace) {
-
-        const newInput = this.props.tagType === TagTypes.youtube ? this.getYoutubeInputValue() : this.state.inputString;
-
-        const newFieldValue = this.state.tagValue.concat([newInput]);
-
-        this.onUpdate(newFieldValue);
-        this.setState({
-          inputString: '',
-          capiTags: []
-        });
-      }
-
-    } else if (e.keyCode === keyCodes.backspace) {
-      if (this.state.inputString.length === 0) {
-        const lastInput = this.state.tagValue[this.state.tagValue.length - 1];
-
-        if (typeof lastInput === 'string') {
-          //User is trying to delete a string input
-          this.setState(
-            {
-              lastAction: UserActions.delete
-            },
-            () => {
-              this.updateInput();
-            }
-          );
-        }
-      }
-    } else {
-      this.setState({
-        lastAction: UserActions.other
-      });
-    }
-  };
-
-  renderFieldValue(value, index) {
-    if (value.webTitle) {
-      return (
-        <span key={`${value.id}-${index}`}>
-          <span className="form__field__tag__display">{value.webTitle}</span>
-          {' '}
-        </span>
-      );
-    } else {
-      return `${value} `;
-    }
-  }
-
-  renderValue = (field, i) => {
-    const removeFn = () => {
-      const newFieldValue = this.state.tagValue.filter(oldField => {
-        return field.id !== oldField.id;
-      });
-
-      this.setState({
-        inputString: ''
-      });
-      this.onUpdate(newFieldValue);
-    };
-
-    if (field.id) {
-      return (
-        <span
-          className="form__field--multiselect__value"
-          key={`${field.id}-${i}`}
-          onClick={removeFn}
-        >
-          {field.webTitle}{' '}
-        </span>
-      );
-    }
-    return (
-      <span
-        className="form__field--multistring__value"
-        key={`${field.id}-${i}`}
-      >
-        {' '}{field}{' '}
-      </span>
-    );
-  };
-
-  renderCapiUnavailable() {
-    if (this.state.capiUnavailable) {
-      return (
-        <span className="form__field--external__error">
-          Tags are currently unavailable
-        </span>
-      );
-    }
-  }
-
-  renderTextInputElement(lastElement) {
-    const getInputPlaceholder = () => {
-      if (!this.props.fieldValue || this.props.fieldValue.length === 0) {
-        return this.props.inputPlaceholder;
-      }
-      return '';
-    };
-
-    if (this.props.disableTextInput) {
-      return (
-        <span className="form__field__tag--container">
-          {lastElement && this.renderValue(lastElement, 0)}
-          <input
-            type="text"
-            className={
-              'form__field__tag--input' +
-                (getInputPlaceholder().length !== 0
-                  ? ' form__field__tag--input--empty'
-                  : '')
-            }
-            id={this.props.fieldName}
-            ref={this.props.tagType + 'Input'}
-            onChange={this.updateInput}
-            value={this.state.inputString}
-            placeholder={getInputPlaceholder()}
-          />
-        </span>
-      );
-    }
-
-    return (
-      <span className="form__field__tag--container">
-        {lastElement && this.renderValue(lastElement, 0)}
-        <input
-          type="text"
-          className="form__field__tag--input"
-          id={this.props.fieldName}
-          onKeyDown={this.processTagInput}
-r         onChange={this.updateInput}
-          value={this.state.inputString}
-          placeholder={getInputPlaceholder()}
-        />
-      </span>
-    );
-  }
-
-  renderBylineInstructions() {
-    if (this.props.tagType === TagTypes.contributor) {
-      return (
-        <span className="form__field__instructions">
-          Press enter to add byline as text
-        </span>
-      );
-    }
-  }
-
-  onSort = (sortedList) => {
-
-    const newTagValues = sortedList.reduce((newTagValues, sortedValue) => {
-
-      //For each component in the list of dragged elements,
-      //we have to extract the name of the tag it represents.
-      const child = sortedValue.content.props.children[0];
-
-      const tagTitle = typeof child === 'string' ? child : child.props.children[0];
-
-      const tagValue = this.state.tagValue.find(value => value.webTitle === tagTitle);
-
-      newTagValues.push(tagValue);
-      return newTagValues;
-    }, []);
-
-    this.onUpdate(newTagValues);
-  }
-
-  renderInputElements() {
-
-    const valueLength = this.state.tagValue.length;
-    const lastElement = !valueLength || valueLength === 0
-      ? null
-      : this.state.tagValue[valueLength - 1];
-
-    if (this.props.tagType !== TagTypes.keyword) {
-      return (
-        <div className="form__field__tag--selector">
-          {valueLength
-            ? this.state.tagValue.map((value, i) => {
-                if (i < valueLength - 1) {
-                  return this.renderValue(value, i);
-                }
-              })
-            : ''}
-
-          {this.renderTextInputElement(lastElement)}
-
-        </div>
-
-      );
-
-    } else {
-      const existingItems = this.state.tagValue.reduce((values, value, i) => {
-        if (i < valueLength - 1) {
-          values.push({ content: this.renderValue(value, i) });
-        }
-        return values;
-      }, [])
-
-      const items = existingItems.concat([{content: this.renderTextInputElement(lastElement)}]);
-
-      return (
-        <div className="form__field__tag--selector">
-          <DragSortableList
-            items={items}
-            dropBackTransitionDuration={0.3}
-            type="horizontal"
-            onSort={this.onSort}
-            placeholder={<span></span>}
-          />
-        </div>
-      );
-
-    }
-
-  }
-
-  selectTag = () => {
-
-  }
-
-  hideTagResults = (e) => {
-
-    // For each tag picker component, there is a tagsVisible state variable.
-    // The onBlur event attached to the tag picker gets fired when
-    // any of its children are clicked. This variable is used to check if the event
-    // was fired by clicking on one of the child elements and makes sure that this
-    // does not hide the tag search results.
-
-    const tagsVisible = this.state.tagsVisible;
-
-    if (!tagsVisible) {
-      this.setState({
-        showTags: false,
-        inputString: '',
-      });
-    } else {
-      this.setState({
-        tagsVisible: false
-      });
-    }
-  }
-
-  showTagResults = () => {
+    //TODO: does setting this at all times produce weird
+    //behaviour when deleting bylines?
+    //Do we need to displayAnbele this when deleting/
     this.setState({
-      showTags: true
+      capiTags: []
     });
-  }
-
-  tagsToVisible = () => {
-    this.setState({
-      tagsVisible: true
-    });
-  }
+  };
 
   render() {
-    if (!this.props.editable) {
-      if (!this.state.tagValue || this.state.tagValue.length === 0) {
-        return (
-          <div>
-            <p className="details-list__title">{this.props.fieldName}</p>
-            <p className={'details-list__field details-list__empty'}>
-              {this.props.placeholder}
-            </p>
-          </div>
-        );
-      }
-      return (
-        <div>
-          <p className="details-list__title">{this.props.fieldName}</p>
-          <p className="details-list__field ">
-            {this.state.tagValue.map(this.renderFieldValue)}
-          </p>
-        </div>
-      );
-    }
 
     return (
-      <div className="form__row"
-        onKeyDown={this.navigateDown}
-        onKeyUp={this.navigateUpTagList}
-
-        onBlur={this.hideTagResults}
-        onMouseDown={this.showTagResults}
-      >
-
-        <div className="form__label__layout">
-          <label className="form__label">{this.props.fieldName}</label>
-          {this.renderBylineInstructions()}
-        </div>
-        {this.renderCapiUnavailable()}
-
-        {this.renderInputElements()}
-
-        <CapiSearch
-          capiTags={this.state.capiTags}
-          showTags={this.state.showTags}
-          tagsToVisible={this.tagsToVisible}
-          selectNewTag={this.selectNewTag}
-          tagValue={this.state.tagValue}
-          removeDupes={removeStringTagDuplicates}
-        />
-
-        {this.state.tagValue.map(this.renderFieldValue)}
-
-      </div>
+      <TextInputTagPicker
+        tagValue={this.state.tagValue}
+        capiUnavailable={this.state.capiUnavailable}
+        onUpdate={this.onUpdate}
+        fetchTags={this.fetchTags}
+        capiTags={this.state.capiTags}
+        selectNewTag={this.selectNewTag}
+        {...this.props}
+      />
     );
   }
 }

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -11,7 +11,6 @@ export default class TagPicker extends React.Component {
 
   state = {
     capiTags: [],
-    inputString: '',
     tagValue: [],
     capiUnavailable: false,
     showTags: true,
@@ -58,9 +57,6 @@ export default class TagPicker extends React.Component {
     });
     this.props.onUpdateField(tagsToStringList(newValue));
 
-    //TODO: does setting this at all times produce weird
-    //behaviour when deleting bylines?
-    //Do we need to displayAnbele this when deleting/
     this.setState({
       capiTags: []
     });
@@ -79,7 +75,6 @@ export default class TagPicker extends React.Component {
     if (!tagsVisible) {
       this.setState({
         showTags: false,
-        inputString: '',
       });
     } else {
       this.setState({

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -9,6 +9,7 @@ import TextInputTagPicker from './TextInputTagPicker';
 import PureTagPicker from './PureTagPicker';
 import TagFieldValue from '../Tags/TagFieldValue';
 import CapiUnavailable from '../CapiSearch/CapiUnavailable';
+import DragSortableList from 'react-drag-sortable';
 
 export default class TagPicker extends React.Component {
 
@@ -98,6 +99,67 @@ export default class TagPicker extends React.Component {
     });
   }
 
+  onSort = (sortedList) => {
+    const newTagValues = sortedList.reduce((newTagValues, sortedValue) => {
+
+      //For each component in the list of dragged elements,
+      //we have to extract the name of the tag it represents.
+      const tagTitle = sortedValue.content.props.children[0].props.children;
+
+      const tagValue = this.state.tagValue.find(value => value.webTitle === tagTitle);
+
+      newTagValues.push(tagValue);
+      return newTagValues;
+    }, []);
+
+    this.onUpdate(newTagValues);
+  }
+
+  renderSelectedTags = () => {
+
+    if (this.props.tagType !== TagTypes.keyword) {
+      return (
+          this.state.tagValue.map((tag, index) => this.renderTag(tag, index))
+      );
+    }
+
+    const tagItems = this.state.tagValue.map((value, index) => {
+      return {
+        content: this.renderTag(value, index)
+      }
+    });
+
+    return (
+        <DragSortableList
+          items={tagItems}
+          moveTransitionDuration={0.3}
+          dropBackTransitionDuration={0.3}
+          type="vertical"
+          onSort={this.onSort}
+          placeholder={<span></span>}
+        />
+    );
+
+  }
+  renderTag = (tag, index) => {
+    return (
+      <div
+        key={`${tag.id}-${index}`}
+        className="form__field__selected__tag"
+      >
+        <span>
+          {tag.webTitle}
+        </span>
+        <span
+          className="form__field__tag__remove"
+          onClick={this.removeFn}>
+        </span>
+      </div>
+    );
+
+  }
+
+
 
   render() {
 
@@ -158,6 +220,7 @@ export default class TagPicker extends React.Component {
 
           {...this.props}
         />
+        {this.renderSelectedTags()}
       </div>
     );
   }

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -66,6 +66,15 @@ export default class TagPicker extends React.Component {
     });
   };
 
+  removeFn = (tag) => {
+    const newFieldValue = this.state.tagValue.filter(oldField => {
+      return tag.id !== oldField.id;
+    });
+
+    this.onUpdate(newFieldValue);
+  };
+
+
   hideTagResults = (e) => {
 
     // For each tag picker component, there is a tagsVisible state variable.
@@ -152,7 +161,7 @@ export default class TagPicker extends React.Component {
         </span>
         <span
           className="form__field__tag__remove"
-          onClick={this.removeFn}>
+          onClick={() => this.removeFn(tag)}>
         </span>
       </div>
     );
@@ -172,6 +181,7 @@ export default class TagPicker extends React.Component {
             showTagResults={this.showTagResults}
             showTags={this.state.showTags}
             hideTagResults={this.hideTagResults}
+            removeFn={this.removeFn}
 
             {...this.props}
           />

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -108,12 +108,6 @@ export default class TagPicker extends React.Component {
     }
   }
 
-  showTagResults = () => {
-    this.setState({
-      showTags: true
-    });
-  }
-
   tagsToVisible = () => {
     this.setState({
       tagsVisible: true
@@ -121,6 +115,11 @@ export default class TagPicker extends React.Component {
   }
 
   onKeyDown = (e) => {
+
+    this.setState({
+      showTags: true
+    });
+
     if (e.keyCode === keyCodes.down) {
       if (this.state.selectedTagIndex === null && this.state.capiTags.length > 0) {
 
@@ -230,7 +229,6 @@ export default class TagPicker extends React.Component {
             fetchTags={this.fetchTags}
             capiTags={this.state.capiTags}
             tagsToVisible={this.tagsToVisible}
-            showTagResults={this.showTagResults}
             showTags={this.state.showTags}
             hideTagResults={this.hideTagResults}
             removeFn={this.removeFn}
@@ -251,7 +249,6 @@ export default class TagPicker extends React.Component {
         fetchTags={this.fetchTags}
         capiTags={this.state.capiTags}
         tagsToVisible={this.tagsToVisible}
-        showTagResults={this.showTagResults}
         showTags={this.state.showTags}
         hideTagResults={this.hideTagResults}
         selectedTagIndex={this.state.selectedTagIndex}
@@ -315,7 +312,6 @@ export default class TagPicker extends React.Component {
     return (
       <div className="form__row"
         onBlur={this.hideTagResults}
-        onMouseDown={this.showTagResults}
         onKeyDown={this.onKeyDown}
       >
 

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -156,7 +156,11 @@ export default class TagPicker extends React.Component {
 
     if (e.keyCode === keyCodes.enter && this.state.selectedTagIndex !== null) {
       const newTag = this.state.capiTags[this.state.selectedTagIndex];
-      const valueWithoutDupes = this.props.tagType === TagTypes.contributor ? removeStringTagDuplicates(newTag, this.state.tagValue) : removeTagDuplicates(newTag, this.state.tagValue);
+
+      const valueWithoutDupes = this.props.tagType === TagTypes.contributor ?
+        removeStringTagDuplicates(newTag, this.state.tagValue) :
+        removeTagDuplicates(newTag, this.state.tagValue);
+
       const newFieldValue = valueWithoutDupes.concat([newTag]);
 
       this.setState({

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -6,6 +6,8 @@ import UserActions from '../../constants/UserActions';
 import TagTypes from '../../constants/TagTypes';
 import getTagDisplayNames from '../../util/getTagDisplayNames';
 import TextInputTagPicker from './TextInputTagPicker';
+import TagFieldValue from '../Tags/TagFieldValue';
+import CapiUnavailable from '../CapiSearch/CapiUnavailable';
 
 export default class TagPicker extends React.Component {
 
@@ -98,20 +100,44 @@ export default class TagPicker extends React.Component {
 
   render() {
 
-    return (
-      <TextInputTagPicker
-        tagValue={this.state.tagValue}
-        capiUnavailable={this.state.capiUnavailable}
-        onUpdate={this.onUpdate}
-        fetchTags={this.fetchTags}
-        capiTags={this.state.capiTags}
-        tagsToVisible={this.tagsToVisible}
-        showTagResults={this.showTagResults}
-        showTags={this.state.showTags}
-        hideTagResults={this.hideTagResults}
+    if (!this.props.editable) {
+      if (!this.state.tagValue || this.state.tagValue.length === 0) {
+        return (
+          <div>
+            <p className="details-list__title">{this.props.fieldName}</p>
+            <p className={'details-list__field details-list__empty'}>
+              {this.props.placeholder}
+            </p>
+          </div>
+        );
+      }
+      return (
+        <div>
+          <p className="details-list__title">{this.props.fieldName}</p>
+          <CapiUnavailable capiUnavailable={this.state.capiUnavailable} />
+          <p className="details-list__field ">
+            <TagFieldValue tagValue={this.state.tagValue}/>
+          </p>
+        </div>
+      );
+    }
 
-        {...this.props}
-      />
+    return (
+      <div>
+        <CapiUnavailable capiUnavailable={this.state.capiUnavailable} />
+        <TextInputTagPicker
+          tagValue={this.state.tagValue}
+          onUpdate={this.onUpdate}
+          fetchTags={this.fetchTags}
+          capiTags={this.state.capiTags}
+          tagsToVisible={this.tagsToVisible}
+          showTagResults={this.showTagResults}
+          showTags={this.state.showTags}
+          hideTagResults={this.hideTagResults}
+
+          {...this.props}
+        />
+      </div>
     );
   }
 }

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -7,6 +7,7 @@ import TagTypes from '../../constants/TagTypes';
 import DragSortableList from 'react-drag-sortable';
 import CapiSearch from '../CapiSearch/Capisearch';
 import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
+import getTagDisplayNames from '../../util/getTagDisplayNames';
 
 export default class TagPicker extends React.Component {
   state = {
@@ -36,29 +37,6 @@ export default class TagPicker extends React.Component {
         });
     }
   }
-
-  parseTags = results => {
-    return results.map(result => {
-      if (this.props.tagType === TagTypes.keyword) {
-        let detailedTitle;
-
-        //Some webtitles on keyword tags are too unspecific and we need to add
-        //the section name to them to know what tags they are referring to
-
-        if (
-          result.webTitle !== result.sectionName &&
-          result.webTitle.split(' ').length <= 2
-        ) {
-          detailedTitle = result.webTitle + ' (' + result.sectionName + ')';
-        } else {
-          detailedTitle = result.webTitle;
-        }
-
-        return { id: result.id, webTitle: detailedTitle };
-      }
-      return { id: result.id, webTitle: result.webTitle };
-    });
-  };
 
   onUpdate = newValue => {
     this.setState({
@@ -119,7 +97,7 @@ export default class TagPicker extends React.Component {
 
         ContentApi.getTagsByType(searchText, this.props.tagType)
           .then(capiResponse => {
-            const tags = this.parseTags(capiResponse.response.results);
+            const tags = getTagDisplayNames(capiResponse.response.results, this.props.tagType);
             this.setState({
               capiTags: tags
             });

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -13,7 +13,9 @@ export default class TagPicker extends React.Component {
     inputString: '',
     lastAction: UserActions.other,
     tagValue: [],
-    capiUnavailable: false
+    capiUnavailable: false,
+    showTags: true,
+    tagsVisible: false
   };
 
   componentDidMount() {
@@ -376,6 +378,40 @@ export default class TagPicker extends React.Component {
     }
 
   }
+
+  selectTag = () => {
+
+  }
+
+  hideTagResults = (e) => {
+
+    // For each tag picker component, there is a tagsVisible state variable.
+    // The onBlur event attached to the tag picker gets fired when
+    // any of its children are clicked. This variable is used to check if the event
+    // was fired by clicking on one of the child elements and makes sure that this
+    // does not hide the tag search results.
+
+    const tagsVisible = this.state.tagsVisible;
+
+    if (!tagsVisible) {
+      this.setState({
+        showTags: false,
+        inputString: '',
+      });
+    } else {
+      this.setState({
+        tagsVisible: false
+      });
+    }
+  }
+
+  showTagResults = () => {
+    this.setState({
+      showTags: true
+    });
+  }
+
+
   render() {
     if (!this.props.editable) {
       if (!this.state.tagValue || this.state.tagValue.length === 0) {
@@ -399,7 +435,13 @@ export default class TagPicker extends React.Component {
     }
 
     return (
-      <div className="form__row">
+      <div className="form__row"
+        onKeyDown={this.navigateDown}
+        onKeyUp={this.navigateUpTagList}
+
+        onBlur={this.hideTagResults}
+        onMouseDown={this.showTagResults}
+      >
 
         <div className="form__label__layout">
           <label className="form__label">{this.props.fieldName}</label>
@@ -409,8 +451,8 @@ export default class TagPicker extends React.Component {
 
         {this.renderInputElements()}
 
-        {this.state.capiTags.length !== 0
-          ? <div className="form__field__tags">
+        {(this.state.capiTags.length !== 0 && this.state.showTags)
+          ? <div className="form__field__tags" onMouseDown={() => this.setState({tagsVisible: true})}>
               {this.state.capiTags.map(tag => this.renderTags(tag))}
             </div>
           : ''}

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -144,7 +144,7 @@ export default class TagPicker extends React.Component {
       }
     }
 
-    if (e.keyCode === keyCodes.enter) {
+    if (e.keyCode === keyCodes.enter && this.state.selectedTagIndex !== null) {
       const newTag = this.state.capiTags[this.state.selectedTagIndex];
       const valueWithoutDupes = this.props.tagType === TagTypes.contributor ? removeStringTagDuplicates(newTag, this.state.tagValue) : removeTagDuplicates(newTag, this.state.tagValue);
       const newFieldValue = valueWithoutDupes.concat([newTag]);
@@ -259,7 +259,8 @@ export default class TagPicker extends React.Component {
   }
 
   renderAddedTags() {
-    if (this.props.tagType === TagTypes.contributor) {
+    if (this.props.tagType === TagTypes.contributor ||
+        this.props.tagType === TagTypes.youtube) {
       return (
         <TagFieldValue tagValue={this.state.tagValue}/>
       );

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -174,7 +174,7 @@ export default class TagPicker extends React.Component {
   }
 
   onSort = (sortedList) => {
-    const newTagValues = sortedList.reduce((newTagValues, sortedValue) => {
+    const newTagValues = sortedList.reduce((sortedTagList, sortedValue) => {
 
       //For each component in the list of dragged elements,
       //we have to extract the name of the tag it represents.
@@ -182,8 +182,7 @@ export default class TagPicker extends React.Component {
 
       const tagValue = this.state.tagValue.find(value => value.webTitle === tagTitle);
 
-      newTagValues.push(tagValue);
-      return newTagValues;
+      return [...sortedTagList, tagValue];
     }, []);
 
     this.onUpdate(newTagValues);

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.js
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.js
@@ -129,22 +129,6 @@ export default class TextInputTagPicker extends React.Component {
 
   renderTextInputElement(lastElement) {
 
-    if (this.props.disableTextInput) {
-      return (
-        <span className="form__field__tag--container">
-          {lastElement && this.renderValue(lastElement, 0)}
-          <input
-            type="text"
-            className="form__field__tag--input"
-            id={this.props.fieldName}
-            ref={this.props.tagType + 'Input'}
-            onChange={this.updateInput}
-            value={this.state.inputString}
-          />
-        </span>
-      );
-    }
-
     return (
       <span className="form__field__tag--container">
         {lastElement && this.renderValue(lastElement, 0)}

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.js
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.js
@@ -9,15 +9,9 @@ import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
 
 export default class TextInputTagPicker extends React.Component {
 
-  //rename to props if commented out!
   state = {
-    //capiTags: [],
     inputString: '',
     lastAction: UserActions.other,
-    //tagValue: [],
-    //capiUnavailable: false,
-    showTags: true,
-    tagsVisible: false
   };
 
   selectNewTag = (newFieldValue) => {
@@ -282,44 +276,6 @@ r         onChange={this.updateInput}
 
   }
 
-  selectTag = () => {
-
-  }
-
-  hideTagResults = (e) => {
-
-    // For each tag picker component, there is a tagsVisible state variable.
-    // The onBlur event attached to the tag picker gets fired when
-    // any of its children are clicked. This variable is used to check if the event
-    // was fired by clicking on one of the child elements and makes sure that this
-    // does not hide the tag search results.
-
-    const tagsVisible = this.state.tagsVisible;
-
-    if (!tagsVisible) {
-      this.setState({
-        showTags: false,
-        inputString: '',
-      });
-    } else {
-      this.setState({
-        tagsVisible: false
-      });
-    }
-  }
-
-  showTagResults = () => {
-    this.setState({
-      showTags: true
-    });
-  }
-
-  tagsToVisible = () => {
-    this.setState({
-      tagsVisible: true
-    });
-  }
-
   render() {
     if (!this.props.editable) {
       if (!this.props.tagValue || this.props.tagValue.length === 0) {
@@ -344,11 +300,8 @@ r         onChange={this.updateInput}
 
     return (
       <div className="form__row"
-        onKeyDown={this.navigateDown}
-        onKeyUp={this.navigateUpTagList}
-
-        onBlur={this.hideTagResults}
-        onMouseDown={this.showTagResults}
+        onBlur={this.props.hideTagResults}
+        onMouseDown={this.props.showTagResults}
       >
 
         <div className="form__label__layout">
@@ -362,8 +315,8 @@ r         onChange={this.updateInput}
 
         <CapiSearch
           capiTags={this.props.capiTags}
-          showTags={this.state.showTags}
-          tagsToVisible={this.tagsToVisible}
+          showTags={this.props.showTags}
+          tagsToVisible={this.props.tagsToVisible}
           selectNewTag={this.selectNewTag}
           tagValue={this.props.tagValue}
           removeDupes={removeStringTagDuplicates}
@@ -374,6 +327,4 @@ r         onChange={this.updateInput}
       </div>
     );
   }
-
-
 };

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.js
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.js
@@ -4,7 +4,6 @@ import UserActions from '../../constants/UserActions';
 import TagTypes from '../../constants/TagTypes';
 import DragSortableList from 'react-drag-sortable';
 import CapiSearch from '../CapiSearch/Capisearch';
-import CapiUnavailable from '../CapiSearch/CapiUnavailable';
 import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
 import TagFieldValue from '../Tags/TagFieldValue';
 
@@ -265,27 +264,6 @@ r         onChange={this.updateInput}
   }
 
   render() {
-    if (!this.props.editable) {
-      if (!this.props.tagValue || this.props.tagValue.length === 0) {
-        return (
-          <div>
-            <p className="details-list__title">{this.props.fieldName}</p>
-            <p className={'details-list__field details-list__empty'}>
-              {this.props.placeholder}
-            </p>
-          </div>
-        );
-      }
-      return (
-        <div>
-          <p className="details-list__title">{this.props.fieldName}</p>
-          <p className="details-list__field ">
-            <TagFieldValue tagValue={this.props.tagValue}/>
-          </p>
-        </div>
-      );
-    }
-
     return (
       <div className="form__row"
         onBlur={this.props.hideTagResults}
@@ -297,7 +275,6 @@ r         onChange={this.updateInput}
           {this.renderBylineInstructions()}
         </div>
 
-        <CapiUnavailable capiUnavailable={this.state.capiUnavailable} />
 
         {this.renderInputElements()}
 

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.js
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.js
@@ -68,17 +68,20 @@ export default class TextInputTagPicker extends React.Component {
 
   processTagInput = e => {
     if (e.keyCode === keyCodes.enter) {
-      const onlyWhitespace = !/\S/.test(this.state.inputString);
-      if (!onlyWhitespace) {
 
-        const newInput = this.props.tagType === TagTypes.youtube ? this.getYoutubeInputValue() : this.state.inputString;
+      if (this.props.selectedTagIndex === null) {
+        const onlyWhitespace = !/\S/.test(this.state.inputString);
+        if (!onlyWhitespace) {
 
-        const newFieldValue = this.props.tagValue.concat([newInput]);
+          const newInput = this.props.tagType === TagTypes.youtube ? this.getYoutubeInputValue() : this.state.inputString;
 
-        this.props.onUpdate(newFieldValue);
-        this.setState({
-          inputString: '',
-        });
+          const newFieldValue = this.props.tagValue.concat([newInput]);
+
+          this.props.onUpdate(newFieldValue);
+          this.setState({
+            inputString: '',
+          });
+        }
       }
 
     } else if (e.keyCode === keyCodes.backspace) {
@@ -144,16 +147,6 @@ r         onChange={this.updateInput}
     );
   }
 
-  renderBylineInstructions() {
-    if (this.props.tagType === TagTypes.contributor) {
-      return (
-        <span className="form__field__instructions">
-          Press enter to add byline as text
-        </span>
-      );
-    }
-  }
-
   renderInputElements() {
 
     const valueLength = this.props.tagValue.length;
@@ -179,16 +172,7 @@ r         onChange={this.updateInput}
 
   render() {
     return (
-      <div className="form__row"
-        onBlur={this.props.hideTagResults}
-        onMouseDown={this.props.showTagResults}
-      >
-
-        <div className="form__label__layout">
-          <label className="form__label">{this.props.fieldName}</label>
-          {this.renderBylineInstructions()}
-        </div>
-
+      <div>
 
         {this.renderInputElements()}
 
@@ -199,6 +183,7 @@ r         onChange={this.updateInput}
           selectNewTag={this.selectNewTag}
           tagValue={this.props.tagValue}
           removeDupes={removeStringTagDuplicates}
+          selectedTagIndex={this.props.selectedTagIndex}
         />
 
       </div>

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.js
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { keyCodes } from '../../constants/keyCodes';
 import UserActions from '../../constants/UserActions';
 import TagTypes from '../../constants/TagTypes';
-import DragSortableList from 'react-drag-sortable';
 import CapiSearch from '../CapiSearch/Capisearch';
 import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
 import TagFieldValue from '../Tags/TagFieldValue';
@@ -181,25 +180,6 @@ r         onChange={this.updateInput}
     }
   }
 
-  onSort = (sortedList) => {
-
-    const newTagValues = sortedList.reduce((newTagValues, sortedValue) => {
-
-      //For each component in the list of dragged elements,
-      //we have to extract the name of the tag it represents.
-      const child = sortedValue.content.props.children[0];
-
-      const tagTitle = typeof child === 'string' ? child : child.props.children[0];
-
-      const tagValue = this.props.tagValue.find(value => value.webTitle === tagTitle);
-
-      newTagValues.push(tagValue);
-      return newTagValues;
-    }, []);
-
-    this.props.onUpdate(newTagValues);
-  }
-
   renderInputElements() {
 
     const valueLength = this.props.tagValue.length;
@@ -207,46 +187,21 @@ r         onChange={this.updateInput}
       ? null
       : this.props.tagValue[valueLength - 1];
 
-    if (this.props.tagType !== TagTypes.keyword) {
-      return (
-        <div className="form__field__tag--selector">
-          {valueLength
-            ? this.props.tagValue.map((value, i) => {
-                if (i < valueLength - 1) {
-                  return this.renderValue(value, i);
-                }
-              })
-            : ''}
+    return (
+      <div className="form__field__tag--selector">
+        {valueLength
+          ? this.props.tagValue.map((value, i) => {
+              if (i < valueLength - 1) {
+                return this.renderValue(value, i);
+              }
+            })
+          : ''}
 
-          {this.renderTextInputElement(lastElement)}
+        {this.renderTextInputElement(lastElement)}
 
-        </div>
+      </div>
 
-      );
-
-    } else {
-      const existingItems = this.props.tagValue.reduce((values, value, i) => {
-        if (i < valueLength - 1) {
-          values.push({ content: this.renderValue(value, i) });
-        }
-        return values;
-      }, [])
-
-      const items = existingItems.concat([{content: this.renderTextInputElement(lastElement)}]);
-
-      return (
-        <div className="form__field__tag--selector">
-          <DragSortableList
-            items={items}
-            dropBackTransitionDuration={0.3}
-            type="horizontal"
-            onSort={this.onSort}
-            placeholder={<span></span>}
-          />
-        </div>
-      );
-
-    }
+    );
 
   }
 
@@ -275,7 +230,6 @@ r         onChange={this.updateInput}
         />
 
         <TagFieldValue tagValue={this.props.tagValue}/>
-
       </div>
     );
   }

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.js
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.js
@@ -6,6 +6,7 @@ import DragSortableList from 'react-drag-sortable';
 import CapiSearch from '../CapiSearch/Capisearch';
 import CapiUnavailable from '../CapiSearch/CapiUnavailable';
 import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
+import TagFieldValue from '../Tags/TagFieldValue';
 
 export default class TextInputTagPicker extends React.Component {
 
@@ -104,19 +105,6 @@ export default class TextInputTagPicker extends React.Component {
       });
     }
   };
-
-  renderFieldValue(value, index) {
-    if (value.webTitle) {
-      return (
-        <span key={`${value.id}-${index}`}>
-          <span className="form__field__tag__display">{value.webTitle}</span>
-          {' '}
-        </span>
-      );
-    } else {
-      return `${value} `;
-    }
-  }
 
   renderValue = (field, i) => {
     const removeFn = () => {
@@ -292,7 +280,7 @@ r         onChange={this.updateInput}
         <div>
           <p className="details-list__title">{this.props.fieldName}</p>
           <p className="details-list__field ">
-            {this.props.tagValue.map(this.renderFieldValue)}
+            <TagFieldValue tagValue={this.props.tagValue}/>
           </p>
         </div>
       );
@@ -322,7 +310,7 @@ r         onChange={this.updateInput}
           removeDupes={removeStringTagDuplicates}
         />
 
-        {this.props.tagValue.map(this.renderFieldValue)}
+        <TagFieldValue tagValue={this.props.tagValue}/>
 
       </div>
     );

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.js
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { PropTypes } from 'prop-types';
 import { keyCodes } from '../../constants/keyCodes';
 import UserActions from '../../constants/UserActions';
 import TagTypes from '../../constants/TagTypes';
@@ -7,6 +8,23 @@ import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
 import removeTagDuplicates from '../../util/removeTagDuplicates';
 
 export default class TextInputTagPicker extends React.Component {
+
+  static propTypes = {
+    tagValue: PropTypes.array.isRequired,
+    onUpdate: PropTypes.func.isRequired,
+    fetchTags: PropTypes.func.isRequired,
+    removeFn: PropTypes.func.isRequired,
+    onUpdate: PropTypes.func.isRequired,
+    capiTags: PropTypes.array.isRequired,
+    tagsToVisible: PropTypes.func.isRequired,
+    showTags: PropTypes.bool.isRequired,
+    hideTagResults: PropTypes.func.isRequired,
+    selectedTagIndex: PropTypes.number,
+    inputClearCount: PropTypes.number.isRequired,
+    disableCapiTags: PropTypes.bool,
+    tagType: PropTypes.string,
+    fieldName: PropTypes.string
+  }
 
   state = {
     inputString: '',

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.js
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.js
@@ -115,7 +115,7 @@ export default class TextInputTagPicker extends React.Component {
     }
   };
 
-  renderValue = (field, i) => {
+  renderValue = (field, i, isLastInput = false) => {
 
     if (field.id) {
       return (
@@ -130,7 +130,7 @@ export default class TextInputTagPicker extends React.Component {
     }
     return (
       <span
-        className="form__field--multistring__value"
+        className={ !isLastInput ? "form__field--multistring__value" : "form__field--multistring__last"}
         key={`${field.id}-${i}`}
       >
         {' '}{field}{' '}
@@ -142,7 +142,7 @@ export default class TextInputTagPicker extends React.Component {
 
     return (
       <span className="form__field__tag--container">
-        {lastElement && this.renderValue(lastElement, 0)}
+        {lastElement && this.renderValue(lastElement, 0, true)}
         <input
           type="text"
           className="form__field__tag--input"

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.js
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.js
@@ -61,7 +61,7 @@ export default class TextInputTagPicker extends React.Component {
       if (!this.props.disableCapiTags) {
         const searchText = e.target.value;
 
-        this.props.fetchTags(searchText)
+        this.props.fetchTags(searchText);
 
       }
     }
@@ -120,7 +120,7 @@ export default class TextInputTagPicker extends React.Component {
     if (field.id) {
       return (
         <span
-          className="form__field--multiselect__value"
+          className="form__field--multiselect__value form__field__tag__remove"
           key={`${field.id}-${i}`}
           onClick={removeFn}
         >
@@ -139,12 +139,6 @@ export default class TextInputTagPicker extends React.Component {
   };
 
   renderTextInputElement(lastElement) {
-    const getInputPlaceholder = () => {
-      if (!this.props.fieldValue || this.props.fieldValue.length === 0) {
-        return this.props.inputPlaceholder;
-      }
-      return '';
-    };
 
     if (this.props.disableTextInput) {
       return (
@@ -152,17 +146,11 @@ export default class TextInputTagPicker extends React.Component {
           {lastElement && this.renderValue(lastElement, 0)}
           <input
             type="text"
-            className={
-              'form__field__tag--input' +
-                (getInputPlaceholder().length !== 0
-                  ? ' form__field__tag--input--empty'
-                  : '')
-            }
+            className="form__field__tag--input"
             id={this.props.fieldName}
             ref={this.props.tagType + 'Input'}
             onChange={this.updateInput}
             value={this.state.inputString}
-            placeholder={getInputPlaceholder()}
           />
         </span>
       );
@@ -178,7 +166,6 @@ export default class TextInputTagPicker extends React.Component {
           onKeyDown={this.processTagInput}
 r         onChange={this.updateInput}
           value={this.state.inputString}
-          placeholder={getInputPlaceholder()}
         />
       </span>
     );

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.js
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.js
@@ -4,7 +4,6 @@ import UserActions from '../../constants/UserActions';
 import TagTypes from '../../constants/TagTypes';
 import CapiSearch from '../CapiSearch/Capisearch';
 import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
-import TagFieldValue from '../Tags/TagFieldValue';
 
 export default class TextInputTagPicker extends React.Component {
 
@@ -200,9 +199,7 @@ r         onChange={this.updateInput}
         {this.renderTextInputElement(lastElement)}
 
       </div>
-
     );
-
   }
 
   render() {
@@ -229,7 +226,6 @@ r         onChange={this.updateInput}
           removeDupes={removeStringTagDuplicates}
         />
 
-        <TagFieldValue tagValue={this.props.tagValue}/>
       </div>
     );
   }

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.js
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.js
@@ -41,7 +41,7 @@ export default class TextInputTagPicker extends React.Component {
         webTitle: this.state.inputString
       };
     }
-    return [];
+    return '';
   };
 
   updateInput = e => {
@@ -83,7 +83,7 @@ export default class TextInputTagPicker extends React.Component {
 
           const newInput = this.props.tagType === TagTypes.youtube ? this.getYoutubeInputValue() : this.state.inputString;
 
-          const newFieldValue = this.props.tagValue.concat([newInput]);
+          const newFieldValue = newInput ? this.props.tagValue.concat([newInput]) : this.props.tagValue;
 
           this.props.onUpdate(newFieldValue);
           this.setState({

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.js
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.js
@@ -105,23 +105,13 @@ export default class TextInputTagPicker extends React.Component {
   };
 
   renderValue = (field, i) => {
-    const removeFn = () => {
-      const newFieldValue = this.props.tagValue.filter(oldField => {
-        return field.id !== oldField.id;
-      });
-
-      this.setState({
-        inputString: ''
-      });
-      this.props.onUpdate(newFieldValue);
-    };
 
     if (field.id) {
       return (
         <span
           className="form__field--multiselect__value form__field__tag__remove"
           key={`${field.id}-${i}`}
-          onClick={removeFn}
+          onClick={tag => this.props.removeFn(field)}
         >
           {field.webTitle}{' '}
         </span>

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.js
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.js
@@ -13,6 +13,14 @@ export default class TextInputTagPicker extends React.Component {
     lastAction: UserActions.other,
   };
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.inputClearCount !== nextProps.inputClearCount) {
+      this.setState({
+        inputString: '',
+      });
+    }
+  }
+
   selectNewTag = (newFieldValue) => {
 
       this.setState({

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.js
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.js
@@ -4,6 +4,7 @@ import UserActions from '../../constants/UserActions';
 import TagTypes from '../../constants/TagTypes';
 import CapiSearch from '../CapiSearch/Capisearch';
 import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
+import removeTagDuplicates from '../../util/removeTagDuplicates';
 
 export default class TextInputTagPicker extends React.Component {
 

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.js
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { keyCodes } from '../../constants/keyCodes';
 import UserActions from '../../constants/UserActions';
 import TagTypes from '../../constants/TagTypes';
-import CapiSearch from '../CapiSearch/Capisearch';
+import CapiSearch from '../CapiSearch/CapiSearch';
 import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
 import removeTagDuplicates from '../../util/removeTagDuplicates';
 

--- a/public/video-ui/src/components/Tags/TagFieldValue.js
+++ b/public/video-ui/src/components/Tags/TagFieldValue.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export default class TagFieldValue extends React.Component {
+
+  renderFieldValue(value, index) {
+    if (value.webTitle) {
+      return (
+        <span key={`${value.id}-${index}`}>
+          <span className="form__field__tag__display">{value.webTitle}</span>
+          {' '}
+        </span>
+      );
+
+    }
+    return `${value} `;
+  }
+
+  render() {
+    return (
+      <span>
+        {this.props.tagValue.map(this.renderFieldValue)}
+      </span>
+    );
+
+  }
+}

--- a/public/video-ui/src/constants/keyCodes.js
+++ b/public/video-ui/src/constants/keyCodes.js
@@ -1,4 +1,6 @@
 export const keyCodes = {
   enter: 13,
-  backspace: 8
+  backspace: 8,
+  down: 40,
+  up: 38
 };

--- a/public/video-ui/src/services/capi.js
+++ b/public/video-ui/src/services/capi.js
@@ -36,17 +36,18 @@ export default class ContentApi {
   }
 
   static getTagsByType(query, types) {
-
-    return Promise.all(types.map(type => {
-      if (query === '*') {
+    return Promise.all(
+      types.map(type => {
+        if (query === '*') {
+          return pandaReqwest({
+            url: `${ContentApi.proxyUrl}/tags?page-size=100&type=${type}` //TODO this is likely to change based on CAPI work to search by prefix on webTitle
+          });
+        }
+        const encodedQuery = encodeURIComponent(query);
         return pandaReqwest({
-          url: `${ContentApi.proxyUrl}/tags?page-size=100&type=${type}` //TODO this is likely to change based on CAPI work to search by prefix on webTitle
+          url: `${ContentApi.proxyUrl}/tags?page-size=100&type=${type}&web-title=${encodedQuery}`
         });
-      }
-      const encodedQuery = encodeURIComponent(query);
-      return pandaReqwest({
-        url: `${ContentApi.proxyUrl}/tags?page-size=100&type=${type}&web-title=${encodedQuery}`
-      });
-    }));
+      })
+    );
   }
 }

--- a/public/video-ui/src/util/getTagDisplayNames.js
+++ b/public/video-ui/src/util/getTagDisplayNames.js
@@ -1,0 +1,25 @@
+import TagTypes from '../constants/TagTypes';
+
+export default function getTagDisplayNames(tags, tagType) {
+  return tags.map(tag => {
+    if (tagType === TagTypes.keyword) {
+      let detailedTitle;
+
+      //Some webtitles on keyword tags are too unspecific and we need to add
+      //the section name to them to know what tags they are referring to
+
+      if (
+        tag.webTitle !== tag.sectionName &&
+        tag.webTitle.split(' ').length <= 2
+      ) {
+        detailedTitle = tag.webTitle + ' (' + tag.sectionName + ')';
+      } else {
+        detailedTitle = tag.webTitle;
+      }
+
+      return { id: tag.id, webTitle: detailedTitle };
+    }
+    return { id: tag.id, webTitle: tag.webTitle };
+  });
+
+}

--- a/public/video-ui/src/util/removeTagDuplicates.js
+++ b/public/video-ui/src/util/removeTagDuplicates.js
@@ -1,0 +1,4 @@
+export default function removeTagDuplicates(tag, tagValue) {
+
+  return tagValue.filter(value => value.id !== tag.id);
+}

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -114,7 +114,7 @@
     border-color: $dangerColor;
   }
 
-  &--external__error {
+  &--external-error {
     color: $dangerColor;
     margin-top: 10px;
   }

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -355,6 +355,7 @@
     display: inline-block;
     font-weight: normal;
     margin-left: 4px;
+    cursor: pointer;
   }
 }
 

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -21,6 +21,9 @@
   color: $textColor;
   font-size: 13px;
   width: 60px;
+  padding-top: 4px;
+  margin-bottom: 4px;
+  margin-left: 2px;
   &:focus {
     outline: none;
   }
@@ -31,7 +34,7 @@
 }
 
 .form__field__tag--container {
-  padding-top: 2px;
+  display: flex;
 }
 
 .form__field__selected__tag {
@@ -55,7 +58,7 @@
   padding: 5px 5px;
   cursor: pointer;
   flex-wrap: wrap;
-  min-height: 35px;
+  min-height: 36px;
 }
 
 .form__field {
@@ -67,7 +70,7 @@
   background-color: $color650Grey;
   color: $cWhite;
   display: inline-block;
-  height: 35px;
+  height: 36px;
 
   &:not(:last-child) {
     margin: 0 0 10px;
@@ -362,6 +365,11 @@
 .form__field--multistring__value {
   padding-right: 2px;
   padding-top: 2px;
+}
+
+
+.form__field--multistring__last {
+  margin-top: 2px;
 }
 
 // bit specific

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -35,6 +35,12 @@
 }
 
 .form__field__selected__tag {
+  border: 1px solid $color400Grey;
+  margin-top: 3px;
+  padding: 3px;
+}
+
+.form__field__tag__list {
   padding: 3px;
   border: 1px solid $color400Grey;
   margin-top: 3px;

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -290,6 +290,7 @@
 
 .form__field__tag__display {
   text-decoration: underline $textColor;
+  padding: 3px;
 }
 
 .form__field--multiselect {

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -34,6 +34,12 @@
   padding-top: 2px;
 }
 
+.form__field__selected__tag {
+  padding: 3px;
+  border: 1px solid $color400Grey;
+  margin-top: 3px;
+}
+
 .form__field__tag--selector {
   display: flex;
   align-content: flex-start;
@@ -327,13 +333,15 @@
     cursor: pointer;
     flex-shrink: 0;
 
+  }
+}
 
-    &:after {
-      content: '×';
-      display: inline-block;
-      font-weight: normal;
-      margin-left: 4px;
-    }
+.form__field__tag__remove {
+  &:after {
+    content: '×';
+    display: inline-block;
+    font-weight: normal;
+    margin-left: 4px;
   }
 }
 

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -107,6 +107,7 @@
 
   &--external__error {
     color: $dangerColor;
+    margin-top: 10px;
   }
 
   &--warning {
@@ -274,7 +275,12 @@
   cursor: pointer;
   overflow: auto;
   max-height: 250px;
+
+  &--selected {
+    background: $color800Grey;
+  }
 }
+
 
 .form__field__tag__display {
   text-decoration: underline $textColor;


### PR DESCRIPTION

![out](https://user-images.githubusercontent.com/3066534/28963720-0e12a51c-7902-11e7-8f49-bf404d237766.gif)
- Apologies for the long PR: by the time I realised I needed to rearrange the tag picker for this, I had already started on many of the improvements. 

- This PR makes many improvements to the usability of the tag pickers
- It hides tag search results when user is no longer focuses on the input
- It allows for navigating up and down search results using arrow keys
- It fixes padding issues in the byline picker
- It changes the commissioning and keyword tag picker presentation to be more in line with what is on composer (showing selected tag as a vertical list, not on the input element itself)
- It also breaks the tag picker into multiple components to make it more usable and to allow for more customisation.

