### PR TITLE
set poster image for self hosted video preview

### DIFF
--- a/public/video-ui/src/components/VideoPreview/VideoPreview.js
+++ b/public/video-ui/src/components/VideoPreview/VideoPreview.js
@@ -4,6 +4,7 @@ import { YouTubeEmbed } from '../utils/YouTubeEmbed';
 import { formNames } from '../../constants/formNames';
 import VideoPoster from '../VideoPoster/VideoPoster';
 import GridImageSelect from '../utils/GridImageSelect';
+import { findSmallestAssetAboveWidth } from '../../util/imageHelpers';
 
 export default class VideoPreview extends React.Component {
 
@@ -31,7 +32,15 @@ export default class VideoPreview extends React.Component {
       return { src: asset.id, mimeType: asset.mimeType };
     });
 
-    return <VideoEmbed sources={sources} />;
+    if (this.props.video.posterImage) {
+      const poster = findSmallestAssetAboveWidth(
+        this.props.video.posterImage.assets
+      );
+
+      return <VideoEmbed sources={sources} posterUrl={poster.file}/>;
+    }
+
+    return <VideoEmbed sources={sources}/>;
   }
 
   render() {

--- a/public/video-ui/src/components/utils/VideoEmbed.js
+++ b/public/video-ui/src/components/utils/VideoEmbed.js
@@ -1,11 +1,15 @@
 import React from 'react';
 
-export function VideoEmbed({ sources }) {
+export function VideoEmbed({ sources, posterUrl }) {
   const props = {
     className: 'video-player',
     controls: 'controls',
     preload: 'metadata'
   };
+
+  if (posterUrl) {
+    props.poster = posterUrl;
+  }
 
   if (sources.length === 1) {
     // to appease Safari


### PR DESCRIPTION
Makes the video preview more consistent to how it'll render on site.

# Before
![image](https://user-images.githubusercontent.com/836140/29525807-c301b9ea-868b-11e7-867d-338c5468b00e.png)


# After
![image](https://user-images.githubusercontent.com/836140/29525781-aee2edd0-868b-11e7-9014-30047ae8cc27.png)
