### PR TITLE
youtube iframe args match frontend

### DIFF
--- a/app/views/MediaAtom/defaultEmbed.scala.html
+++ b/app/views/MediaAtom/defaultEmbed.scala.html
@@ -7,7 +7,7 @@
   }
 
   case (Some(YouTubeAsset(id)), _) => {
-    <iframe frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/@id"></iframe>
+    <iframe frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/@id?showinfo=0&rel=0"></iframe>
   }
 
   case (Some(SelfHostedAsset(sources)), maybePoster) => {

--- a/public/video-ui/src/components/utils/YouTubeEmbed.js
+++ b/public/video-ui/src/components/utils/YouTubeEmbed.js
@@ -3,7 +3,7 @@ import { getStore } from '../../util/storeAccessor';
 
 export function YouTubeEmbed({ id, className }) {
   const embedUrl = getStore().getState().config.youtubeEmbedUrl;
-  const src = `${embedUrl}${id}?showinfo=0`;
+  const src = `${embedUrl}${id}?showinfo=0&rel=0`;
 
   return (
     <iframe

--- a/test/ThriftUtilSpec.scala
+++ b/test/ThriftUtilSpec.scala
@@ -61,7 +61,7 @@ class ThriftUtilSpec extends FunSpec
               }
 
               val iframe = Jsoup.parse(defaultHtml).getElementsByTag("iframe")
-              iframe.attr("src") should be(s"https://www.youtube.com/embed/$youtubeId")
+              iframe.attr("src") should be(s"https://www.youtube.com/embed/$youtubeId?showinfo=0&rel=0")
           }
       }
     }


### PR DESCRIPTION
to make the youtube video preview within the Tool and within Composer more WYSIWYG for Editorial

Here are frontend's arguments - https://github.com/guardian/frontend/blob/master/common/app/views/fragments/atoms/youtube.scala.html#L39-L40