### PR TITLE
rename 'hosted' to 'hosted by'

### DIFF
--- a/public/video-ui/src/constants/videoCategories.js
+++ b/public/video-ui/src/constants/videoCategories.js
@@ -5,5 +5,5 @@ export const videoCategories = [
   'Feature',
   'Hosted'
 ].map(cat => {
-  return { id: cat, title: cat };
+  return { id: cat, title: cat === 'Hosted' ? 'Hosted by' : cat };
 });


### PR DESCRIPTION
this is just for the display value, we're still saving 'hosted' per the enum

this is towards fully supported Labs with their hosted and paid for categories

![image](https://user-images.githubusercontent.com/836140/30102154-9e52d95a-92e6-11e7-9b89-ad343a8cb6e0.png)
