### PR TITLE
fix tooltip opacity issue

### DIFF
--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -156,7 +156,6 @@ class VideoDisplay extends React.Component {
             data-tip="Edit Assets"
           >
             <Icon className="icon__edit" icon="edit" />
-            <ReactTooltip place="bottom" />
           </Link>
         </div>
         <div className="video-preview">
@@ -260,6 +259,7 @@ class VideoDisplay extends React.Component {
             </div>
           </div>
         </div>
+        <ReactTooltip />
       </div>
     );
   }


### PR DESCRIPTION
as requested in [training feedback](https://docs.google.com/spreadsheets/d/1YuJypnDOzfyx5dQ27T1V50zc_ZvzuiDOjk1vg6IGnOI/edit#gid=488173267)

fix tooltip opacity issue by putting it further up the DOM. The opacity style effects all children, before, the tooltip was a child of an element whose opacity was set to 0.4 when it had a disabled class. Now, the tooltip is higher up the DOM so doesn't inherit any opacity.

before:
![tooltip-before](https://user-images.githubusercontent.com/836140/30576489-30fae18a-9d00-11e7-9c29-a70df7dcacc7.gif)

after:
![tooltip-after](https://user-images.githubusercontent.com/836140/30576490-3667b3aa-9d00-11e7-9793-a0167bf9370c.gif)

