### PR TITLE
Image metadata

### DIFF
--- a/app/model/Image.scala
+++ b/app/model/Image.scala
@@ -25,14 +25,16 @@ object ImageAsset {
     imgAsset.dimensions.map(ImageAssetDimensions.fromThrift), imgAsset.size, imgAsset.aspectRatio)
 }
 
-case class Image(assets: List[ImageAsset], master: Option[ImageAsset], mediaId: String, source: Option[String]) {
-  def asThrift = ThriftImage(assets.map(_.asThrift), master.map(_.asThrift), mediaId, source)
+case class Image(assets: List[ImageAsset], master: Option[ImageAsset], mediaId: String, source: Option[String],
+                photographer: Option[String], suppliersReference: Option[String]) {
+  def asThrift = ThriftImage(assets.map(_.asThrift), master.map(_.asThrift), mediaId, source, photographer, suppliersReference)
 }
 
 object Image {
   implicit val imageFormat = Jsonx.formatCaseClass[Image]
 
   def fromThrift(img: ThriftImage) =
-    Image(img.assets.map(ImageAsset.fromThrift).toList, img.master.map(ImageAsset.fromThrift), img.mediaId, img.source)
+    Image(img.assets.map(ImageAsset.fromThrift).toList, img.master.map(ImageAsset.fromThrift), img.mediaId, img.source,
+    img.photographer, img.suppliersReference)
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val awsVersion = "1.11.125"
   val pandaVersion = "0.4.0"
   val mockitoVersion = "2.0.97-beta"
-  val atomMakerVersion = "1.1.2"
+  val atomMakerVersion = "1.1.5"
   val slf4jVersion = "1.7.21"
   val typesafeConfigVersion = "1.3.0" // to match what we get from Play transitively
   val scanamoVersion = "0.9.1" // to match what we get from atom-publisher-lib transitively

--- a/public/video-ui/src/util/parseGridMetadata.js
+++ b/public/video-ui/src/util/parseGridMetadata.js
@@ -31,7 +31,9 @@ export function parseImageFromGridCrop(cropData, imageData) {
     assets: cropData.assets.map(asset => parseAsset(asset, aspectRatio)),
     master: parseAsset(cropData.master, aspectRatio),
     mediaId: cropData.specification.uri,
-    source: imageData.data.metadata.credit
+    source: imageData.data.metadata.credit,
+    suppliersReference: imageData.data.metadata.suppliersReference,
+    photographer: imageData.data.metadata.byline
   };
 }
 
@@ -71,7 +73,9 @@ export function parseComposerDataFromImage(image, trail) {
       isMandatory: true,
       mediaApiUrl: image.mediaId,
       mediaId: mediaId,
-      source: image.source
+      source: image.source,
+      suppliersReference: image.suppliersReference,
+      photographer: image.photographer
     }
   };
 }


### PR DESCRIPTION
Depends on https://github.com/guardian/atom-maker/pull/34

Saves two new image fields on the atom from the grid and pushes them to composer. 