### PR TITLE
open to individual atom page

### DIFF
--- a/public/video-ui/src/services/WorkflowApi.js
+++ b/public/video-ui/src/services/WorkflowApi.js
@@ -8,8 +8,7 @@ export default class WorkflowApi {
   }
 
   static workflowItemLink() {
-    //TODO link to atom in Workflow
-    return `${WorkflowApi.workflowUrl}/dashboard?atom-type=media`;
+    return `${WorkflowApi.workflowUrl}/dashboard?editorId=${video.id}`;
   }
 
   static getSections() {


### PR DESCRIPTION
Change workflow link to open directly to the individual atom page.

See:
https://github.com/guardian/workflow/pull/1028
https://github.com/guardian/workflow-frontend/pull/98
