### PR TITLE
check for asset length before parsing composer data

### DIFF
--- a/public/video-ui/src/util/getComposerData.js
+++ b/public/video-ui/src/util/getComposerData.js
@@ -77,7 +77,7 @@ export function getComposerData(video) {
     },
     {
       name: 'thumbnail',
-      value: video.trailImage
+      value: (video.trailImage && video.trailImage.assets.length > 0)
         ? parseComposerDataFromImage(video.trailImage, video.trailText)
         : null,
       belongsTo: 'thumbnail'


### PR DESCRIPTION
When there is no trail image the trailImage object exists but the assets array is empty. We should check for the assets length so that we don't get errors when trying to create a video page without a trail image.