### PR TITLE
training mode

### DIFF
--- a/app/controllers/Youtube.scala
+++ b/app/controllers/Youtube.scala
@@ -3,20 +3,29 @@ package controllers
 import com.gu.pandahmac.HMACAuthActions
 import play.api.libs.json.Json
 import play.api.mvc.Controller
-import util.YouTube
+import util.{TrainingMode, YouTube}
 import model.commands.CommandExceptions._
 
-class Youtube (val authActions: HMACAuthActions, youTube: YouTube) extends Controller {
+class Youtube (val authActions: HMACAuthActions, youtube: YouTube) extends Controller with TrainingMode {
   import authActions.AuthAction
 
   def listCategories() = AuthAction {
-    Ok(Json.toJson(youTube.categories))
+    Ok(Json.toJson(youtube.categories))
   }
 
-  def listChannels() = AuthAction {
-    val channels = youTube.allowedChannels match {
-      case Nil => youTube.channels
-      case allowedList => youTube.channels.filter(c => allowedList.contains(c.id))
+  def listChannels() = AuthAction { req =>
+    val isTrainingMode = isInTrainingMode(req)
+
+    val channels = if (isTrainingMode) {
+      youtube.trainingChannels match {
+        case Nil => List()
+        case trainingList => youtube.channels.filter(c => trainingList.contains(c.id))
+      }
+    } else {
+      youtube.allowedChannels match {
+        case Nil => youtube.channels
+        case allowedList => youtube.channels.filter(c => allowedList.contains(c.id))
+      }
     }
 
     Ok(Json.toJson(channels))
@@ -24,7 +33,7 @@ class Youtube (val authActions: HMACAuthActions, youTube: YouTube) extends Contr
 
   def commercialVideoInfo(id: String) = AuthAction {
     try {
-      Ok(Json.toJson(youTube.getCommercialVideoInfo(id)))
+      Ok(Json.toJson(youtube.getCommercialVideoInfo(id)))
     } catch {
       commandExceptionAsResult
     }

--- a/app/model/ClientConfig.scala
+++ b/app/model/ClientConfig.scala
@@ -12,21 +12,23 @@ object Presence {
   implicit val format: Format[Presence] = Jsonx.formatCaseClass[Presence]
 }
 
-case class ClientConfig(presence: Option[Presence],
-                        youtubeEmbedUrl: String,
-                        youtubeThumbnailUrl: String,
-                        reauthUrl: String,
-                        gridUrl: String,
-                        capiProxyUrl: String,
-                        liveCapiProxyUrl: String,
-                        composerUrl: String,
-                        ravenUrl: String,
-                        stage: String,
-                        viewerUrl: String,
-                        // permissions also validated server-side on every request
-                        permissions: Permissions,
-                        minDurationForAds: Long
-                       )
+case class ClientConfig(
+  presence: Option[Presence],
+  youtubeEmbedUrl: String,
+  youtubeThumbnailUrl: String,
+  reauthUrl: String,
+  gridUrl: String,
+  capiProxyUrl: String,
+  liveCapiProxyUrl: String,
+  composerUrl: String,
+  ravenUrl: String,
+  stage: String,
+  viewerUrl: String,
+  // permissions also validated server-side on every request
+  permissions: Permissions,
+  minDurationForAds: Long,
+  isTrainingMode: Boolean
+)
 
 object ClientConfig {
   implicit val format: Format[ClientConfig] = Jsonx.formatCaseClass[ClientConfig]

--- a/app/util/TrainingMode.scala
+++ b/app/util/TrainingMode.scala
@@ -1,0 +1,15 @@
+package util
+
+import com.gu.pandomainauth.action.UserRequest
+import play.api.mvc.AnyContent
+
+import scala.util.Try
+
+trait TrainingMode {
+  def isInTrainingMode (req: UserRequest[AnyContent]): Boolean = {
+      req.session.get("isTrainingMode") match {
+      case Some(trainingMode) => Try(trainingMode.toBoolean).getOrElse(false)
+      case None => false
+    }
+  }
+}

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
@@ -14,6 +14,7 @@ trait YouTubeAccess extends Settings {
   def appName: String = getMandatoryString("name")
   def contentOwner: String = getMandatoryString("youtube.contentOwner")
   val allowedChannels: List[String] = getStringList("youtube.allowedChannels")
+  val trainingChannels: List[String] = getStringList("youtube.trainingChannels")
   val disallowedVideos: List[String] = getStringList("youtube.disallowedVideos")
   val usePartnerApi: Boolean = getString("youtube.usePartnerApi").forall(_.toBoolean)
 

--- a/conf/routes
+++ b/conf/routes
@@ -78,6 +78,9 @@ GET /videos/:id                         controllers.VideoUIApp.index(id)
 GET /videos/:id/audit                   controllers.VideoUIApp.index(id)
 GET /videos/:id/upload                  controllers.VideoUIApp.index(id)
 GET /help                               controllers.VideoUIApp.index(id = "")
+GET /training                           controllers.VideoUIApp.index(id = "")
+GET /training/on                        controllers.VideoUIApp.training(inTraining: Boolean ?= true)
+GET /training/off                       controllers.VideoUIApp.training(inTraining: Boolean ?= false)
 
 #Support
 GET /support/previewCapi/*path          controllers.Support.capiProxy(path: String, queryLive: Boolean ?= false)

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -121,9 +121,15 @@ export default class Header extends React.Component {
   }
 
   render() {
+    const className = this.props.isTrainingMode
+      ? 'topbar topbar--training-mode flex-container'
+      : 'topbar flex-container';
+
+    console.log(className);
+
     if (this.props.currentPath.endsWith('/upload')) {
       return (
-        <header className="topbar flex-container">
+        <header className={className}>
           {this.renderPresence()}
           {this.renderProgress()}
           {this.renderHeaderBack()}
@@ -132,7 +138,7 @@ export default class Header extends React.Component {
     }
     if (!this.props.showPublishedState) {
       return (
-        <header className="topbar flex-container">
+        <header className={className}>
           {this.renderPresence()}
           {this.renderProgress()}
 
@@ -150,7 +156,7 @@ export default class Header extends React.Component {
       );
     } else {
       return (
-        <header className="topbar flex-container">
+        <header className={className}>
           {this.renderPresence()}
           {this.renderProgress()}
           {this.renderHome()}

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -125,8 +125,6 @@ export default class Header extends React.Component {
       ? 'topbar topbar--training-mode flex-container'
       : 'topbar flex-container';
 
-    console.log(className);
-
     if (this.props.currentPath.endsWith('/upload')) {
       return (
         <header className={className}>

--- a/public/video-ui/src/components/Help/Help.js
+++ b/public/video-ui/src/components/Help/Help.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router';
 
 export default class Help extends React.Component {
   helpPages = [
@@ -40,6 +41,9 @@ export default class Help extends React.Component {
   renderLinkList() {
     return (
       <ul>
+        <li>
+          <Link className="button__secondary" to={'/training'}>Training</Link>
+        </li>
         {this.helpPages.map(page => (
           <li key={page.url}>{this.renderLink(page)}</li>
         ))}

--- a/public/video-ui/src/components/ReactApp.js
+++ b/public/video-ui/src/components/ReactApp.js
@@ -51,6 +51,8 @@ class ReactApp extends React.Component {
   };
 
   render() {
+    const showPublishedState = this.props.params.id || this.props.location.pathname === '/videos/create';
+
     return (
       <div className="wrap">
         <Header
@@ -59,12 +61,7 @@ class ReactApp extends React.Component {
           currentPath={this.props.location.pathname}
           video={this.props.video || {}}
           publishedVideo={this.props.publishedVideo || {}}
-          showPublishedState={
-            this.props.params.id ||
-              this.props.location.pathname === '/videos/create'
-              ? true
-              : false
-          }
+          showPublishedState={showPublishedState}
           s3Upload={this.props.s3Upload}
           publishVideo={this.props.appActions.publishVideo}
           saveState={this.props.saveState}
@@ -74,6 +71,7 @@ class ReactApp extends React.Component {
           videoEditOpen={this.props.videoEditOpen}
           usages={this.props.usages}
           presenceConfig={this.props.config.presence}
+          isTrainingMode={this.props.config.isTrainingMode}
         />
         {this.props.error
           ? <div className="error-bar">{this.props.error}</div>

--- a/public/video-ui/src/components/Training/Training.js
+++ b/public/video-ui/src/components/Training/Training.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { getStore } from '../../util/storeAccessor';
+
+export default class Training extends React.Component {
+  render() {
+    const trainingModeState = getStore().getState().config.isTrainingMode
+      ? 'on'
+      : 'off';
+
+    return (
+      <div className="container">
+        <h1>Training mode is currently {trainingModeState}</h1>
+        <ul>
+          <li>
+            <a href="/training/on">Turn on</a>
+          </li>
+          <li>
+            <a href="/training/off">Turn off</a>
+          </li>
+        </ul>
+      </div>
+    )
+  }
+}

--- a/public/video-ui/src/components/Videos/ComposerPageCreate.js
+++ b/public/video-ui/src/components/Videos/ComposerPageCreate.js
@@ -37,7 +37,8 @@ export default class ComposerPageCreate extends React.Component {
         this.props.video.id,
         this.props.video,
         this.getComposerUrl(),
-        videoBlock
+        videoBlock,
+        getStore().getState().config.isTrainingMode
       )
       .then(() => {
         this.setState({

--- a/public/video-ui/src/routes.js
+++ b/public/video-ui/src/routes.js
@@ -20,6 +20,7 @@ export const routes = (
       <Route path="/videos/:id/audit" component={VideoAuditTrail} />
       <Route path="/videos/:id/upload" component={VideoUpload} />
       <Route path="/help" component={Help} />
+      <Route path="/training" component={Help} />
     </Route>
   </Router>
 );

--- a/public/video-ui/src/routes.js
+++ b/public/video-ui/src/routes.js
@@ -7,6 +7,7 @@ import VideoAuditTrail from './components/VideoAuditTrail/VideoAuditTrail';
 import VideoUpload from './components/VideoUpload/VideoUpload';
 import VideoPlutoList from './components/VideoPluto/VideoPlutoList';
 import Help from './components/Help/Help';
+import Training from './components/Training/Training';
 import ReactApp from './components/ReactApp';
 
 export const routes = (
@@ -20,7 +21,7 @@ export const routes = (
       <Route path="/videos/:id/audit" component={VideoAuditTrail} />
       <Route path="/videos/:id/upload" component={VideoUpload} />
       <Route path="/help" component={Help} />
-      <Route path="/training" component={Help} />
+      <Route path="/training" component={Training} />
     </Route>
   </Router>
 );

--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -258,5 +258,22 @@ export default {
       }
       return '';
     });
+  },
+
+  preventPublication(composerId, composerUrl) {
+    function doEmbargoIndefinitely(stage) {
+      return pandaReqwest({
+        url: `${composerUrl}/api/content/${composerId}/${stage}/settings/embargoedIndefinitely`,
+        method: 'put',
+        crossOrigin: true,
+        withCredentials: true,
+        data: `"true"`
+      });
+    }
+
+    return Promise.all([
+      doEmbargoIndefinitely('preview'),
+      doEmbargoIndefinitely('live')
+    ]);
   }
 };

--- a/public/video-ui/src/util/getComposerData.js
+++ b/public/video-ui/src/util/getComposerData.js
@@ -1,11 +1,12 @@
 import { parseComposerDataFromImage } from './parseGridMetadata';
+import { getStore } from '../util/storeAccessor';
 
 function asBooleanString(value) {
   return value ? 'true' : 'false';
 }
 
 export function getComposerData(video) {
-  return [
+  const coreFields = [
     {
       name: 'headline',
       value: video.title,
@@ -77,6 +78,19 @@ export function getComposerData(video) {
       belongsTo: 'thumbnail'
     }
   ];
+
+  const isTrainingMode = getStore().getState().config.isTrainingMode;
+
+  // block training content being published
+  const embargoedIndefinately = {
+    name: 'embargoedIndefinitely',
+    value: asBooleanString(true),
+    belongsTo: 'settings'
+  };
+
+  return !isTrainingMode
+    ? coreFields
+    : [...coreFields, embargoedIndefinately];
 }
 
 export function getRightsPayload(video) {

--- a/public/video-ui/styles/components/_advanced.scss
+++ b/public/video-ui/styles/components/_advanced.scss
@@ -11,7 +11,6 @@
         align-items: center;
         padding: 5px 10px;
         width: 100%;
-        background: $color700Grey;
     }
 
     &__button {

--- a/public/video-ui/styles/layout/_topbar.scss
+++ b/public/video-ui/styles/layout/_topbar.scss
@@ -3,6 +3,16 @@ $topbarHeight: 50px;
 .topbar {
   background: $color700Grey;
   border-bottom: 1px solid $greyBorderColor;
+
+  &--training-mode {
+    background: repeating-linear-gradient(
+        -45deg,
+        $color500Grey,
+        $color500Grey 10px,
+        $color800Grey 10px,
+        $color800Grey 20px
+    );
+  }
 }
 
 .topbar__search {

--- a/public/video-ui/styles/layout/_topbar.scss
+++ b/public/video-ui/styles/layout/_topbar.scss
@@ -12,6 +12,10 @@ $topbarHeight: 50px;
         $color800Grey 10px,
         $color800Grey 20px
     );
+
+    .topbar__search {
+      background-color: $color700Grey;
+    }
   }
 }
 
@@ -22,6 +26,9 @@ $topbarHeight: 50px;
   input {
     background-color: transparent;
     border: none;
+    &::placeholder {
+      color: $color400Grey;
+    }
   }
 }
 


### PR DESCRIPTION
Add a training mode to the app. When in this mode:
- You can only use the dev youtube channel
- Created composer pages are embargoed indefinitely

# Why?
- Prevent test videos landing on public, heavily subscribed YouTube channels
- Prevent video page launch
- Publishing is scary!

# User flow
- To enter training mode, visit `/training/on`
- To exit training mode, visit `/training/off`
- Links are on `/training` and on `/help`

# UX
Training mode is denoted by a stripy header:
![image](https://user-images.githubusercontent.com/836140/29212433-88182b54-7e96-11e7-9689-b3b64ff2cbc6.png)

Additionally, `/training` has some information:
![image](https://user-images.githubusercontent.com/836140/29212488-dc40d514-7e96-11e7-9f8f-c41cbe10bb3e.png)

# How it works
Visiting `/training/on` sets session storage in a cookie and its value is injected onto the DOM for client-side use.

Visiting `/training/off` sets the session storage value to `false`.

After `/training/on` and `/training/off` has set session storage, they redirect to `/` for normal app operations... this results in a small "loading..." flash whilst the React app is loaded, but I think that's fine for now (we could always style that loading screen...).