### PR TITLE
split usage

### DIFF
--- a/public/video-ui/src/actions/VideoActions/videoPageCreate.js
+++ b/public/video-ui/src/actions/VideoActions/videoPageCreate.js
@@ -31,13 +31,18 @@ export function createVideoPage(id, video, composerUrl, videoBlock, isTrainingMo
 
     return VideosApi.createComposerPage(id, video, composerUrl)
       .then(res => {
-        const pageId = res.data.id;
+        const composerId = res.data.id;
         const pagePath = res.data.identifiers.path.data;
 
-        const addVideo = VideosApi.addVideoToComposerPage(pageId, videoBlock, composerUrl, false);
+        const addVideo = VideosApi.addVideoToComposerPage({
+          composerId,
+          previewData: videoBlock,
+          composerUrlBase: composerUrl,
+          state: ContentApi.preview
+        });
 
         const postCreation = isTrainingMode
-          ? [VideosApi.preventPublication(pageId, composerUrl), addVideo]
+          ? [VideosApi.preventPublication(composerId, composerUrl), addVideo]
           : [addVideo];
 
         return Promise.all(postCreation).then(() => {

--- a/public/video-ui/src/actions/VideoActions/videoPageUpdate.js
+++ b/public/video-ui/src/actions/VideoActions/videoPageUpdate.js
@@ -7,10 +7,10 @@ function requestVideoPageUpdate() {
   };
 }
 
-function receiveVideoPageUpdate(newTitle) {
+function receiveVideoPageUpdate(updatedUsages) {
   return {
     type: 'VIDEO_PAGE_UPDATE_POST_RECEIVE',
-    newTitle: newTitle,
+    updatedUsages: updatedUsages,
     receivedAt: Date.now()
   };
 }
@@ -35,8 +35,9 @@ export function updateVideoPage(id, video, composerUrl, videoBlock, usages) {
       videoBlock,
       usages
     )
-      .then(() => {
-        return dispatch(receiveVideoPageUpdate(video.title));
+      .then(updatedUsages => {
+
+        return dispatch(receiveVideoPageUpdate(updatedUsages));
       })
       .catch(error => {
         dispatch(errorReceivingVideoPageUpdate(error));

--- a/public/video-ui/src/actions/VideoActions/videoPageUpdate.js
+++ b/public/video-ui/src/actions/VideoActions/videoPageUpdate.js
@@ -7,10 +7,10 @@ function requestVideoPageUpdate() {
   };
 }
 
-function receiveVideoPageUpdate(updatedUsages) {
+function receiveVideoPageUpdate(newTitle) {
   return {
     type: 'VIDEO_PAGE_UPDATE_POST_RECEIVE',
-    updatedUsages: updatedUsages,
+    newTitle: newTitle,
     receivedAt: Date.now()
   };
 }
@@ -34,12 +34,7 @@ export function updateVideoPage(video, composerUrl, videoBlock, usages) {
       videoBlock,
       usages
     )
-      .then(updatedUsages => {
-
-        return dispatch(receiveVideoPageUpdate(updatedUsages));
-      })
-      .catch(error => {
-        dispatch(errorReceivingVideoPageUpdate(error));
-      });
+      .then(() => dispatch(receiveVideoPageUpdate(video.title)))
+      .catch(error => dispatch(errorReceivingVideoPageUpdate(error)));
   };
 }

--- a/public/video-ui/src/actions/VideoActions/videoPageUpdate.js
+++ b/public/video-ui/src/actions/VideoActions/videoPageUpdate.js
@@ -24,12 +24,11 @@ function errorReceivingVideoPageUpdate(error) {
   };
 }
 
-export function updateVideoPage(id, video, composerUrl, videoBlock, usages) {
+export function updateVideoPage(video, composerUrl, videoBlock, usages) {
   return dispatch => {
     dispatch(requestVideoPageUpdate());
 
-    return VideosApi.updateComposerPage(
-      id,
+    return VideosApi.updateCanonicalPages(
       video,
       composerUrl,
       videoBlock,

--- a/public/video-ui/src/actions/VideoActions/videoUsages.js
+++ b/public/video-ui/src/actions/VideoActions/videoUsages.js
@@ -30,30 +30,12 @@ export function getUsages(id) {
     dispatch(requestVideoUsages());
 
     if (!id) {
-      return dispatch(receiveVideoUsages([]));
+      return dispatch(receiveVideoUsages({}));
     }
 
     return VideosApi.getVideoUsages(id)
-      .then(res => {
-        const usagePaths = res.response.results;
-
-        // the atom usage endpoint in capi only returns article paths,
-        // lookup the articles in capi to get their fields
-        Promise.all(usagePaths.map(ContentApi.getByPath)).then(capiResponse => {
-          const usages = capiResponse.reduce((all, item) => {
-            all.push(item.response.content);
-            return all;
-          }, []);
-
-          // sort by article creation date DESC
-          usages.sort(
-            (first, second) =>
-              new Date(second.fields.creationDate) -
-              new Date(first.fields.creationDate)
-          );
-
-          dispatch(receiveVideoUsages(usages));
-        });
+      .then(usages => {
+        dispatch(receiveVideoUsages(usages));
       })
       .catch(error => {
         dispatch(errorReceivingVideoUsages(error));

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -196,7 +196,10 @@ export default class Header extends React.Component {
             requiredComposerFieldsMissing={this.requiredComposerFieldsMissing}
             composerPageExists={this.composerPageExists}
           />
-          <AdvancedActions video={this.props.video || {}} />
+          <AdvancedActions
+            video={this.props.video || {}}
+            usages={this.props.usages}
+          />
           <ComposerPageCreate
             usages={this.props.usages}
             videoEditOpen={this.props.videoEditOpen}

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -6,7 +6,6 @@ import AdvancedActions from './Videos/AdvancedActions';
 import ComposerPageCreate from './Videos/ComposerPageCreate';
 import Icon from './Icon';
 import { Presence } from './Presence';
-import { getComposerPages } from '../util/getComposerPages';
 
 export default class Header extends React.Component {
   state = { presence: null };
@@ -21,8 +20,8 @@ export default class Header extends React.Component {
     });
   };
 
-  composerPageExists = () => {
-    return getComposerPages(this.props.usages).length > 0;
+  canonicalVideoPageExists = () => {
+    return this.props.usages.totalVideoPages > 0;
   };
 
   renderProgress() {
@@ -128,7 +127,7 @@ export default class Header extends React.Component {
       return null;
     }
 
-    if (this.composerPageExists()) {
+    if (this.canonicalVideoPageExists()) {
       return (
         <div className="header__fields__missing__warning">
           Fill in required composer fields before publishing
@@ -194,19 +193,18 @@ export default class Header extends React.Component {
             publishVideo={this.publishVideo}
             formFieldsWarning={this.props.formFieldsWarning}
             requiredComposerFieldsMissing={this.requiredComposerFieldsMissing}
-            composerPageExists={this.composerPageExists}
+            canonicalVideoPageExists={this.canonicalVideoPageExists}
           />
           <AdvancedActions
             video={this.props.video || {}}
             usages={this.props.usages}
           />
           <ComposerPageCreate
-            usages={this.props.usages}
             videoEditOpen={this.props.videoEditOpen}
             video={this.props.video || {}}
             createVideoPage={this.props.createVideoPage}
             requiredComposerFieldsMissing={this.requiredComposerFieldsMissing}
-            composerPageExists={this.composerPageExists}
+            canonicalVideoPageExists={this.canonicalVideoPageExists}
           />
           {this.renderComposerMissingWarning()}
           <div className="flex-container">

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -198,7 +198,7 @@ export default class Header extends React.Component {
           />
           <AdvancedActions video={this.props.video || {}} />
           <ComposerPageCreate
-            usages={this.props.usages | {}}
+            usages={this.props.usages}
             videoEditOpen={this.props.videoEditOpen}
             video={this.props.video || {}}
             createVideoPage={this.props.createVideoPage}

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -198,7 +198,7 @@ export default class Header extends React.Component {
           />
           <AdvancedActions video={this.props.video || {}} />
           <ComposerPageCreate
-            usages={this.props.usages}
+            usages={this.props.usages | {}}
             videoEditOpen={this.props.videoEditOpen}
             video={this.props.video || {}}
             createVideoPage={this.props.createVideoPage}

--- a/public/video-ui/src/components/Icon.js
+++ b/public/video-ui/src/components/Icon.js
@@ -66,28 +66,6 @@ export class ViewerIcon extends React.Component {
   }
 }
 
-export class ComposerVideoIcon extends React.Component {
-  render() {
-    return (
-      <span className="icon svg-icon">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="128px"
-          height="107.844px"
-          viewBox="0 0 128 107.844"
-        >
-          <g>
-            <g>
-              <path d="M72.275 68.86L66.705 74.431 66.705 102.277 72.31 107.844 104.298 107.844 104.298 68.86zM123.794 70.249L109.869 84.178 109.869 92.531 123.794 106.449 128.001 106.449 128.001 70.249z" />
-            </g>
-            <path d="M31.541,52.232c0-27.828,7.418-38.244,22.121-38.244c4.996,0,8.992,1.282,11.844,2.568l6.855,16.127H85.49l-1-28.117 C78.208,1.997,67.365,0,54.521,0C27.83,0,0.001,13.988,0.001,54.662c0,37.548,22.031,52.643,50.109,53.182V93.859 C37.373,92.084,31.541,81.683,31.541,52.232z" />
-          </g>
-        </svg>
-      </span>
-    );
-  }
-}
-
 export default class Icon extends React.Component {
   renderText() {
     if (this.props.children) {

--- a/public/video-ui/src/components/ReactApp.js
+++ b/public/video-ui/src/components/ReactApp.js
@@ -51,7 +51,8 @@ class ReactApp extends React.Component {
   };
 
   render() {
-    const showPublishedState = this.props.params.id || this.props.location.pathname === '/videos/create';
+    const showPublishedState =
+      this.props.params.id || this.props.location.pathname === '/videos/create';
 
     return (
       <div className="wrap">

--- a/public/video-ui/src/components/ReactApp.js
+++ b/public/video-ui/src/components/ReactApp.js
@@ -69,7 +69,7 @@ class ReactApp extends React.Component {
           updateVideoPage={this.props.appActions.updateVideoPage}
           createVideoPage={this.props.appActions.createVideoPage}
           videoEditOpen={this.props.videoEditOpen}
-          usages={this.props.usages}
+          usages={this.props.usages || {}}
           presenceConfig={this.props.config.presence}
           isTrainingMode={this.props.config.isTrainingMode}
           formFieldsWarning={this.props.formFieldsWarning}

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -197,7 +197,7 @@ class VideoDisplay extends React.Component {
                 <VideoUsages
                   video={this.props.video || {}}
                   publishedVideo={this.props.publishedVideo || {}}
-                  usages={this.props.usages || []}
+                  usages={this.props.usages || {}}
                 />
               </div>
               <div className="video__detailbox">

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -4,7 +4,6 @@ import { isVideoPublished, hasVideoExpired } from '../../util/isVideoPublished';
 import { hasUnpublishedChanges } from '../../util/hasUnpublishedChanges';
 import { getVideoBlock } from '../../util/getVideoBlock';
 import { getStore } from '../../util/storeAccessor';
-import { getComposerPages } from '../../util/getComposerPages';
 
 export default class VideoPublishBar extends React.Component {
   videoIsCurrentlyPublishing() {
@@ -33,7 +32,7 @@ export default class VideoPublishBar extends React.Component {
   };
 
   publishVideo = () => {
-    const usages = getComposerPages(this.props.usages.published);
+    const usages = this.props.usages.published && this.props.usages.published.video;
 
     const videoBlock = getVideoBlock(
       this.props.video.id,

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -4,6 +4,7 @@ import { isVideoPublished, hasVideoExpired } from '../../util/isVideoPublished';
 import { hasUnpublishedChanges } from '../../util/hasUnpublishedChanges';
 import { getVideoBlock } from '../../util/getVideoBlock';
 import { getStore } from '../../util/storeAccessor';
+import ContentApi from '../../services/capi';
 
 export default class VideoPublishBar extends React.Component {
   videoIsCurrentlyPublishing() {
@@ -32,7 +33,15 @@ export default class VideoPublishBar extends React.Component {
   };
 
   publishVideo = () => {
-    const usages = this.props.usages.published && this.props.usages.published.video;
+    const previewVideoPageUsages = this.props.usages[ContentApi.preview] && this.props.usages[ContentApi.preview].video || [];
+    const publishedVideoPageUsages = this.props.usages[ContentApi.published] && this.props.usages[ContentApi.published].video || [];
+
+    const usages = {
+      [ContentApi.preview]: previewVideoPageUsages,
+      [ContentApi.published]: publishedVideoPageUsages
+    };
+
+    const totalUsages = previewVideoPageUsages.length + publishedVideoPageUsages.length;
 
     const videoBlock = getVideoBlock(
       this.props.video.id,
@@ -40,9 +49,8 @@ export default class VideoPublishBar extends React.Component {
       this.props.video.source
     );
 
-    if (usages.length > 0) {
+    if (totalUsages > 0) {
       this.props.updateVideoPage(
-        this.props.video.id,
         this.props.video,
         this.getComposerUrl(),
         videoBlock,

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -33,7 +33,7 @@ export default class VideoPublishBar extends React.Component {
   };
 
   publishVideo = () => {
-    const usages = getComposerPages(this.props.usages);
+    const usages = getComposerPages(this.props.usages.published);
 
     const videoBlock = getVideoBlock(
       this.props.video.id,

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -24,7 +24,7 @@ export default class VideoPublishBar extends React.Component {
       this.videoIsCurrentlyPublishing() ||
       this.props.videoEditOpen ||
       !this.videoHasUnpublishedChanges() ||
-      (this.props.composerPageExists() && this.props.requiredComposerFieldsMissing())
+      (this.props.canonicalVideoPageExists() && this.props.requiredComposerFieldsMissing())
     );
   }
 
@@ -33,28 +33,18 @@ export default class VideoPublishBar extends React.Component {
   };
 
   publishVideo = () => {
-    const previewVideoPageUsages = this.props.usages[ContentApi.preview] && this.props.usages[ContentApi.preview].video || [];
-    const publishedVideoPageUsages = this.props.usages[ContentApi.published] && this.props.usages[ContentApi.published].video || [];
-
-    const usages = {
-      [ContentApi.preview]: previewVideoPageUsages,
-      [ContentApi.published]: publishedVideoPageUsages
-    };
-
-    const totalUsages = previewVideoPageUsages.length + publishedVideoPageUsages.length;
-
     const videoBlock = getVideoBlock(
       this.props.video.id,
       this.props.video.title,
       this.props.video.source
     );
 
-    if (totalUsages > 0) {
+    if (this.props.canonicalVideoPageExists()) {
       this.props.updateVideoPage(
         this.props.video,
         this.getComposerUrl(),
         videoBlock,
-        usages
+        this.props.usages
       );
     }
 

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -75,7 +75,7 @@ export default class VideoUsages extends React.Component {
 
       return (
         <div key={`${state}-usages`}>
-          <h4>{state.charAt(0).toUpperCase() + state.slice(1)}</h4>
+          <h4>{`${state.charAt(0).toUpperCase() + state.slice(1)} (Total: ${totalUsages})`}</h4>
           {totalUsages === 0
             ? <div className="usage--none">{`No ${state} usages found`}</div>
             : <ul className="detail__list">

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -36,7 +36,7 @@ export default class VideoUsages extends React.Component {
         }
       >
         <div className="details-list__title">
-          {usage.fields.headline || usage.id}
+          {usage.webTitle || usage.id}
         </div>
         <div>
           Created:
@@ -82,7 +82,7 @@ export default class VideoUsages extends React.Component {
 
       return (
         <div key={`${state}-usages`}>
-          <h1>{state.toUpperCase()}</h1>
+          <h3>{state.toUpperCase()}</h3>
           {totalUsages === 0
             ? <div className="baseline-margin">{`No ${state} usages found`}</div>
             : <ul className="detail__list">

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -29,14 +29,13 @@ export default class VideoUsages extends React.Component {
     return (
       <li key={usage.id} className="detail__list__item">
         <div className="details-list__title">
-
+          <span className={`usage__content-type usage__content-type--${usage.type}`}>{usage.type}</span>
           {usage.webTitle || usage.id}
         </div>
         <div>
           Created:
           {' '}
           <span title={usage.fields.creationDate}>{usageDateFromNow}</span>
-          <span className={`details-list__content-type details-list__content-type--${usage.type}`}>{usage.type}</span>
           <a
             className="usage--platform-link"
             href={composerLink}
@@ -76,9 +75,9 @@ export default class VideoUsages extends React.Component {
 
       return (
         <div key={`${state}-usages`}>
-          <h3>{state.charAt(0).toUpperCase() + state.slice(1)}</h3>
+          <h4>{state.charAt(0).toUpperCase() + state.slice(1)}</h4>
           {totalUsages === 0
-            ? <div className="baseline-margin">{`No ${state} usages found`}</div>
+            ? <div className="usage--none">{`No ${state} usages found`}</div>
             : <ul className="detail__list">
                 {this.props.usages[state].video.map(usage => this.renderUsage({usage, state}))}
                 {this.props.usages[state].other.map(usage => this.renderUsage({usage, state}))}
@@ -90,7 +89,7 @@ export default class VideoUsages extends React.Component {
 
   render() {
     return (
-      <div className="form__group">
+      <div className="usage">
         {this.renderUsages()}
       </div>
     );

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -78,13 +78,16 @@ export default class VideoUsages extends React.Component {
 
   renderUsages() {
     return Object.keys(this.props.usages).map(state => {
+      const totalUsages = this.props.usages[state].video.length + this.props.usages[state].other.length;
+
       return (
         <div key={`${state}-usages`}>
           <h1>{state.toUpperCase()}</h1>
-          {this.props.usages[state].length === 0
+          {totalUsages === 0
             ? <div className="baseline-margin">{`No ${state} usages found`}</div>
             : <ul className="detail__list">
-                {this.props.usages[state].map(usage => this.renderUsage({usage, state}))}
+                {this.props.usages[state].video.map(usage => this.renderUsage({usage, state}))}
+                {this.props.usages[state].other.map(usage => this.renderUsage({usage, state}))}
               </ul>}
         </div>
       );

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -82,7 +82,7 @@ export default class VideoUsages extends React.Component {
 
       return (
         <div key={`${state}-usages`}>
-          <h3>{state.toUpperCase()}</h3>
+          <h3>{state.charAt(0).toUpperCase() + state.slice(1)}</h3>
           {totalUsages === 0
             ? <div className="baseline-margin">{`No ${state} usages found`}</div>
             : <ul className="detail__list">
@@ -96,7 +96,7 @@ export default class VideoUsages extends React.Component {
 
   render() {
     return (
-      <div>
+      <div className="form__group">
         {this.renderUsages()}
       </div>
     );

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -9,6 +9,8 @@ import {
   ComposerVideoIcon
 } from '../Icon';
 
+import ContentApi from '../../services/capi';
+
 export default class VideoUsages extends React.Component {
   getComposerUrl = () => {
     return getStore().getState().config.composerUrl;
@@ -18,7 +20,7 @@ export default class VideoUsages extends React.Component {
     return getStore().getState().config.viewerUrl;
   };
 
-  renderUsage = usage => {
+  renderUsage = ({ usage, state }) => {
     const composerLink = `${this.getComposerUrl()}/content/${usage.fields.internalComposerCode}`;
     const viewerLink = `${this.getViewerUrl()}/preview/${usage.id}`;
     const websiteLink = `https://www.theguardian.com/${usage.id}`;
@@ -40,15 +42,7 @@ export default class VideoUsages extends React.Component {
           Created:
           {' '}
           <span title={usage.fields.creationDate}>{usageDateFromNow}</span>
-          <a
-            className="usage--platform-link"
-            href={websiteLink}
-            title="Open on theguardian.com"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <FrontendIcon />
-          </a>
+
           <a
             className="usage--platform-link"
             href={composerLink}
@@ -67,42 +61,47 @@ export default class VideoUsages extends React.Component {
           >
             <ViewerIcon />
           </a>
+
+          {state === ContentApi.published
+            ? <a className="usage--platform-link"
+                 href={websiteLink}
+                 title="Open on theguardian.com"
+                 target="_blank"
+                 rel="noopener noreferrer">
+              <FrontendIcon />
+            </a>
+            : ''}
         </div>
       </li>
     );
   };
 
   renderUsages() {
-    return (
-      <ul className="detail__list">
-        {this.props.usages.map(this.renderUsage)}
-      </ul>
-    );
+    return Object.keys(this.props.usages).map(state => {
+      return (
+        <div key={`${state}-usages`}>
+          <h1>{state.toUpperCase()}</h1>
+          {this.props.usages[state].length === 0
+            ? <div className="baseline-margin">{`No ${state} usages found`}</div>
+            : <ul className="detail__list">
+                {this.props.usages[state].map(usage => this.renderUsage({usage, state}))}
+              </ul>}
+        </div>
+      );
+    });
   }
 
   render() {
-    if (!this.props.usages) {
-      return <div className="baseline-margin">Fetching Usages...</div>;
-    }
-
-    if (this.props.usages.length === 0) {
-      return (
-        <div>
-          <div className="baseline-margin">No usages found</div>
-        </div>
-      );
-    } else {
-      return (
-        <div>
-          {this.renderUsages()}
-        </div>
-      );
-    }
+    return (
+      <div>
+        {this.renderUsages()}
+      </div>
+    );
   }
 }
 
 VideoUsages.propTypes = {
-  usages: PropTypes.array.isRequired,
+  // usages: PropTypes.object.isRequired,
   video: PropTypes.object.isRequired,
   publishedVideo: PropTypes.object.isRequired
 };

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -70,8 +70,10 @@ export default class VideoUsages extends React.Component {
   };
 
   renderUsages() {
-    return Object.keys(this.props.usages).map(state => {
-      const totalUsages = this.props.usages[state].video.length + this.props.usages[state].other.length;
+    const usages = this.props.usages.data;
+
+    return Object.keys(usages).map(state => {
+      const totalUsages = usages[state].video.length + usages[state].other.length;
 
       return (
         <div key={`${state}-usages`}>
@@ -79,8 +81,8 @@ export default class VideoUsages extends React.Component {
           {totalUsages === 0
             ? <div className="usage--none">{`No ${state} usages found`}</div>
             : <ul className="detail__list">
-                {this.props.usages[state].video.map(usage => this.renderUsage({usage, state}))}
-                {this.props.usages[state].other.map(usage => this.renderUsage({usage, state}))}
+                {usages[state].video.map(usage => this.renderUsage({usage, state}))}
+                {usages[state].other.map(usage => this.renderUsage({usage, state}))}
               </ul>}
         </div>
       );

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -5,8 +5,7 @@ import { getStore } from '../../util/storeAccessor';
 import {
   FrontendIcon,
   ComposerIcon,
-  ViewerIcon,
-  ComposerVideoIcon
+  ViewerIcon
 } from '../Icon';
 
 import ContentApi from '../../services/capi';
@@ -24,25 +23,20 @@ export default class VideoUsages extends React.Component {
     const composerLink = `${this.getComposerUrl()}/content/${usage.fields.internalComposerCode}`;
     const viewerLink = `${this.getViewerUrl()}/preview/${usage.id}`;
     const websiteLink = `https://www.theguardian.com/${usage.id}`;
-    const isVideoType = usage.type === 'video';
 
     const usageDateFromNow = moment(usage.fields.creationDate).fromNow();
 
     return (
-      <li
-        key={usage.id}
-        className={
-          isVideoType ? 'detail__list__item--video' : 'detail__list__item'
-        }
-      >
+      <li key={usage.id} className="detail__list__item">
         <div className="details-list__title">
+
           {usage.webTitle || usage.id}
         </div>
         <div>
           Created:
           {' '}
           <span title={usage.fields.creationDate}>{usageDateFromNow}</span>
-
+          <span className={`details-list__content-type details-list__content-type--${usage.type}`}>{usage.type}</span>
           <a
             className="usage--platform-link"
             href={composerLink}
@@ -50,7 +44,7 @@ export default class VideoUsages extends React.Component {
             target="_blank"
             rel="noopener noreferrer"
           >
-            {isVideoType ? <ComposerVideoIcon /> : <ComposerIcon />}
+            <ComposerIcon />
           </a>
           <a
             className="usage--platform-link"

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -97,7 +97,7 @@ export default class VideoUsages extends React.Component {
 }
 
 VideoUsages.propTypes = {
-  // usages: PropTypes.object.isRequired,
+  usages: PropTypes.object.isRequired,
   video: PropTypes.object.isRequired,
   publishedVideo: PropTypes.object.isRequired
 };

--- a/public/video-ui/src/components/Videos/AdvancedActions.js
+++ b/public/video-ui/src/components/Videos/AdvancedActions.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { getStore } from '../../util/storeAccessor';
+import ContentApi from '../../services/capi';
 
 class AdvancedActions extends React.Component {
   // the permissions are also validated on the server-side for each request
@@ -13,7 +14,13 @@ class AdvancedActions extends React.Component {
       return false;
     }
 
-    const disabled = this.props.usage.length > 0;
+    const totalUsages = Object.keys(this.props.usages).reduce((total, state) => {
+      return total + Object.keys(this.props.usages[state]).reduce((subTotal, contentType) => {
+        return subTotal + this.props.usages[state][contentType].length;
+      }, 0);
+    }, 0);
+
+    const disabled = totalUsages > 0;
     const deleteMsg = this.state.deleteDoubleCheck
       ? 'Confirm delete from database'
       : 'Delete from database';

--- a/public/video-ui/src/components/Videos/AdvancedActions.js
+++ b/public/video-ui/src/components/Videos/AdvancedActions.js
@@ -14,13 +14,8 @@ class AdvancedActions extends React.Component {
       return false;
     }
 
-    const totalUsages = Object.keys(this.props.usages).reduce((total, state) => {
-      return total + Object.keys(this.props.usages[state]).reduce((subTotal, contentType) => {
-        return subTotal + this.props.usages[state][contentType].length;
-      }, 0);
-    }, 0);
+    const disabled = this.props.usages.totalUsages > 0;
 
-    const disabled = totalUsages > 0;
     const deleteMsg = this.state.deleteDoubleCheck
       ? 'Confirm delete from database'
       : 'Delete from database';
@@ -71,17 +66,10 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as deleteVideo from '../../actions/VideoActions/deleteVideo';
 
-function mapStateToProps(state) {
-  return {
-    video: state.video,
-    usage: state.usage
-  };
-}
-
 function mapDispatchToProps(dispatch) {
   return {
     videoActions: bindActionCreators(Object.assign({}, deleteVideo), dispatch)
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(AdvancedActions);
+export default connect(mapDispatchToProps)(AdvancedActions);

--- a/public/video-ui/src/components/Videos/ComposerPageCreate.js
+++ b/public/video-ui/src/components/Videos/ComposerPageCreate.js
@@ -43,7 +43,7 @@ export default class ComposerPageCreate extends React.Component {
   };
 
   render() {
-    const hasPublishedCanonicalPage = this.props.usages.published.video.length > 0;
+    const hasPublishedCanonicalPage = this.props.usages.published && this.props.usages.published.video.length > 0;
 
     if (hasPublishedCanonicalPage || this.isHosted()) {
       return null;

--- a/public/video-ui/src/components/Videos/ComposerPageCreate.js
+++ b/public/video-ui/src/components/Videos/ComposerPageCreate.js
@@ -43,7 +43,9 @@ export default class ComposerPageCreate extends React.Component {
   };
 
   render() {
-    if (this.props.composerPageExists() || this.isHosted()) {
+    const hasPublishedCanonicalPage = this.props.usages.published.video.length > 0;
+
+    if (hasPublishedCanonicalPage || this.isHosted()) {
       return null;
     }
 

--- a/public/video-ui/src/components/Videos/ComposerPageCreate.js
+++ b/public/video-ui/src/components/Videos/ComposerPageCreate.js
@@ -43,9 +43,7 @@ export default class ComposerPageCreate extends React.Component {
   };
 
   render() {
-    const hasPublishedCanonicalPage = this.props.usages.published && this.props.usages.published.video.length > 0;
-
-    if (hasPublishedCanonicalPage || this.isHosted()) {
+    if (this.props.canonicalVideoPageExists() || this.isHosted()) {
       return null;
     }
 

--- a/public/video-ui/src/constants/keyCodes.js
+++ b/public/video-ui/src/constants/keyCodes.js
@@ -4,5 +4,5 @@ export const keyCodes = {
   down: 40,
   up: 38,
   b: 66,
-  i: 73,
+  i: 73
 };

--- a/public/video-ui/src/reducers/usageReducer.js
+++ b/public/video-ui/src/reducers/usageReducer.js
@@ -9,13 +9,13 @@ export default function usage(state = [], action) {
       return state;
     }
     case 'VIDEO_PAGE_UPDATE_POST_RECEIVE': {
-      debugger;
-      const newState = state.map(usage => {
-        usage.fields.headline = action.newTitle;
-        return usage;
+      Object.keys(action.updatedUsages).forEach(contentState => {
+        state[contentState] = Object.assign({}, state[contentState], {
+          video: action.updatedUsages[contentState]
+        });
       });
 
-      return newState;
+      return state;
     }
     default: {
       return state;

--- a/public/video-ui/src/reducers/usageReducer.js
+++ b/public/video-ui/src/reducers/usageReducer.js
@@ -1,7 +1,7 @@
 export default function usage(state = [], action) {
   switch (action.type) {
     case 'VIDEO_USAGE_GET_RECEIVE': {
-      return action.usages || [];
+      return action.usages || {};
     }
     case 'VIDEO_PAGE_CREATE_POST_RECEIVE': {
       // usages are sorted creation date DESC, new usage goes to the top

--- a/public/video-ui/src/reducers/usageReducer.js
+++ b/public/video-ui/src/reducers/usageReducer.js
@@ -10,14 +10,40 @@ export default function usage(state = initialState, action) {
       return action.usages || {};
     }
     case 'VIDEO_PAGE_CREATE_POST_RECEIVE': {
+      // TODO avoid mutation... but how on such a deep property?!
       // usages are sorted creation date DESC, new usage goes to the top
       state.data.preview.video = [action.newPage, ...state.data.preview.video];
-      state.totalUsages = state.totalUsages + 1;
-      state.totalVideoPages = state.totalVideoPages + 1;
-      return state;
+
+      return Object.assign({}, state, {
+        totalUsages: state.totalUsages + 1,
+        totalVideoPages: state.totalVideoPages + 1
+      });
     }
     case 'VIDEO_PAGE_UPDATE_POST_RECEIVE': {
-      return action.updatedUsages;
+      const usages = state.data;
+
+      return Object.keys(usages).reduce(
+        (all, publishState) => {
+
+          const updated = usages[publishState].video.map(usage => {
+            return Object.assign({}, usage, {
+              webTitle: action.newTitle
+            });
+          });
+
+          // TODO avoid mutation... but how on such a deep property?!
+          all.data[publishState] = {
+            video: updated,
+            other: usages[publishState].other
+          };
+
+          return all;
+        },
+        Object.assign({}, initialState, {
+          totalUsages: state.totalUsages,
+          totalVideoPages: state.totalVideoPages
+        })
+      );
     }
     default: {
       return state;

--- a/public/video-ui/src/reducers/usageReducer.js
+++ b/public/video-ui/src/reducers/usageReducer.js
@@ -5,10 +5,11 @@ export default function usage(state = [], action) {
     }
     case 'VIDEO_PAGE_CREATE_POST_RECEIVE': {
       // usages are sorted creation date DESC, new usage goes to the top
-      state.unshift(action.newPage);
+      state.preview.video = [action.newPage, ...state.preview.video];
       return state;
     }
     case 'VIDEO_PAGE_UPDATE_POST_RECEIVE': {
+      debugger;
       const newState = state.map(usage => {
         usage.fields.headline = action.newTitle;
         return usage;

--- a/public/video-ui/src/reducers/usageReducer.js
+++ b/public/video-ui/src/reducers/usageReducer.js
@@ -1,21 +1,23 @@
-export default function usage(state = {}, action) {
+const initialState = {
+  data: {},
+  totalUsages: 0,
+  totalVideoPages: 0
+};
+
+export default function usage(state = initialState, action) {
   switch (action.type) {
     case 'VIDEO_USAGE_GET_RECEIVE': {
       return action.usages || {};
     }
     case 'VIDEO_PAGE_CREATE_POST_RECEIVE': {
       // usages are sorted creation date DESC, new usage goes to the top
-      state.preview.video = [action.newPage, ...state.preview.video];
+      state.data.preview.video = [action.newPage, ...state.data.preview.video];
+      state.totalUsages = state.totalUsages + 1;
+      state.totalVideoPages = state.totalVideoPages + 1;
       return state;
     }
     case 'VIDEO_PAGE_UPDATE_POST_RECEIVE': {
-      Object.keys(action.updatedUsages).forEach(contentState => {
-        state[contentState] = Object.assign({}, state[contentState], {
-          video: action.updatedUsages[contentState]
-        });
-      });
-
-      return state;
+      return action.updatedUsages;
     }
     default: {
       return state;

--- a/public/video-ui/src/reducers/usageReducer.js
+++ b/public/video-ui/src/reducers/usageReducer.js
@@ -1,4 +1,4 @@
-export default function usage(state = [], action) {
+export default function usage(state = {}, action) {
   switch (action.type) {
     case 'VIDEO_USAGE_GET_RECEIVE': {
       return action.usages || {};

--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -256,30 +256,7 @@ export default {
           })
         );
       })
-    ).then(() => {
-      return Object.keys(usages.data).reduce(
-        (all, state) => {
-          const updated = usages.data[state].video.map(usage => {
-            return Object.assign({}, usage, {
-              webTitle: video.title
-            });
-          });
-
-          // TODO avoid mutation... but how on such a deep property?!
-          all.data[state] = {
-            video: updated,
-            other: usages.data[state].other
-          };
-
-          return all;
-        },
-        {
-          data: {},
-          totalUsages: usages.totalUsages,
-          totalVideoPages: usages.totalVideoPages
-        }
-      );
-    });
+    );
   },
 
   createComposerPage(id, video, composerUrlBase) {

--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -31,6 +31,17 @@ function getUsages({ id, stage }) {
   });
 }
 
+function splitUsages({ usages }) {
+  return usages.reduce((all, usage) => {
+    if (usage.type === 'video') {
+      all.video = [...all.video, usage];
+    } else {
+      all.other = [...all.other, usage];
+    }
+    return all;
+  }, {video: [], other: []});
+}
+
 export default {
   fetchVideos: (search, limit) => {
     let url = `/api2/atoms?limit=${limit}`;
@@ -110,13 +121,13 @@ export default {
       // remove Published usages from Preview response
       const draft = [...previewUsages].filter(previewUsage => {
         return !publishedUsages.find(publishedUsage => {
-          return publishedUsage.path === previewUsage.path;
+          return publishedUsage.id === previewUsage.id;
         });
       });
 
       return {
-        [ContentApi.preview]: draft,
-        [ContentApi.published]: publishedUsages
+        [ContentApi.preview]: splitUsages({usages: draft}),
+        [ContentApi.published]: splitUsages({usages: publishedUsages})
       };
     });
   },

--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -32,14 +32,17 @@ function getUsages({ id, stage }) {
 }
 
 function splitUsages({ usages }) {
-  return usages.reduce((all, usage) => {
-    if (usage.type === 'video') {
-      all.video = [...all.video, usage];
-    } else {
-      all.other = [...all.other, usage];
-    }
-    return all;
-  }, {video: [], other: []});
+  return usages.reduce(
+    (all, usage) => {
+      if (usage.type === 'video') {
+        all.video = [...all.video, usage];
+      } else {
+        all.other = [...all.other, usage];
+      }
+      return all;
+    },
+    { video: [], other: [] }
+  );
 }
 
 export default {
@@ -125,13 +128,13 @@ export default {
         });
       });
 
-      const splitPreview = splitUsages({usages: draft});
-      const splitPublished = splitUsages({usages: publishedUsages});
+      const splitPreview = splitUsages({ usages: draft });
+      const splitPublished = splitUsages({ usages: publishedUsages });
 
       return {
         data: {
           [ContentApi.preview]: splitPreview,
-          [ContentApi.published]: splitPublished,
+          [ContentApi.published]: splitPublished
         },
 
         // a lot of components conditionally render based on the number of usages,
@@ -164,8 +167,12 @@ export default {
       // For both published and unpublished articles, we need to update both live and preview versions.
       const composerData = getComposerData(video);
       const dataUpdatePromises = composerData.reduce((promises, data) => {
-        promises.push(updateArticleField('preview', data, composerUrlBase, composerId));
-        promises.push(updateArticleField('live', data, composerUrlBase, composerId));
+        promises.push(
+          updateArticleField('preview', data, composerUrlBase, composerId)
+        );
+        promises.push(
+          updateArticleField('live', data, composerUrlBase, composerId)
+        );
 
         return promises;
       }, []);
@@ -225,46 +232,53 @@ export default {
       });
     }
 
-    return Promise.all(Object.keys(usages.data).map(state => {
-      const videoPageUsages = usages.data[state].video;
+    return Promise.all(
+      Object.keys(usages.data).map(state => {
+        const videoPageUsages = usages.data[state].video;
 
-      return Promise.all(videoPageUsages.map(usage => {
-        const composerId = usage.fields.internalComposerCode;
+        return Promise.all(
+          videoPageUsages.map(usage => {
+            const composerId = usage.fields.internalComposerCode;
 
-        const fieldPromises = getComposerUpdateRequests({
-          composerId,
-          video,
-          composerUrlBase
-        });
+            const fieldPromises = getComposerUpdateRequests({
+              composerId,
+              video,
+              composerUrlBase
+            });
 
-        const videoPagePromise = this.addVideoToComposerPage({
-          composerId,
-          previewData: videoBlock,
-          composerUrlBase
-        });
+            const videoPagePromise = this.addVideoToComposerPage({
+              composerId,
+              previewData: videoBlock,
+              composerUrlBase
+            });
 
-        return Promise.all([...fieldPromises, videoPagePromise]);
-      }));
-    })).then(() => {
-      return Object.keys(usages.data).reduce((all, state) => {
-        const updated = usages.data[state].video.map(usage => {
-          return Object.assign({}, usage, {
-            webTitle: video.title
+            return Promise.all([...fieldPromises, videoPagePromise]);
+          })
+        );
+      })
+    ).then(() => {
+      return Object.keys(usages.data).reduce(
+        (all, state) => {
+          const updated = usages.data[state].video.map(usage => {
+            return Object.assign({}, usage, {
+              webTitle: video.title
+            });
           });
-        });
 
-        // TODO avoid mutation... but how on such a deep property?!
-        all.data[state] = {
-          video: updated,
-          other: usages.data[state].other
-        };
+          // TODO avoid mutation... but how on such a deep property?!
+          all.data[state] = {
+            video: updated,
+            other: usages.data[state].other
+          };
 
-        return all;
-      }, {
-        data: {},
-        totalUsages: usages.totalUsages,
-        totalVideoPages: usages.totalVideoPages
-      });
+          return all;
+        },
+        {
+          data: {},
+          totalUsages: usages.totalUsages,
+          totalVideoPages: usages.totalVideoPages
+        }
+      );
     });
   },
 
@@ -290,7 +304,7 @@ export default {
     });
   },
 
-  addVideoToComposerPage({composerId, previewData, composerUrlBase}) {
+  addVideoToComposerPage({ composerId, previewData, composerUrlBase }) {
     function updateMainBlock(stage, data) {
       return pandaReqwest({
         url: `${composerUrlBase}/api/content/${composerId}/${stage}/mainblock`,

--- a/public/video-ui/src/services/capi.js
+++ b/public/video-ui/src/services/capi.js
@@ -2,6 +2,20 @@ import { pandaReqwest } from './pandaReqwest';
 import { getStore } from '../util/storeAccessor';
 
 export default class ContentApi {
+  static get published() {
+    return 'published';
+  }
+
+  static get preview() {
+    return 'preview';
+  }
+
+  static getUrl(stage) {
+    return stage === ContentApi.published
+      ? ContentApi.liveProxyUrl
+      : ContentApi.proxyUrl;
+  }
+
   static get proxyUrl() {
     return getStore().getState().config.capiProxyUrl;
   }

--- a/public/video-ui/src/util/getComposerData.js
+++ b/public/video-ui/src/util/getComposerData.js
@@ -93,9 +93,7 @@ export function getComposerData(video) {
     belongsTo: 'settings'
   };
 
-  return !isTrainingMode
-    ? coreFields
-    : [...coreFields, embargoedIndefinately];
+  return !isTrainingMode ? coreFields : [...coreFields, embargoedIndefinately];
 }
 
 export function getRightsPayload(video) {

--- a/public/video-ui/src/util/getComposerPages.js
+++ b/public/video-ui/src/util/getComposerPages.js
@@ -1,6 +1,0 @@
-export function getComposerPages(usages) {
-  if (!usages) {
-    return false;
-  }
-  return usages.filter(value => value.type === 'video');
-}

--- a/public/video-ui/src/util/getTagDisplayNames.js
+++ b/public/video-ui/src/util/getTagDisplayNames.js
@@ -1,7 +1,6 @@
 import TagTypes from '../constants/TagTypes';
 
 export default function getTagDisplayNames(tags) {
-
   return tags.map(tag => {
     if (typeof tag === 'string') {
       return tag;
@@ -11,7 +10,6 @@ export default function getTagDisplayNames(tags) {
     let detailedTitle;
 
     if (tagType === TagTypes.keyword) {
-
       //Some webtitles on keyword tags are too unspecific and we need to add
       //the section name to them to know what tags they are referring to
 
@@ -23,17 +21,11 @@ export default function getTagDisplayNames(tags) {
       } else {
         detailedTitle = tag.webTitle;
       }
-    }
-
-    else if (tagType === TagTypes.series) {
+    } else if (tagType === TagTypes.series) {
       detailedTitle = tag.webTitle + ' (series)';
-    }
-
-    else if (tagType === TagTypes.tone) {
+    } else if (tagType === TagTypes.tone) {
       detailedTitle = tag.webTitle + ' (tone)';
-    }
-
-    else detailedTitle = tag.webTitle;
+    } else detailedTitle = tag.webTitle;
 
     return {
       id: tag.id,
@@ -41,5 +33,4 @@ export default function getTagDisplayNames(tags) {
       detailedTitle: detailedTitle
     };
   });
-
 }

--- a/public/video-ui/src/util/removeTagDuplicates.js
+++ b/public/video-ui/src/util/removeTagDuplicates.js
@@ -1,4 +1,3 @@
 export default function removeTagDuplicates(tag, tagValue) {
-
   return tagValue.filter(value => value.id !== tag.id);
 }

--- a/public/video-ui/styles/abstracts/_variables.scss
+++ b/public/video-ui/styles/abstracts/_variables.scss
@@ -94,3 +94,7 @@ $iconSize: 16px; /* Preferred icon size */
 
 // Font sizes
 $fontsize__detailbox: 17px;
+
+$articleType: #137fcc;
+$liveblogType: #e31f26;
+$videoType: #ffbc01;

--- a/public/video-ui/styles/components/_details-list.scss
+++ b/public/video-ui/styles/components/_details-list.scss
@@ -35,3 +35,21 @@
 
 }
 
+.details-list__content-type {
+  border-radius: 20px;
+  padding: 5px;
+  margin-left: 10px;
+  color: $color900Grey;
+
+  &--video {
+    background-color: $videoType;
+  }
+
+  &--article {
+    background-color: $articleType;
+  }
+
+  &--liveblog {
+    background-color: $liveblogType;
+  }
+}

--- a/public/video-ui/styles/components/_details-list.scss
+++ b/public/video-ui/styles/components/_details-list.scss
@@ -34,22 +34,3 @@
   padding-right: 10px;
 
 }
-
-.details-list__content-type {
-  border-radius: 20px;
-  padding: 5px;
-  margin-left: 10px;
-  color: $color900Grey;
-
-  &--video {
-    background-color: $videoType;
-  }
-
-  &--article {
-    background-color: $articleType;
-  }
-
-  &--liveblog {
-    background-color: $liveblogType;
-  }
-}

--- a/public/video-ui/styles/components/_usage.scss
+++ b/public/video-ui/styles/components/_usage.scss
@@ -1,3 +1,30 @@
+.usage {
+  padding: 10px;
+}
+
+.usage--none {
+  font-style: italic;
+}
+
 .usage--platform-link {
   padding-left: 10px;
+}
+
+.usage__content-type {
+  border-radius: 20px;
+  padding: 3px 5px;
+  margin-right: 10px;
+  color: $color900Grey;
+
+  &--video {
+    background-color: $videoType;
+  }
+
+  &--article {
+    background-color: $articleType;
+  }
+
+  &--liveblog {
+    background-color: $liveblogType;
+  }
 }


### PR DESCRIPTION
Splits usage to show `Preview` and `Published` content separately, also ensures video page usage is always at top of the list.

![image](https://user-images.githubusercontent.com/836140/29498944-16261aa0-85fe-11e7-9d6a-aa52384a5ad8.png)
