### PR TITLE
allow for scoped channels

### DIFF
--- a/app/controllers/Youtube.scala
+++ b/app/controllers/Youtube.scala
@@ -17,15 +17,9 @@ class Youtube (val authActions: HMACAuthActions, youtube: YouTube) extends Contr
     val isTrainingMode = isInTrainingMode(req)
 
     val channels = if (isTrainingMode) {
-      youtube.trainingChannels match {
-        case Nil => List()
-        case trainingList => youtube.channels.filter(c => trainingList.contains(c.id))
-      }
+      youtube.channels.filter(c => youtube.trainingChannels.contains(c.id))
     } else {
-      youtube.allowedChannels match {
-        case Nil => youtube.channels
-        case allowedList => youtube.channels.filter(c => allowedList.contains(c.id))
-      }
+      youtube.channels.filter(c => youtube.allChannels.contains(c.id))
     }
 
     Ok(Json.toJson(channels))

--- a/app/model/MediaAtom.scala
+++ b/app/model/MediaAtom.scala
@@ -2,6 +2,7 @@ package model
 
 import com.gu.contentatom.thrift.atom.media.{MediaAtom => ThriftMediaAtom, Metadata => ThriftMetadata, PlutoData => ThriftPlutoData}
 import com.gu.contentatom.thrift.{AtomData, Atom => ThriftAtom, AtomType => ThriftAtomType, Flags => ThriftFlags}
+import com.gu.media.model.PrivacyStatus
 import org.cvogt.play.json.Jsonx
 import util.atom.MediaAtomImplicits
 

--- a/app/model/Metadata.scala
+++ b/app/model/Metadata.scala
@@ -1,5 +1,6 @@
 package model
 
+import com.gu.media.model.PrivacyStatus
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 

--- a/app/model/commands/CreateAtomCommand.scala
+++ b/app/model/commands/CreateAtomCommand.scala
@@ -10,7 +10,7 @@ import com.gu.media.logging.Logging
 import com.gu.pandomainauth.model.{User => PandaUser}
 import data.DataStores
 import model.commands.CommandExceptions._
-import model.{ChangeRecord, Image, MediaAtom, PrivacyStatus, MediaAtomBeforeCreation, ContentChangeDetails}
+import model.{ChangeRecord, Image, MediaAtom, MediaAtomBeforeCreation, ContentChangeDetails}
 import org.cvogt.play.json.Jsonx
 import play.api.libs.json.Format
 

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -8,6 +8,7 @@ import com.gu.atom.play.AtomAPIActions
 import com.gu.contentatom.thrift.{ContentAtomEvent, EventType}
 import com.gu.media.Capi
 import com.gu.media.logging.Logging
+import com.gu.media.model.PrivacyStatus
 import com.gu.media.youtube.YouTubeMetadataUpdate
 import com.gu.pandomainauth.model.{User => PandaUser}
 import data.DataStores
@@ -98,7 +99,7 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youtu
 
   private def updateYouTube(previewAtom: MediaAtom, asset: Asset): Future[MediaAtom] = {
     previewAtom.channelId match {
-      case Some(channel) if youtube.allowedChannels.contains(channel) =>
+      case Some(channel) if youtube.allChannels.contains(channel) =>
         if (youtube.usePartnerApi) {
           createOrUpdateYoutubeClaim(previewAtom, asset)
         }

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -44,7 +44,13 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youtu
         val duration = youtube.getDuration(asset.id)
         val blockAds = if (duration.getOrElse(0L) < youtube.minDurationForAds) true else previewAtom.blockAds
 
-        val updatedPreviewAtom = previewAtom.copy(duration = duration, blockAds = blockAds)
+        val privacyStatus = previewAtom.channelId match {
+          case Some(channel) if youtube.strictlyUnlistedChannels.contains(channel) => Some(PrivacyStatus.Unlisted)
+          case _ => previewAtom.privacyStatus
+        }
+
+        val updatedPreviewAtom = previewAtom.copy(duration = duration, blockAds = blockAds, privacyStatus = privacyStatus)
+
         updateYouTube(updatedPreviewAtom, asset).map(atomWithYoutubeUpdates => {
           publish(atomWithYoutubeUpdates, user)
         })

--- a/common/src/main/scala/com/gu/media/Settings.scala
+++ b/common/src/main/scala/com/gu/media/Settings.scala
@@ -7,7 +7,7 @@ trait Settings {
   def config: Config
 
   def getString(name: String): Option[String] = if(config.hasPath(name)) { Some(config.getString(name)) } else { None }
-  def getStringList(name: String): List[String] = if(config.hasPath(name)) { config.getStringList(name).asScala.toList } else { List.empty}
+  def getStringSet(name: String): Set[String] = if(config.hasPath(name)) { config.getStringList(name).asScala.toSet } else { Set.empty }
   def getBoolean(name: String): Option[Boolean] = if(config.hasPath(name)) { Some(config.getBoolean(name)) } else { None }
 
   def getMandatoryString(name: String, hint: String = ""): String = if(config.hasPath(name)) {

--- a/common/src/main/scala/com/gu/media/model/PrivacyStatus.scala
+++ b/common/src/main/scala/com/gu/media/model/PrivacyStatus.scala
@@ -1,4 +1,4 @@
-package model
+package com.gu.media.model
 
 import com.gu.contentatom.thrift.atom.media.{PrivacyStatus => ThriftPrivacyStatus}
 import play.api.libs.json._
@@ -26,7 +26,7 @@ object PrivacyStatus {
 
   implicit val format = Format(reads, writes)
 
-  private val types = List(Private, Unlisted, Public)
+  val all: Set[PrivacyStatus] = Set(Private, Unlisted, Public)
 
-  def fromThrift(status: ThriftPrivacyStatus): Option[PrivacyStatus] = types.find(_.name == status.name)
+  def fromThrift(status: ThriftPrivacyStatus): Option[PrivacyStatus] = all.find(_.name == status.name)
 }

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -132,7 +132,7 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
     getVideo(youtubeId, "snippet") match {
       case Some(video) =>
         val channel = video.getSnippet.getChannelId
-        allowedChannels.contains(channel)
+        allChannels.contains(channel)
 
       case None =>
         false
@@ -148,7 +148,7 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
       throw new Exception(msg)
     }
 
-    if (allowedChannels.nonEmpty && !allowedChannels.contains(videoChannelId)) {
+    if (allChannels.nonEmpty && !allChannels.contains(videoChannelId)) {
       val msg = s"Failed to edit video ${video.getId} as its channel ($videoChannelId) isn't in config.youtube.allowedChannels"
       log.info(msg)
       throw new Exception(msg)

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -23,7 +23,7 @@ package object youtube {
     }
   }
 
-  case class YouTubeChannel(id: String, title: String, privacyStatus: Set[PrivacyStatus])
+  case class YouTubeChannel(id: String, title: String, privacyStates: Set[PrivacyStatus] = PrivacyStatus.all)
 
   object YouTubeChannel {
     implicit val reads: Reads[YouTubeChannel] = Json.reads[YouTubeChannel]
@@ -33,7 +33,7 @@ package object youtube {
       YouTubeChannel(
         id = channel.getId,
         title = channel.getSnippet.getTitle,
-        privacyStatus = if (allowPublic) PrivacyStatus.all else Set(PrivacyStatus.Unlisted, PrivacyStatus.Private)
+        privacyStates = if (allowPublic) PrivacyStatus.all else Set(PrivacyStatus.Unlisted, PrivacyStatus.Private)
       )
     }
   }
@@ -67,7 +67,7 @@ package object youtube {
         privacyStatus = video.getStatus.getPrivacyStatus,
         tags = tags,
         contentBundleTags = tags.filter(t => t.startsWith("gdnpfp")),
-        channel = YouTubeChannel(id = video.getSnippet.getChannelId, title = video.getSnippet.getChannelTitle, PrivacyStatus.all)
+        channel = YouTubeChannel(id = video.getSnippet.getChannelId, title = video.getSnippet.getChannelTitle)
       )
     }
   }

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -2,6 +2,7 @@ package com.gu.media
 
 import com.google.api.services.youtube.model.{Channel, Video, VideoCategory}
 import com.google.api.services.youtubePartner.model.VideoAdvertisingOption
+import com.gu.media.model.PrivacyStatus
 import com.gu.media.util.ISO8601Duration
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
@@ -22,16 +23,17 @@ package object youtube {
     }
   }
 
-  case class YouTubeChannel(id: String, title: String)
+  case class YouTubeChannel(id: String, title: String, privacyStatus: Set[PrivacyStatus])
 
   object YouTubeChannel {
     implicit val reads: Reads[YouTubeChannel] = Json.reads[YouTubeChannel]
     implicit val writes: Writes[YouTubeChannel] = Json.writes[YouTubeChannel]
 
-    def build(channel: Channel): YouTubeChannel = {
+    def build(channel: Channel, allowPublic: Boolean): YouTubeChannel = {
       YouTubeChannel(
         id = channel.getId,
-        title = channel.getSnippet.getTitle
+        title = channel.getSnippet.getTitle,
+        privacyStatus = if (allowPublic) PrivacyStatus.all else Set(PrivacyStatus.Unlisted, PrivacyStatus.Private)
       )
     }
   }
@@ -65,7 +67,7 @@ package object youtube {
         privacyStatus = video.getStatus.getPrivacyStatus,
         tags = tags,
         contentBundleTags = tags.filter(t => t.startsWith("gdnpfp")),
-        channel = YouTubeChannel(id = video.getSnippet.getChannelId, title = video.getSnippet.getChannelTitle)
+        channel = YouTubeChannel(id = video.getSnippet.getChannelId, title = video.getSnippet.getChannelTitle, PrivacyStatus.all)
       )
     }
   }

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -9,7 +9,7 @@ import TagPicker from '../FormFields/TagPicker';
 import TagTypes from '../../constants/TagTypes';
 import { fieldLengths } from '../../constants/videoEditValidation';
 import { videoCategories } from '../../constants/videoCategories';
-import { privacyStates } from '../../constants/privacyStates';
+import PrivacyStates from '../../constants/privacyStates';
 import { channelAllowed } from '../../util/channelAllowed';
 import { getStore } from '../../util/storeAccessor';
 
@@ -36,6 +36,10 @@ class VideoData extends React.Component {
       isHosted ||
       !channelAllowed(this.props.video, this.props.youtube.channels);
     const hasAssets = this.props.video.assets.length > 0;
+
+    const privacyStates = this.props.video.channelId && this.props.youtube.channels.length > 0
+      ? this.props.youtube.channels.find(_ => _.id === this.props.video.channelId).privacyStates
+      : PrivacyStates.defaultStates;
 
     return (
       <div className="form__group">
@@ -138,7 +142,7 @@ class VideoData extends React.Component {
               name="Privacy Status"
               disabled={notOnManagedChannel}
             >
-              <SelectBox selectValues={privacyStates} />
+              <SelectBox selectValues={PrivacyStates.forForm(privacyStates)} />
             </ManagedField>
             <ManagedField
               fieldLocation="tags"

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -32,12 +32,11 @@ class VideoData extends React.Component {
 
   render() {
     const isHosted = this.props.video.category === 'Hosted';
-    const notOnManagedChannel =
-      isHosted ||
-      !channelAllowed(this.props.video, this.props.youtube.channels);
     const hasAssets = this.props.video.assets.length > 0;
 
-    const privacyStates = this.props.video.channelId && this.props.youtube.channels.length > 0
+    const canUpdateYouTube = channelAllowed(this.props.video, this.props.youtube.channels);
+
+    const privacyStates = this.props.video.channelId && this.props.youtube.channels.length > 0 && canUpdateYouTube
       ? this.props.youtube.channels.find(_ => _.id === this.props.video.channelId).privacyStates
       : PrivacyStates.defaultStates;
 
@@ -56,7 +55,7 @@ class VideoData extends React.Component {
             <ManagedField
               fieldLocation="title"
               name={
-                notOnManagedChannel ? 'Headline' : 'Headline (YouTube title)'
+                canUpdateYouTube ? 'Headline (YouTube title)' : 'Headline'
               }
               maxLength={fieldLengths.title}
               isRequired={true}
@@ -66,9 +65,9 @@ class VideoData extends React.Component {
             <ManagedField
               fieldLocation="description"
               name={
-                notOnManagedChannel
-                  ? 'Standfirst'
-                  : 'Standfirst (YouTube description)'
+                canUpdateYouTube
+                  ? 'Standfirst (YouTube description)'
+                  : 'Standfirst'
               }
               customValidation={this.props.descriptionValidator}
               maxCharLength={fieldLengths.description.charMax}
@@ -137,10 +136,13 @@ class VideoData extends React.Component {
             >
               <SelectBox selectValues={videoCategories} />
             </ManagedField>
+            <ManagedField fieldLocation="channelId" name="YouTube Channel" disabled={isHosted || hasAssets}>
+              <SelectBox selectValues={this.props.youtube.channels} />
+            </ManagedField>
             <ManagedField
               fieldLocation="privacyStatus"
               name="Privacy Status"
-              disabled={notOnManagedChannel}
+              disabled={!canUpdateYouTube}
             >
               <SelectBox selectValues={PrivacyStates.forForm(privacyStates)} />
             </ManagedField>
@@ -149,7 +151,7 @@ class VideoData extends React.Component {
               name="YouTube Keywords"
               placeholder="No keywords"
               tagType={TagTypes.youtube}
-              disabled={notOnManagedChannel}
+              disabled={!canUpdateYouTube}
             >
               <TagPicker disableCapiTags />
             </ManagedField>
@@ -157,7 +159,7 @@ class VideoData extends React.Component {
               fieldLocation="blockAds"
               name="Block ads"
               fieldDetails="Ads will not be displayed with this video"
-              disabled={notOnManagedChannel}
+              disabled={!canUpdateYouTube}
               tooltip={`Videos less than ${getStore().getState().config.minDurationForAds} seconds will automatically have ads blocked`}
             >
               <CheckBox />
@@ -166,7 +168,7 @@ class VideoData extends React.Component {
               fieldLocation="composerCommentsEnabled"
               name="Comments"
               fieldDetails="Allow comments on Guardian video page (does not change YouTube)"
-              disabled={notOnManagedChannel}
+              disabled={!canUpdateYouTube}
             >
               <CheckBox />
             </ManagedField>
@@ -174,7 +176,7 @@ class VideoData extends React.Component {
               fieldLocation="optimisedForWeb"
               name="Optimised for Web"
               fieldDetails="Optimised for Web"
-              disabled={notOnManagedChannel}
+              disabled={!canUpdateYouTube}
             >
               <CheckBox />
             </ManagedField>
@@ -182,7 +184,7 @@ class VideoData extends React.Component {
               fieldLocation="sensitive"
               name="Sensitive"
               fieldDetails="Contains sensitive content"
-              disabled={notOnManagedChannel}
+              disabled={!canUpdateYouTube}
             >
               <CheckBox />
             </ManagedField>
@@ -190,7 +192,7 @@ class VideoData extends React.Component {
               fieldLocation="legallySensitive"
               name="Legally Sensitive"
               fieldDetails="This content involves active criminal proceedings"
-              disabled={notOnManagedChannel}
+              disabled={!canUpdateYouTube}
             >
               <CheckBox />
             </ManagedField>
@@ -198,7 +200,7 @@ class VideoData extends React.Component {
               fieldLocation="suppressRelatedContent"
               name="Suppress related content"
               fieldDetails="Suppress related content"
-              disabled={notOnManagedChannel}
+              disabled={!canUpdateYouTube}
             >
               <CheckBox />
             </ManagedField>

--- a/public/video-ui/src/components/VideoUpload/AddYouTubeAsset.js
+++ b/public/video-ui/src/components/VideoUpload/AddYouTubeAsset.js
@@ -25,13 +25,6 @@ export default class PlutoProjectPicker extends React.Component {
     const isHosted = video.category === 'Hosted';
     const isManaged = channelAllowed(video, channels);
 
-    const hasYouTubeAssets = video.assets.some(
-      asset => asset.platform === 'Youtube'
-    );
-
-    const editable =
-      !hasYouTubeAssets && (!video.channelId || !!video.youtubeCategoryId);
-
     const missingFields = !video.channelId || !video.youtubeCategoryId;
     const disabled = missingFields || !this.state.file || this.props.uploading;
 
@@ -47,16 +40,6 @@ export default class PlutoProjectPicker extends React.Component {
           </header>
         </div>
         <div className="form__group">
-          <ManagedForm
-            data={video}
-            updateData={this.props.saveVideo}
-            editable={editable}
-            formName="YouTubeChannel"
-          >
-            <ManagedField fieldLocation="channelId" name="YouTube Channel">
-              <SelectBox selectValues={this.props.channels} />
-            </ManagedField>
-          </ManagedForm>
           <ManagedForm
             data={video}
             updateData={this.props.saveVideo}

--- a/public/video-ui/src/constants/privacyStates.js
+++ b/public/video-ui/src/constants/privacyStates.js
@@ -1,3 +1,11 @@
-export const privacyStates = ['Public', 'Unlisted'].map(state => {
-  return { id: state, title: state };
-});
+export default class PrivacyStates {
+  static get defaultStates() {
+    return ['Public', 'Unlisted'];
+  }
+
+  static forForm(states) {
+    return states.filter(_ => _ !== 'Private').map(state => {
+      return { id: state, title: state };
+    });
+  }
+}

--- a/public/video-ui/src/constants/privacyStates.js
+++ b/public/video-ui/src/constants/privacyStates.js
@@ -1,6 +1,6 @@
 export default class PrivacyStates {
   static get defaultStates() {
-    return ['Public', 'Unlisted'];
+    return ['Unlisted'];
   }
 
   static forForm(states) {


### PR DESCRIPTION
Editorial have experienced problems where they've pasted a link to a video on the main channel, however as its not in the allowedChannel list, updates don't go to YouTube. This results in them editing the Atom and then going to youtube.com to do the same thing. This is time-consuming and not scalable because a lot of the subs don't have yt credentials.

We removed the main channel to prevent too many public uploads.

This PR updates the `/api/youtube/channels` endpoint, returning a list of privacyStates that a channel can be uploaded to. That is, we can add the main channel to the config `youtube.channels.unlisted` and allow Editorial to treat this Atom like any other, safe in the knowledge that its always unlisted.

![channel](https://user-images.githubusercontent.com/836140/30567757-be18a994-9cc9-11e7-9890-92a49c6e6809.gif)

TODO
- [x] test on CODE
- [x] confirm behaviour with Adam and Katie
- [ ] update configs in S3 before deploying
