### PR TITLE
split VideoPreview component

### DIFF
--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import VideoSelectBar from '../VideoSelectBar/VideoSelectBar';
 import VideoPreview from '../VideoPreview/VideoPreview';
+import VideoImages from '../VideoImages/VideoImages';
 import VideoUsages from '../VideoUsages/VideoUsages';
 import VideoData from '../VideoData/VideoData';
 import Workflow from '../Workflow/Workflow';
@@ -124,6 +125,24 @@ class VideoDisplay extends React.Component {
 
   renderPreview = () => {
     return (
+      <VideoPreview video={this.props.video || {}} />
+    );
+  };
+
+  renderImages() {
+    return (
+      <VideoImages
+        config={this.props.config}
+        video={this.props.video || {}}
+        saveAndUpdateVideo={this.saveAndUpdateVideo}
+        videoEditOpen={this.props.videoEditOpen}
+        updateErrors={this.props.formErrorActions.updateFormErrors}
+      />
+    );
+  }
+
+  renderPreviewAndImages() {
+    return (
       <div className="video__detailbox">
         <div className="video__detailbox__header__container">
           <header className="video__detailbox__header">Video Preview</header>
@@ -137,16 +156,13 @@ class VideoDisplay extends React.Component {
             <ReactTooltip place="bottom" />
           </Link>
         </div>
-        <VideoPreview
-          video={this.props.video || {}}
-          saveAndUpdateVideo={this.saveAndUpdateVideo}
-          updateErrors={this.props.formErrorActions.updateFormErrors}
-          config={this.props.config}
-          videoEditOpen={this.props.videoEditOpen}
-        />
+        <div className="video-preview">
+          {this.renderPreview()}
+          {this.renderImages()}
+        </div>
       </div>
     );
-  };
+  }
 
   renderSelectBar(video) {
     return (
@@ -233,7 +249,7 @@ class VideoDisplay extends React.Component {
           <div className="video__main">
             <div className="video__row">
               {this.renderMetadata()}
-              {this.renderPreview()}
+              {this.renderPreviewAndImages()}
             </div>
             <div className="video__row">
               {this.renderUsages()}

--- a/public/video-ui/src/components/VideoImages/VideoImages.js
+++ b/public/video-ui/src/components/VideoImages/VideoImages.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { formNames } from '../../constants/formNames';
+import VideoPoster from '../VideoPoster/VideoPoster';
+import GridImageSelect from '../utils/GridImageSelect';
+
+export default class VideoImages extends React.Component {
+  static propTypes = {
+    config: PropTypes.object.isRequired,
+    video: PropTypes.object.isRequired,
+    saveAndUpdateVideo: PropTypes.func.isRequired,
+    videoEditOpen: PropTypes.bool.isRequired,
+    updateErrors: PropTypes.func.isRequired
+  };
+
+  saveAndUpdateVideoPoster = (poster, location) => {
+    const newVideo = Object.assign({}, this.props.video, {
+      [location]: poster
+    });
+    this.props.saveAndUpdateVideo(newVideo);
+  };
+
+  render() {
+    return (
+      <div className="video__imagebox">
+        <div className="video__detailbox">
+          <div className="video__detailbox__header__container">
+            <header className="video__detailbox__header">
+              Main Image (YouTube poster)
+            </header>
+            <GridImageSelect
+              updateVideo={this.saveAndUpdateVideoPoster}
+              gridUrl={this.props.config.gridUrl}
+              disabled={this.props.videoEditOpen}
+              fieldLocation="posterImage"
+            />
+          </div>
+          <VideoPoster
+            video={this.props.video || {}}
+            updateVideo={this.props.saveAndUpdateVideo}
+            formName={formNames.posterImage}
+            updateErrors={this.props.updateErrors}
+            fieldLocation="posterImage"
+            name="Main Image (YouTube poster)"
+          />
+        </div>
+        <div className="video__detailbox">
+          <div className="video__detailbox__header__container">
+            <header className="video__detailbox__header">
+              Composer Trail Image
+            </header>
+            <GridImageSelect
+              updateVideo={this.saveAndUpdateVideoPoster}
+              gridUrl={this.props.config.gridUrl}
+              disabled={this.props.videoEditOpen || !this.props.video.posterImage}
+              isComposerImage={true}
+              posterImage={this.props.video.posterImage}
+              fieldLocation="trailImage"
+            />
+          </div>
+          <VideoPoster
+            video={this.props.video || {}}
+            updateVideo={this.props.saveAndUpdateVideo}
+            updateErrors={this.props.updateErrors}
+            fieldLocation="trailImage"
+            name="Composer Trail Image"
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/public/video-ui/src/components/VideoPreview/VideoPreview.js
+++ b/public/video-ui/src/components/VideoPreview/VideoPreview.js
@@ -1,18 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { VideoEmbed } from '../utils/VideoEmbed';
 import { YouTubeEmbed } from '../utils/YouTubeEmbed';
-import { formNames } from '../../constants/formNames';
-import VideoPoster from '../VideoPoster/VideoPoster';
-import GridImageSelect from '../utils/GridImageSelect';
+
 import { findSmallestAssetAboveWidth } from '../../util/imageHelpers';
 
 export default class VideoPreview extends React.Component {
-
-  saveAndUpdateVideoPoster = (poster, location) => {
-    const newVideo = Object.assign({}, this.props.video, {
-      [location]: poster
-    });
-    this.props.saveAndUpdateVideo(newVideo);
+  static propTypes = {
+    video: PropTypes.object.isRequired
   };
 
   renderPreview() {
@@ -45,56 +40,9 @@ export default class VideoPreview extends React.Component {
 
   render() {
     return (
-      <div className="video-preview">
       <div className="video__preview__container">
         {this.renderPreview()}
       </div>
-      <div className="video__imagebox">
-        <div className="video__detailbox">
-          <div className="video__detailbox__header__container">
-            <header className="video__detailbox__header">
-              Main Image (YouTube poster)
-            </header>
-            <GridImageSelect
-              updateVideo={this.saveAndUpdateVideoPoster}
-              gridUrl={this.props.config.gridUrl}
-              disabled={this.props.videoEditOpen}
-              fieldLocation="posterImage"
-            />
-          </div>
-          <VideoPoster
-            video={this.props.video || {}}
-            updateVideo={this.props.saveAndUpdateVideo}
-            formName={formNames.posterImage}
-            updateErrors={this.props.updateErrors}
-            fieldLocation="posterImage"
-            name="Main Image (YouTube poster)"
-          />
-        </div>
-        <div className="video__detailbox">
-          <div className="video__detailbox__header__container">
-            <header className="video__detailbox__header">
-              Composer Trail Image
-            </header>
-            <GridImageSelect
-              updateVideo={this.saveAndUpdateVideoPoster}
-              gridUrl={this.props.config.gridUrl}
-              disabled={this.props.videoEditOpen || !this.props.video.posterImage}
-              isComposerImage={true}
-              posterImage={this.props.video.posterImage}
-              fieldLocation="trailImage"
-            />
-          </div>
-          <VideoPoster
-            video={this.props.video || {}}
-            updateVideo={this.props.saveAndUpdateVideo}
-            updateErrors={this.props.updateErrors}
-            fieldLocation="trailImage"
-            name="Composer Trail Image"
-          />
-        </div>
-      </div>
-    </div>
     );
   }
 }


### PR DESCRIPTION
Separate the images into a component in their own right.

This will make adding the alt text field for the trail image easier.

There's no UI difference, its just more componetised on the DOM as demonstrated by the red boxes below.

Before
![before](https://user-images.githubusercontent.com/836140/29970428-6dd5c134-8f1c-11e7-858d-d32517d971b1.jpg)

After
![after](https://user-images.githubusercontent.com/836140/29970433-73a0af16-8f1c-11e7-8bb1-cb37f376514d.jpg)
