### PR TITLE
content bundle tags only needed when video is monetized

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -192,11 +192,13 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youtu
       description = description,
       tags = previewAtom.tags,
       license = previewAtom.license,
-      privacyStatus = previewAtom.privacyStatus.map(_.name))
-      .withSaneTitle()
-      .withContentBundleTags()
+      privacyStatus = previewAtom.privacyStatus.map(_.name)
+    ).withSaneTitle()
 
-    youtube.updateMetadata(asset.id, metadata)
+    youtube.updateMetadata(
+      asset.id,
+      if (previewAtom.blockAds) metadata else metadata.withContentBundleTags() // content bundle tags only needed on monetized videos
+    )
 
     previewAtom
   }

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -197,7 +197,7 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youtu
 
     youtube.updateMetadata(
       asset.id,
-      if (previewAtom.blockAds) metadata else metadata.withContentBundleTags() // content bundle tags only needed on monetized videos
+      if (previewAtom.blockAds) metadata.withoutContentBundleTags() else metadata.withContentBundleTags() // content bundle tags only needed on monetized videos
     )
 
     previewAtom

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -118,6 +118,11 @@ package object youtube {
       this.copy(tags = contentBundledTags)
     }
 
+    def withoutContentBundleTags(): YouTubeMetadataUpdate = {
+      val noContentBundleTags = tags.filterNot(_.startsWith("gdnpfp"))
+      this.copy(tags = noContentBundleTags)
+    }
+
     private def getContentBundlingTags(): List[String] = {
       val contentBundlingMap: Map[String, String] = Map (
         "uk" -> "gdnpfpnewsuk",


### PR DESCRIPTION
Add content bundle tags on Publish if blockAds = false
Remove content bundle tags on Publish if blockAds = true

This is so that the video only appears in DfP in a content bundle if ads have been turned on. (Not entirely sure why the videos are even getting to DfP when ads are off, a YouTube bug??)