### PR TITLE
Revert "Revert "set composer link text""

### DIFF
--- a/public/video-ui/src/util/getComposerData.js
+++ b/public/video-ui/src/util/getComposerData.js
@@ -25,6 +25,11 @@ export function getComposerData(video) {
       isFreeText: true
     },
     {
+      name: 'linkText',
+      value: video.title,
+      belongsTo: 'fields'
+    },
+    {
       name: 'sensitive',
       value: asBooleanString(video.sensitive),
       belongsTo: 'settings'


### PR DESCRIPTION
This reverts commit b19649ea4d4302af6d99aa467cbd2b7dbaa091f8.

Reverts the [revert](https://github.com/guardian/media-atom-maker/pull/561). It was originally reverted to enable reverting an older PR.