### PR TITLE
Tone tags

### DIFF
--- a/public/video-ui/src/components/CapiSearch/CapiSearch.js
+++ b/public/video-ui/src/components/CapiSearch/CapiSearch.js
@@ -40,7 +40,7 @@ export default class CapiSearch extends React.Component {
         title={tag.id}
         onClick={addTag}
       >
-        {' '}{tag.webTitle}{' '}
+        {' '}{tag.detailedTitle}{' '}
       </li>
     );
   }

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -30,7 +30,7 @@ export default class TagPicker extends React.Component {
       tagsFromStringList(this.props.fieldValue, this.props.tagType)
         .then(result => {
           this.setState({
-            tagValue: result
+            tagValue: getTagDisplayNames(result)
           });
         })
         .catch(() => {
@@ -221,7 +221,7 @@ export default class TagPicker extends React.Component {
         className="form__field__selected__tag"
       >
         <span>
-          {tag.webTitle}
+          {tag.detailedTitle}
         </span>
         <span
           className="form__field__tag__remove"

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -45,7 +45,7 @@ export default class TagPicker extends React.Component {
 
   fetchTags = searchText => {
 
-     const tagTypes = this.props.tagType === TagTypes.keyword ? [TagTypes.series, TagTypes.keyword] : [this.props.tagType];
+     const tagTypes = this.props.tagType === TagTypes.keyword ? [TagTypes.tone, TagTypes.series, TagTypes.keyword] : [this.props.tagType];
 
     ContentApi.getTagsByType(searchText, tagTypes)
       .then(capiResponses => {

--- a/public/video-ui/src/constants/TagTypes.js
+++ b/public/video-ui/src/constants/TagTypes.js
@@ -19,4 +19,7 @@ export default class TagTypes {
     return 'youtube';
   }
 
+  static get tone() {
+    return 'tone';
+  }
 }

--- a/public/video-ui/src/util/getTagDisplayNames.js
+++ b/public/video-ui/src/util/getTagDisplayNames.js
@@ -5,9 +5,9 @@ export default function getTagDisplayNames(tags) {
   return tags.map(tag => {
 
     const tagType = tag.type;
+    let detailedTitle;
 
     if (tagType === TagTypes.keyword) {
-      let detailedTitle;
 
       //Some webtitles on keyword tags are too unspecific and we need to add
       //the section name to them to know what tags they are referring to
@@ -20,15 +20,23 @@ export default function getTagDisplayNames(tags) {
       } else {
         detailedTitle = tag.webTitle;
       }
-
-      return { id: tag.id, webTitle: detailedTitle };
     }
 
-    if (tagType === TagTypes.series) {
-      return { id: tag.id, webTitle: tag.webTitle + ' (series)' };
+    else if (tagType === TagTypes.series) {
+      detailedTitle = tag.webTitle + ' (series)';
     }
 
-    return { id: tag.id, webTitle: tag.webTitle };
+    else if (tagType === TagTypes.tone) {
+      detailedTitle = tag.webTitle + ' (tone)';
+    }
+
+    else detailedTitle = tag.webTitle;
+
+    return {
+      id: tag.id,
+      webTitle: tag.webTitle,
+      detailedTitle: detailedTitle
+    };
   });
 
 }

--- a/public/video-ui/src/util/tagParsers.js
+++ b/public/video-ui/src/util/tagParsers.js
@@ -16,7 +16,9 @@ export function tagsFromStringList(savedTags, tagType) {
           const tag = capiResponse.response.tag;
           return {
             id: tag.id,
-            webTitle: tag.webTitle
+            webTitle: tag.webTitle,
+            type: tag.type,
+            sectionName: tag.sectionName
           };
         });
       }


### PR DESCRIPTION
- Add tone tags to top of keywords search list.
- I noticed a small bug in tag display as well. More detailed tag titles were not displayed in already saved tags. Because these detailed names can be a bit long, I'm now displaying them only if the form is in edit mode. 
<img width="496" alt="screen shot 2017-08-11 at 10 23 01" src="https://user-images.githubusercontent.com/3066534/29207736-2c34c26e-7e7f-11e7-83ea-7d4ce29bec0d.png">
<img width="453" alt="screen shot 2017-08-11 at 10 23 10" src="https://user-images.githubusercontent.com/3066534/29207743-30184284-7e7f-11e7-9bd5-99e3f206611b.png">

