### PR TITLE
reorder atom view

### DIFF
--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -165,7 +165,6 @@ class VideoDisplay extends React.Component {
         <div className="video">
           <div className="video__main">
             <div className="video__row">
-              {this.renderPreview()}
               <div className="video__detailbox video__data">
                 <div className="video__detailbox__header__container">
                   <header className="video__detailbox__header">
@@ -181,6 +180,7 @@ class VideoDisplay extends React.Component {
                   updateErrors={this.props.formErrorActions.updateFormErrors}
                 />
               </div>
+              {this.renderPreview()}
             </div>
             <div className="video__row">
               <div className="video__detailbox">


### PR DESCRIPTION
metadata on left, preview on right

the move to css grid is taking a little longer than I'd have hoped, so lets just do this change quickly...

![image](https://user-images.githubusercontent.com/836140/29166660-393bf9de-7dbf-11e7-806d-235b2de179af.png)
