### PR TITLE
add a better error message

### DIFF
--- a/public/video-ui/src/actions/VideoActions/videoPageUpdate.js
+++ b/public/video-ui/src/actions/VideoActions/videoPageUpdate.js
@@ -18,7 +18,7 @@ function receiveVideoPageUpdate(newTitle) {
 function errorReceivingVideoPageUpdate(error) {
   return {
     type: 'SHOW_ERROR',
-    message: 'Could not update a video page',
+    message: 'Could not update a composer video page. Make sure you have permissions to relaunch published content. ',
     error: error,
     receivedAt: Date.now()
   };


### PR DESCRIPTION
In the future publishing a composer page can fail if user does not have permissions to relaunch live content. A simple fix is to just tell users to check their permissions if they fail to update a composer page.