### PR TITLE
disable poster image picker when edit form is open

### DIFF
--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -135,6 +135,7 @@ class VideoDisplay extends React.Component {
           saveAndUpdateVideo={this.saveAndUpdateVideo}
           updateErrors={this.props.formErrorActions.updateFormErrors}
           config={this.props.config}
+          videoEditOpen={this.props.videoEditOpen}
         />
       </div>
     );


### PR DESCRIPTION
The prop wasn't passed in so the button didn't get disabled.