### PR TITLE
don't add spaces around commas

### DIFF
--- a/public/video-ui/src/components/Tags/TagFieldValue.js
+++ b/public/video-ui/src/components/Tags/TagFieldValue.js
@@ -12,7 +12,12 @@ export default class TagFieldValue extends React.Component {
       );
 
     }
-    return `${value} `;
+
+    if (index === 0 || value === ',') {
+      return value;
+    }
+
+    return ` ${value}`;
   }
 
   render() {

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -293,7 +293,7 @@
 
 .form__field__tag__display {
   text-decoration: underline $textColor;
-  padding: 3px;
+  padding-left: 3px;
 }
 
 .form__field--multiselect {


### PR DESCRIPTION
Commas in bylines should not have spaces on both sides when they are displayed to users, they should follow whichever word appears before them.