### PR TITLE
Spell YouTube correctly

### DIFF
--- a/public/video-ui/src/components/VideoPreview/VideoPreview.js
+++ b/public/video-ui/src/components/VideoPreview/VideoPreview.js
@@ -53,7 +53,7 @@ export default class VideoPreview extends React.Component {
         <div className="video__detailbox">
           <div className="video__detailbox__header__container">
             <header className="video__detailbox__header">
-              Youtube Poster Image
+              YouTube Poster Image
             </header>
             <GridImageSelect
               updateVideo={this.saveAndUpdateVideoPoster}
@@ -68,7 +68,7 @@ export default class VideoPreview extends React.Component {
             formName={formNames.posterImage}
             updateErrors={this.props.updateErrors}
             fieldLocation="posterImage"
-            name="Youtube Poster Image"
+            name="YouTube Poster Image"
           />
         </div>
         <div className="video__detailbox">


### PR DESCRIPTION
Too many capitalisations all over the app, but it may be subjective... Spelling “YouTube” isn’t.

EDIT: BTW, isn’t this used as a poster frame for when the atom is embedded on our frontends? “YouTube Poster Image” would be a bit misleading/irrelevant, then.