### PR TITLE
isMandatory as string

### DIFF
--- a/public/video-ui/src/util/parseGridMetadata.js
+++ b/public/video-ui/src/util/parseGridMetadata.js
@@ -68,7 +68,7 @@ export function parseComposerDataFromImage(image, trail) {
     fields: {
       alt: alt,
       imageType: 'Photograph',
-      isMandatory: true,
+      isMandatory: 'true',
       mediaApiUrl: image.mediaId,
       mediaId: mediaId,
       source: image.source


### PR DESCRIPTION
`isMandatory` should be a string so that the image fields get parsed correctly by composer and alt text is displayed on the image.