### PR TITLE
Rv fix tooltip

### DIFF
--- a/public/video-ui/src/components/FormFields/CheckBox.js
+++ b/public/video-ui/src/components/FormFields/CheckBox.js
@@ -22,7 +22,7 @@ export default class CheckBox extends React.Component {
 
   render() {
     return (
-      <div data-tip={this.props.tooltip}>
+      <div data-tip={this.props.editable ? this.props.tooltip : ""} data-place="top">
         <p className="details-list__title">{this.props.fieldName}</p>
         <div className="details-list__labeled-filter">
           {this.renderCheckbox()}

--- a/public/video-ui/src/components/FormFields/ScribeEditor.js
+++ b/public/video-ui/src/components/FormFields/ScribeEditor.js
@@ -7,6 +7,7 @@ import scribePluginLinkPromptCommand from 'scribe-plugin-link-prompt-command';
 import scribePluginSanitizer from 'scribe-plugin-sanitizer';
 import {keyCodes} from '../../constants/keyCodes';
 import {requiredForComposerWarning} from '../../constants/requiredForComposerWarning';
+import ReactTooltip from 'react-tooltip';
 
 export default class ScribeEditorField extends React.Component {
   state = {
@@ -83,9 +84,10 @@ export default class ScribeEditorField extends React.Component {
           disabled={!this.props.derivedFrom}
           className="btn form__label__button"
           onClick={this.updateValueFromCopy}
+          data-tip="Copy trail text from description"
+          data-place="top"
         >
           <i className="icon">edit</i>
-          <span data-tip="Copy trail text from description" />
         </button>
         );
   };
@@ -170,6 +172,7 @@ export class ScribeEditor extends React.Component {
 
 
   componentDidMount() {
+    ReactTooltip.rebuild();
     this.scribe = new Scribe(this.refs.editor);
 
     this.configureScribe();


### PR DESCRIPTION
The tooltip was not displaying on top of the copy to trail button. This was because he tooltip needed reloading so that it gets rendered when the form is made editable. I wanted to make the effect solid too to make tooltips more visible inside the form but reloading the tooltip seems to erase the effect settings (but only the effect setting!). Placing the tooltip to the top makes it readable at least. 

I've also hidden the block adds tooltip checkbox tooltip when the edit form is not editable. 