### PR TITLE
fix usage bug on create form

### DIFF
--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -28,6 +28,7 @@ class VideoDisplay extends React.Component {
   saveAndUpdateVideo = video => {
     if (this.props.route.mode === 'create') {
       this.props.videoActions.createVideo(video);
+      this.props.videoActions.getUsages(this.props.video.id);
     } else {
       this.props.videoActions.saveVideo(video);
     }

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -27,8 +27,10 @@ class VideoDisplay extends React.Component {
 
   saveAndUpdateVideo = video => {
     if (this.props.route.mode === 'create') {
-      this.props.videoActions.createVideo(video);
-      this.props.videoActions.getUsages(this.props.video.id);
+      this.props.videoActions.createVideo(video)
+        .then(() => {
+          this.props.videoActions.getUsages(this.props.video.id);
+        });
     } else {
       this.props.videoActions.saveVideo(video);
     }


### PR DESCRIPTION
Usage aren't getting updated when you create a new atom. This is ok when there is nothing in the store (blankUsageData), however if you've looked at an atom, then go to create a new atom, the usages do not change, that is, the usages of the newly created atom are the same as the atom you were previously looking at.

This fixes this by refreshing usages when creating a new atom.

relates to https://github.com/guardian/media-atom-maker/pull/583 and https://github.com/guardian/media-atom-maker/pull/584