### PR TITLE
empty array for usages when no video page

### DIFF
--- a/public/video-ui/src/actions/VideoActions/videoUsages.js
+++ b/public/video-ui/src/actions/VideoActions/videoUsages.js
@@ -28,6 +28,11 @@ function errorReceivingVideoUsages(error) {
 export function getUsages(id) {
   return dispatch => {
     dispatch(requestVideoUsages());
+
+    if (!id) {
+      return dispatch(receiveVideoUsages([]));
+    }
+
     return VideosApi.getVideoUsages(id)
       .then(res => {
         const usagePaths = res.response.results;

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -13,12 +13,14 @@ import { blankVideoData } from '../../constants/blankVideoData';
 
 class VideoDisplay extends React.Component {
   componentWillMount() {
+
+    this.props.videoActions.getUsages(this.props.params.id);
+
     if (this.props.route.mode === 'create') {
       this.props.videoActions.updateVideo(blankVideoData);
       this.props.videoActions.updateVideoEditState(true);
     } else {
       this.props.videoActions.getVideo(this.props.params.id);
-      this.props.videoActions.getUsages(this.props.params.id);
     }
   }
 


### PR DESCRIPTION
We should always fetch usages for videos but when the video id does not exist, we should just return an empty array.

