### PR TITLE
remove video title from header

### DIFF
--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -66,14 +66,6 @@ export default class Header extends React.Component {
     );
   }
 
-  renderVideoTitle() {
-    return (
-      <div className="flex-container">
-        <span className="header__video__title">{this.props.video.title}</span>
-      </div>
-    );
-  }
-
   renderHelpLink() {
     return (
       <nav className="topbar__nav-link">
@@ -154,10 +146,6 @@ export default class Header extends React.Component {
           {this.renderPresence()}
           {this.renderProgress()}
           {this.renderHome()}
-
-          <div>
-            {this.renderVideoTitle()}
-          </div>
 
           <VideoPublishBar
             className="flex-grow"


### PR DESCRIPTION
Numerous reasons for this:
- the title is already on the page in the video metadata form, so its use is questionable
- it renders with ellipses when the title is long so isn't that useful
- it keeps the header more in-line with other Tools, such as Composer
- it frees up space to add a "Track in Workflow" button

# Before
![image](https://user-images.githubusercontent.com/836140/29270923-df6ba618-80f0-11e7-94a0-598e155dc96b.png)

# After
![image](https://user-images.githubusercontent.com/836140/29270930-e72ecdbc-80f0-11e7-8508-bf8c44e682e6.png)
