### PR TITLE
always edit the main block

### DIFF
--- a/public/video-ui/src/actions/FormErrorActions/updateFormWarnings.js
+++ b/public/video-ui/src/actions/FormErrorActions/updateFormWarnings.js
@@ -1,0 +1,7 @@
+export function updateFormWarnings(warning) {
+  return {
+    type: 'FIELD_WARNINGS_UPDATE_REQUEST',
+    warning: warning,
+    receivedAt: Date.now()
+  };
+}

--- a/public/video-ui/src/components/FormFields/ScribeEditor.js
+++ b/public/video-ui/src/components/FormFields/ScribeEditor.js
@@ -6,6 +6,7 @@ import scribePluginToolbar from 'scribe-plugin-toolbar';
 import scribePluginLinkPromptCommand from 'scribe-plugin-link-prompt-command';
 import scribePluginSanitizer from 'scribe-plugin-sanitizer';
 import {keyCodes} from '../../constants/keyCodes';
+import {requiredForComposerWarning} from '../../constants/requiredForComposerWarning';
 
 export default class ScribeEditorField extends React.Component {
   state = {
@@ -102,7 +103,7 @@ export default class ScribeEditorField extends React.Component {
   };
 
   renderField() {
-    const hasWarning = this.state.wordCount === 0;
+    const hasWarning = this.state.wordCount === 0  && this.props.fieldLocation === 'trailText';
 
     if (!this.props.editable) {
       if (this.state.wordCount === 0) {
@@ -136,7 +137,7 @@ export default class ScribeEditorField extends React.Component {
         </div>
         {hasWarning
           ? <p className="form__message form__message--warning">
-              This field is recommended
+            {requiredForComposerWarning}
             </p>
           : ''}
       </div>

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -304,6 +304,8 @@ export default class TagPicker extends React.Component {
 
   render() {
 
+    const hasWarning = this.props.hasWarning(this.props) && this.state.capiTags.length === 0;
+
     if (!this.props.editable) {
       if (!this.state.tagValue || this.state.tagValue.length === 0) {
         return (

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -12,6 +12,7 @@ import CapiUnavailable from '../CapiSearch/CapiUnavailable';
 import DragSortableList from 'react-drag-sortable';
 import removeTagDuplicates from '../../util/removeTagDuplicates';
 import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
+import {requiredForComposerWarning} from '../../constants/requiredForComposerWarning';
 
 export default class TagPicker extends React.Component {
 
@@ -341,6 +342,11 @@ export default class TagPicker extends React.Component {
 
         <CapiUnavailable capiUnavailable={this.state.capiUnavailable} />
         {this.renderTagPicker()}
+        {hasWarning
+          ? <p className="form__message form__message--warning">
+          {requiredForComposerWarning}
+          </p>
+            : ''}
         {this.renderAddedTags()}
       </div>
     );

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -342,12 +342,12 @@ export default class TagPicker extends React.Component {
 
         <CapiUnavailable capiUnavailable={this.state.capiUnavailable} />
         {this.renderTagPicker()}
+        {this.renderAddedTags()}
         {hasWarning
           ? <p className="form__message form__message--warning">
-          {requiredForComposerWarning}
+          {this.props.notification.message}
           </p>
             : ''}
-        {this.renderAddedTags()}
       </div>
     );
   }

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -9,26 +9,21 @@ import { Presence } from './Presence';
 import { getComposerPages } from '../util/getComposerPages';
 
 export default class Header extends React.Component {
- estate = { presence: null };
+  state = { presence: null };
 
   publishVideo = () => {
     this.props.publishVideo(this.props.video.id);
   };
 
-
   requiredComposerFieldsMissing = () => {
-
     return Object.keys(this.props.formFieldsWarning).some(key => {
-
       return this.props.formFieldsWarning[key];
     });
-  }
+  };
 
   composerPageExists = () => {
     return getComposerPages(this.props.usages).length > 0;
   };
-
-
 
   renderProgress() {
     if (this.props.s3Upload.total) {
@@ -67,7 +62,7 @@ export default class Header extends React.Component {
     );
   }
 
-  render() {
+  renderHeaderBack() {
     return (
       <div className="flex-container topbar__global">
         <Link
@@ -128,6 +123,26 @@ export default class Header extends React.Component {
     return false;
   }
 
+  renderComposerMissingWarning() {
+    if (!this.requiredComposerFieldsMissing()) {
+      return null;
+    }
+
+    if (this.composerPageExists()) {
+      return (
+        <div className="header__fields__missing__warning">
+          Fill in required composer fields before publishing
+        </div>
+      );
+    }
+
+    return (
+      <div className="header__fields__missing__warning">
+        Fill in required composer fields before creating video page
+      </div>
+    );
+  }
+
   render() {
     const className = this.props.isTrainingMode
       ? 'topbar topbar--training-mode flex-container'
@@ -181,7 +196,6 @@ export default class Header extends React.Component {
             requiredComposerFieldsMissing={this.requiredComposerFieldsMissing}
             composerPageExists={this.composerPageExists}
           />
-
           <AdvancedActions video={this.props.video || {}} />
           <ComposerPageCreate
             usages={this.props.usages}
@@ -191,6 +205,7 @@ export default class Header extends React.Component {
             requiredComposerFieldsMissing={this.requiredComposerFieldsMissing}
             composerPageExists={this.composerPageExists}
           />
+          {this.renderComposerMissingWarning()}
           <div className="flex-container">
             {this.renderAuditLink()}
             {this.renderHelpLink()}

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -6,13 +6,29 @@ import AdvancedActions from './Videos/AdvancedActions';
 import ComposerPageCreate from './Videos/ComposerPageCreate';
 import Icon from './Icon';
 import { Presence } from './Presence';
+import { getComposerPages } from '../util/getComposerPages';
 
 export default class Header extends React.Component {
-  state = { presence: null };
+ estate = { presence: null };
 
   publishVideo = () => {
     this.props.publishVideo(this.props.video.id);
   };
+
+
+  requiredComposerFieldsMissing = () => {
+
+    return Object.keys(this.props.formFieldsWarning).some(key => {
+
+      return this.props.formFieldsWarning[key];
+    });
+  }
+
+  composerPageExists = () => {
+    return getComposerPages(this.props.usages).length > 0;
+  };
+
+
 
   renderProgress() {
     if (this.props.s3Upload.total) {
@@ -51,7 +67,7 @@ export default class Header extends React.Component {
     );
   }
 
-  renderHeaderBack() {
+  render() {
     return (
       <div className="flex-container topbar__global">
         <Link
@@ -161,6 +177,9 @@ export default class Header extends React.Component {
             updateVideoPage={this.props.updateVideoPage}
             usages={this.props.usages}
             publishVideo={this.publishVideo}
+            formFieldsWarning={this.props.formFieldsWarning}
+            requiredComposerFieldsMissing={this.requiredComposerFieldsMissing}
+            composerPageExists={this.composerPageExists}
           />
 
           <AdvancedActions video={this.props.video || {}} />
@@ -169,6 +188,8 @@ export default class Header extends React.Component {
             videoEditOpen={this.props.videoEditOpen}
             video={this.props.video || {}}
             createVideoPage={this.props.createVideoPage}
+            requiredComposerFieldsMissing={this.requiredComposerFieldsMissing}
+            composerPageExists={this.composerPageExists}
           />
           <div className="flex-container">
             {this.renderAuditLink()}

--- a/public/video-ui/src/components/ManagedForm/ManagedField.js
+++ b/public/video-ui/src/components/ManagedForm/ManagedField.js
@@ -26,7 +26,8 @@ export class ManagedField extends React.Component {
     fieldDetails: PropTypes.string,
     tagType: PropTypes.string,
     inputPlaceholder: PropTypes.string,
-    tooltip: PropTypes.string
+    tooltip: PropTypes.string,
+    fieldLocation: PropTypes.string
   };
 
   state = {
@@ -140,7 +141,8 @@ export class ManagedField extends React.Component {
         maxCharLength: this.props.maxCharLength,
         tagType: this.props.tagType,
         inputPlaceholder: this.props.inputPlaceholder,
-        tooltip: this.props.tooltip
+        tooltip: this.props.tooltip,
+        fieldLocation: this.props.fieldLocation
       });
     });
     return <div className={className}>{hydratedChildren}</div>;

--- a/public/video-ui/src/components/ManagedForm/ManagedField.js
+++ b/public/video-ui/src/components/ManagedForm/ManagedField.js
@@ -3,7 +3,9 @@ import { PropTypes } from 'prop-types';
 import _get from 'lodash/fp/get';
 import _set from 'lodash/fp/set';
 import validateField from '../../util/validateField';
+import {getTextFromHtml} from '../../util/getTextFromHtml';
 import FieldNotification from '../../constants/FieldNotification';
+import {fieldsWithHtml} from '../../constants/fieldsWithHtml';
 
 export class ManagedField extends React.Component {
   static propTypes = {
@@ -14,7 +16,7 @@ export class ManagedField extends React.Component {
     ]),
     updateData: PropTypes.func,
     updateFormErrors: PropTypes.func,
-    updateFormWarnings: PropTypes.func,
+    updateWarnings: PropTypes.func,
     customValidation: PropTypes.func,
     data: PropTypes.object,
     fieldName: PropTypes.string,
@@ -45,24 +47,40 @@ export class ManagedField extends React.Component {
   }
 
   checkErrorsAndWarnings(value) {
-    if (this.props.updateFormErrors) {
-      const notification = validateField(
-        value,
-        this.props.isRequired,
-        this.props.isDesired,
-        this.props.customValidation
-      );
 
+    if (value && fieldsWithHtml.includes(this.props.fieldLocation)) {
+      value = getTextFromHtml(value);
+    }
+
+    const notification = validateField(
+      value,
+      this.props.isRequired,
+      this.props.isDesired,
+      this.props.customValidation
+    );
+
+    if (this.props.updateFormErrors) {
       if (notification && notification.type === FieldNotification.error) {
         this.props.updateFormErrors(notification, this.props.fieldLocation);
       } else {
         this.props.updateFormErrors(null, this.props.fieldLocation);
       }
-
-      this.setState({
-        fieldNotification: notification
-      });
     }
+
+    if (this.props.updateWarnings) {
+
+      if (notification && notification.type === FieldNotification.warning) {
+        this.props.updateWarnings(true, this.props.fieldLocation);
+
+      } else {
+        this.props.updateWarnings(false, this.props.fieldLocation);
+
+      }
+    }
+
+    this.setState({
+      fieldNotification: notification
+    });
   }
 
   updateFn = newValue => {

--- a/public/video-ui/src/components/ManagedForm/ManagedForm.js
+++ b/public/video-ui/src/components/ManagedForm/ManagedForm.js
@@ -12,13 +12,22 @@ export class ManagedForm extends React.Component {
     editable: PropTypes.bool,
     formName: PropTypes.string,
     formClass: PropTypes.string,
-    updateErrors: PropTypes.func
+    updateErrors: PropTypes.func,
+    updateWarnings: PropTypes.func
   };
 
   updateFormErrors = (fieldError, fieldName) => {
     if (this.props.updateErrors) {
       this.props.updateErrors({
         [this.props.formName]: { [fieldName]: fieldError }
+      });
+    }
+  };
+
+  updateWarnings = (hasFieldWarning, fieldName) => {
+    if (this.props.updateWarnings) {
+      this.props.updateWarnings({
+        [fieldName]: hasFieldWarning
       });
     }
   };
@@ -40,6 +49,7 @@ export class ManagedForm extends React.Component {
         data: this.props.data,
         updateData: this.props.updateData,
         updateFormErrors: this.updateFormErrors,
+        updateWarnings: this.updateWarnings,
         editable: this.props.editable
       });
     });

--- a/public/video-ui/src/components/ManagedForm/ManagedSection.js
+++ b/public/video-ui/src/components/ManagedForm/ManagedSection.js
@@ -23,6 +23,7 @@ export class ManagedSection extends React.Component {
         data: this.props.data,
         updateData: this.props.updateData,
         updateFormErrors: this.props.updateFormErrors,
+        updateWarnings: this.props.updateWarnings,
         editable: this.props.editable
       });
     });

--- a/public/video-ui/src/components/ReactApp.js
+++ b/public/video-ui/src/components/ReactApp.js
@@ -72,6 +72,7 @@ class ReactApp extends React.Component {
           usages={this.props.usages}
           presenceConfig={this.props.config.presence}
           isTrainingMode={this.props.config.isTrainingMode}
+          formFieldsWarning={this.props.formFieldsWarning}
         />
         {this.props.error
           ? <div className="error-bar">{this.props.error}</div>
@@ -109,7 +110,8 @@ function mapStateToProps(state) {
     checkedFormFields: state.checkedFormFields,
     videoEditOpen: state.videoEditOpen,
     usages: state.usage,
-    config: state.config
+    config: state.config,
+    formFieldsWarning: state.formFieldsWarning
   };
 }
 

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -178,6 +178,7 @@ class VideoDisplay extends React.Component {
                   editable={this.props.videoEditOpen}
                   formName={formNames.videoData}
                   updateErrors={this.props.formErrorActions.updateFormErrors}
+                  updateWarnings={this.props.formErrorActions.updateFormWarnings}
                 />
               </div>
               {this.renderPreview()}
@@ -215,6 +216,8 @@ import * as updateVideoEditState
   from '../../actions/VideoActions/updateVideoEditState';
 import * as updateFormErrors
   from '../../actions/FormErrorActions/updateFormErrors';
+import * as updateFormWarnings
+  from '../../actions/FormErrorActions/updateFormWarnings';
 
 function mapStateToProps(state) {
   return {
@@ -224,7 +227,7 @@ function mapStateToProps(state) {
     composerPageWithUsage: state.pageCreate,
     publishedVideo: state.publishedVideo,
     videoEditOpen: state.videoEditOpen,
-    checkedFormFields: state.checkedFormFields
+    checkedFormFields: state.checkedFormFields,
   };
 }
 
@@ -244,7 +247,7 @@ function mapDispatchToProps(dispatch) {
       dispatch
     ),
     formErrorActions: bindActionCreators(
-      Object.assign({}, updateFormErrors),
+      Object.assign({}, updateFormErrors, updateFormWarnings),
       dispatch
     )
   };

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -68,13 +68,18 @@ class VideoDisplay extends React.Component {
     });
   };
 
-  validateDescription = description => {
-    if (!description) {
-      return new FieldNotification(
-        'required',
-        'It is recommeded you fill in this field for seo',
-        FieldNotification.warning
-      );
+  validateKeywords = keywords => {
+    if (!Array.isArray(keywords) ||
+        keywords.length === 0 ||
+        keywords.every(keyword => {
+          return keyword.match(/^tone/);
+        })
+       ) {
+        return new FieldNotification(
+          'desired',
+          'A series or a keyword tag is required for creating composer pages',
+          FieldNotification.warning
+        );
     }
     return null;
   };
@@ -179,6 +184,7 @@ class VideoDisplay extends React.Component {
                   formName={formNames.videoData}
                   updateErrors={this.props.formErrorActions.updateFormErrors}
                   updateWarnings={this.props.formErrorActions.updateFormWarnings}
+                  validateKeywords={this.validateKeywords}
                 />
               </div>
               {this.renderPreview()}

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -100,6 +100,7 @@ class VideoData extends React.Component {
               name="Comissioning Desks"
               formRowClass="form__row__byline"
               tagType={TagTypes.tracking}
+              isDesired={true}
               inputPlaceholder="Search commissioning info (type '*' to show all)"
             >
               <TagPicker disableTextInput />
@@ -110,6 +111,7 @@ class VideoData extends React.Component {
               name="Composer Keywords"
               formRowClass="form__row__byline"
               tagType={TagTypes.keyword}
+              isDesired={true}
               inputPlaceholder="Search keywords (type '*' to show all)"
             >
               <TagPicker disableTextInput />

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -44,6 +44,7 @@ class VideoData extends React.Component {
           updateData={this.props.updateVideo}
           editable={this.props.editable}
           updateErrors={this.props.updateErrors}
+          updateWarnings={this.props.updateWarnings}
           formName={this.props.formName}
           formClass="atom__edit__form"
         >
@@ -66,7 +67,6 @@ class VideoData extends React.Component {
                   : 'Standfirst (YouTube description)'
               }
               customValidation={this.props.descriptionValidator}
-              isDesired={true}
               maxCharLength={fieldLengths.description.charMax}
               maxLength={fieldLengths.description.max}
             >
@@ -80,6 +80,7 @@ class VideoData extends React.Component {
               name="Trail Text"
               maxCharLength={fieldLengths.description.charMax}
               maxLength={fieldLengths.description.max}
+              isDesired={true}
             >
               <ScribeEditorField
                 allowedEdits={['bold', 'italic']}

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -114,6 +114,7 @@ class VideoData extends React.Component {
               tagType={TagTypes.keyword}
               isDesired={true}
               inputPlaceholder="Search keywords (type '*' to show all)"
+              customValidation={this.props.validateKeywords}
             >
               <TagPicker disableTextInput />
             </ManagedField>

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -23,7 +23,8 @@ export default class VideoPublishBar extends React.Component {
     return (
       this.videoIsCurrentlyPublishing() ||
       this.props.videoEditOpen ||
-      !this.videoHasUnpublishedChanges()
+      !this.videoHasUnpublishedChanges() ||
+      (this.props.composerPageExists() && this.props.requiredComposerFieldsMissing())
     );
   }
 

--- a/public/video-ui/src/components/Videos/ComposerPageCreate.js
+++ b/public/video-ui/src/components/Videos/ComposerPageCreate.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { getVideoBlock } from '../../util/getVideoBlock';
 import Icon from '../Icon';
 import { getStore } from '../../util/storeAccessor';
-import { getComposerPages } from '../../util/getComposerPages';
 
 export default class ComposerPageCreate extends React.Component {
   state = {
@@ -11,10 +10,6 @@ export default class ComposerPageCreate extends React.Component {
 
   getComposerUrl = () => {
     return getStore().getState().config.composerUrl;
-  };
-
-  composerPageExists = () => {
-    return getComposerPages(this.props.usages).length > 0;
   };
 
   isHosted = () => {
@@ -48,7 +43,7 @@ export default class ComposerPageCreate extends React.Component {
   };
 
   render() {
-    if (this.composerPageExists() || this.isHosted()) {
+    if (this.props.composerPageExists() || this.isHosted()) {
       return null;
     }
 
@@ -57,7 +52,7 @@ export default class ComposerPageCreate extends React.Component {
         className="button__secondary"
         onClick={this.pageCreate}
         disabled={
-          this.props.videoEditOpen || this.state.composerUpdateInProgress
+          this.props.videoEditOpen || this.state.composerUpdateInProgress || this.props.requiredComposerFieldsMissing()
         }
       >
         <Icon icon="add_to_queue" /> Create Video Page

--- a/public/video-ui/src/constants/fieldsWithHtml.js
+++ b/public/video-ui/src/constants/fieldsWithHtml.js
@@ -1,0 +1,1 @@
+export const fieldsWithHtml = ['trailText', 'description'];

--- a/public/video-ui/src/constants/requiredForComposerWarning.js
+++ b/public/video-ui/src/constants/requiredForComposerWarning.js
@@ -1,0 +1,1 @@
+export const requiredForComposerWarning = 'This field is required for creating composer pages';

--- a/public/video-ui/src/constants/requiredForComposerWarning.js
+++ b/public/video-ui/src/constants/requiredForComposerWarning.js
@@ -1,1 +1,2 @@
-export const requiredForComposerWarning = 'This field is required for creating composer pages';
+export const requiredForComposerWarning =
+  'This field is required for creating composer pages';

--- a/public/video-ui/src/reducers/formFieldsWarningReducer.js
+++ b/public/video-ui/src/reducers/formFieldsWarningReducer.js
@@ -1,0 +1,10 @@
+export default function warnings(state = {}, action) {
+  switch (action.type) {
+    case 'FIELD_WARNINGS_UPDATE_REQUEST':
+      return Object.assign({}, state, action.warning);
+
+  default:
+    return state;
+  }
+
+}

--- a/public/video-ui/src/reducers/formFieldsWarningReducer.js
+++ b/public/video-ui/src/reducers/formFieldsWarningReducer.js
@@ -3,8 +3,7 @@ export default function warnings(state = {}, action) {
     case 'FIELD_WARNINGS_UPDATE_REQUEST':
       return Object.assign({}, state, action.warning);
 
-  default:
-    return state;
+    default:
+      return state;
   }
-
 }

--- a/public/video-ui/src/reducers/rootReducer.js
+++ b/public/video-ui/src/reducers/rootReducer.js
@@ -15,6 +15,7 @@ import s3Upload from './s3UploadReducer';
 import videoEditOpen from './editStateReducer';
 import plutoVideos from './plutoVideosReducer';
 import checkedFormFields from './checkedFormFieldsReducer';
+import formFieldsWarning from './formFieldsWarningReducer';
 import uploads from './uploadsReducer';
 import path from './pathReducer';
 import pluto from './plutoReducer';
@@ -33,6 +34,7 @@ export default combineReducers({
   publishedVideo,
   plutoVideos,
   checkedFormFields,
+  formFieldsWarning,
   s3Upload,
   videoEditOpen,
   uploads,

--- a/public/video-ui/src/util/getTextFromHtml.js
+++ b/public/video-ui/src/util/getTextFromHtml.js
@@ -1,7 +1,4 @@
 export function getTextFromHtml(html) {
-
-  const string = html.replace(/<\/?[^>]+(>|$)/g, "");
+  const string = html.replace(/<\/?[^>]+(>|$)/g, '');
   return string;
-
 }
-

--- a/public/video-ui/src/util/getTextFromHtml.js
+++ b/public/video-ui/src/util/getTextFromHtml.js
@@ -1,0 +1,7 @@
+export function getTextFromHtml(html) {
+
+  const string = html.replace(/<\/?[^>]+(>|$)/g, "");
+  return string;
+
+}
+

--- a/public/video-ui/src/util/parseGridMetadata.js
+++ b/public/video-ui/src/util/parseGridMetadata.js
@@ -1,4 +1,5 @@
 import { getGridMediaId } from './getGridMediaId';
+import { getTextFromHtml } from './getTextFromHtml';
 
 function parseMimeType(mimeType) {
   //Normalise Mime Types coming from the grid.
@@ -57,9 +58,7 @@ export function parseComposerDataFromImage(image, trail) {
     return composerAsset;
   }
 
-  const tempDiv = document.createElement('div');
-  tempDiv.innerHTML = trail;
-  const alt = tempDiv.innerText;
+  const alt = getTextFromHtml(trail);
 
   return {
     assets: [getComposerMasterAsset(image.master)].concat(

--- a/public/video-ui/src/util/validateField.js
+++ b/public/video-ui/src/util/validateField.js
@@ -7,6 +7,7 @@ const validateField = (
   isDesired: false,
   customValidation: null
 ) => {
+
   if (customValidation) {
     return customValidation(fieldValue);
   }
@@ -19,8 +20,10 @@ const validateField = (
     );
   }
 
-  if (isDesired &&
-      (!fieldValue || (fieldValue instanceof Array && fieldValue.length === 0))) {
+  if (
+      isDesired &&
+      (!fieldValue || (fieldValue instanceof Array && fieldValue.length === 0))
+    ) {
     return new FieldNotification(
       'desired',
       requiredForComposerWarning,

--- a/public/video-ui/src/util/validateField.js
+++ b/public/video-ui/src/util/validateField.js
@@ -1,4 +1,5 @@
 import FieldNotification from '../constants/FieldNotification';
+import {requiredForComposerWarning} from '../constants/requiredForComposerWarning';
 
 const validateField = (
   fieldValue,
@@ -21,7 +22,7 @@ const validateField = (
   if (isDesired && !fieldValue) {
     return new FieldNotification(
       'desired',
-      'This field is recommended',
+      requiredForComposerWarning,
       FieldNotification.warning
     );
   }

--- a/public/video-ui/src/util/validateField.js
+++ b/public/video-ui/src/util/validateField.js
@@ -23,7 +23,7 @@ const validateField = (
 
   if (
     isDesired &&
-    (!fieldValue || (fieldValue instanceof Array && fieldValue.length === 0))
+    (!fieldValue || (Array.isArray(fieldValue) && fieldValue.length === 0))
   ) {
     return new FieldNotification(
       'desired',

--- a/public/video-ui/src/util/validateField.js
+++ b/public/video-ui/src/util/validateField.js
@@ -19,7 +19,8 @@ const validateField = (
     );
   }
 
-  if (isDesired && !fieldValue) {
+  if (isDesired &&
+      (!fieldValue || (fieldValue instanceof Array && fieldValue.length === 0))) {
     return new FieldNotification(
       'desired',
       requiredForComposerWarning,

--- a/public/video-ui/src/util/validateField.js
+++ b/public/video-ui/src/util/validateField.js
@@ -1,5 +1,7 @@
 import FieldNotification from '../constants/FieldNotification';
-import {requiredForComposerWarning} from '../constants/requiredForComposerWarning';
+import {
+  requiredForComposerWarning
+} from '../constants/requiredForComposerWarning';
 
 const validateField = (
   fieldValue,
@@ -7,7 +9,6 @@ const validateField = (
   isDesired: false,
   customValidation: null
 ) => {
-
   if (customValidation) {
     return customValidation(fieldValue);
   }
@@ -21,9 +22,9 @@ const validateField = (
   }
 
   if (
-      isDesired &&
-      (!fieldValue || (fieldValue instanceof Array && fieldValue.length === 0))
-    ) {
+    isDesired &&
+    (!fieldValue || (fieldValue instanceof Array && fieldValue.length === 0))
+  ) {
     return new FieldNotification(
       'desired',
       requiredForComposerWarning,

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -160,7 +160,7 @@
 
 .form__message {
   font-size: 13px;
-  margin: 0;
+  margin-top: 10px;
 
   &--error {
     color: $dangerColor;

--- a/public/video-ui/styles/components/_header.scss
+++ b/public/video-ui/styles/components/_header.scss
@@ -41,3 +41,9 @@
   text-overflow: ellipsis;
   margin-right: 10px;
 }
+
+.header__fields__missing__warning {
+  color: $dangerColor;
+  width: 180px;
+  margin-left: 5px;
+}


### PR DESCRIPTION
- If a composer video page is live, any changes to media atom fields should update the live composer page on publish

- Just editing the live data of a published composer page seems to be enough to accomplish this.

- I've added checks and warning messages to make sure we don't create or update composer when required composer fields are not filled in. The warning messages look pretty ugly but since the logic is a little bit complicated (publishing is only disabled if a composer page exists, otherwise creation of composer page is restricted), I didn't want to rely on only exclamation marks on buttons or tooltips. @akash1810 

<img width="967" alt="screen shot 2017-08-09 at 08 15 10" src="https://user-images.githubusercontent.com/3066534/29110943-532e99b2-7ce0-11e7-8ef0-a76008380250.png">
