### PR TITLE
extract common sixteen by nine styling

### DIFF
--- a/public/video-ui/src/components/VideoPreview/VideoPreview.js
+++ b/public/video-ui/src/components/VideoPreview/VideoPreview.js
@@ -20,7 +20,7 @@ export default class VideoPreview extends React.Component {
     }
 
     if (active.length === 1 && active[0].platform === 'Youtube') {
-      return <YouTubeEmbed id={active[0].id} className="video__preview__player" />;
+      return <YouTubeEmbed id={active[0].id} />;
     }
 
     const sources = active.map(asset => {
@@ -40,7 +40,7 @@ export default class VideoPreview extends React.Component {
 
   render() {
     return (
-      <div className="video__preview__container">
+      <div className="sixteen-by-nine">
         {this.renderPreview()}
       </div>
     );

--- a/public/video-ui/src/components/Videos/VideoItem.js
+++ b/public/video-ui/src/components/Videos/VideoItem.js
@@ -40,7 +40,7 @@ export default class VideoItem extends React.Component {
         <Link className="grid__link" to={'/videos/' + this.props.video.id}>
 
           <div className="grid__info">
-            <div className="grid__image">
+            <div className="grid__image sixteen-by-nine">
               {this.renderItemImage()}
             </div>
             <div className="grid__status__overlay">

--- a/public/video-ui/styles/base/_helpers.scss
+++ b/public/video-ui/styles/base/_helpers.scss
@@ -71,7 +71,6 @@ $baselineMargin: 20px;
   justify-content: center;
   flex-direction: column;
   text-align: center;
-  margin: 10px;
   height: 282px;
   width: 90%;
   border-style: none;

--- a/public/video-ui/styles/layout/_common.scss
+++ b/public/video-ui/styles/layout/_common.scss
@@ -1,0 +1,17 @@
+.sixteen-by-nine {
+  // https://www.w3schools.com/howto/howto_css_aspect_ratio.asp
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-top: 56.25%; // 16:9 ratio
+
+  :first-child {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -31,21 +31,6 @@
   padding: 10px;
 }
 
-.video__preview__player {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  left: 0;
-  top: 0;
-}
-
-.video__preview__container {
-  position: relative;
-  width: 100%;
-  height: 0;
-  padding-bottom: 57.5%;
-}
-
 .video-assets__show-btn {
   width: 100%;
   text-align: center;

--- a/public/video-ui/styles/main.scss
+++ b/public/video-ui/styles/main.scss
@@ -19,6 +19,7 @@
 
 // 4. Layout-related sections
 @import
+  'layout/_common.scss',
   'layout/flex',
   'layout/topbar',
   'layout/grid',

--- a/public/video-ui/styles/main.scss
+++ b/public/video-ui/styles/main.scss
@@ -19,7 +19,7 @@
 
 // 4. Layout-related sections
 @import
-  'layout/_common.scss',
+  'layout/common',
   'layout/flex',
   'layout/topbar',
   'layout/grid',


### PR DESCRIPTION
apply style to video preview and search image

fixes the empty state of video preview

before
![image](https://user-images.githubusercontent.com/836140/30482243-1624a06e-9a1a-11e7-9a2b-597033555f77.png)


after
![image](https://user-images.githubusercontent.com/836140/30482230-0a73594a-9a1a-11e7-9226-bec85359c6f6.png)
