### PR TITLE
presence indicators

### DIFF
--- a/app/controllers/VideoUIApp.scala
+++ b/app/controllers/VideoUIApp.scala
@@ -77,16 +77,12 @@ class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfi
   }
 
   private def presenceConfig(user: User): Option[Presence] = {
-    (awsConfig.stage, conf.getString("presence.domain")) match {
-      case ("DEV", _ ) =>
-        None
-
-      case (_, None) =>
+    conf.getString("presence.domain") match {
+      case Some(origin) =>
+        Some(Presence(origin, user.firstName, user.lastName, user.email))
+      case None =>
         log.warn("Presence disabled. Missing presence.domain in config")
         None
-
-      case (_, Some(origin)) =>
-        Some(Presence(origin, user.firstName, user.lastName, user.email))
     }
   }
 }

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -112,7 +112,6 @@ export default class Header extends React.Component {
   }
 
   renderPresence() {
-    // No indicator in the UI yet, just reporting back for use in Workflow
     if (this.props.presenceConfig) {
       return (
         <Presence video={this.props.video} config={this.props.presenceConfig} />
@@ -150,20 +149,20 @@ export default class Header extends React.Component {
     if (this.props.currentPath.endsWith('/upload')) {
       return (
         <header className={className}>
-          {this.renderPresence()}
           {this.renderProgress()}
           {this.renderHeaderBack()}
+          {this.renderPresence()}
         </header>
       );
     }
     if (!this.props.showPublishedState) {
       return (
         <header className={className}>
-          {this.renderPresence()}
           {this.renderProgress()}
 
           {this.renderHome()}
           {this.renderSearch()}
+          {this.renderPresence()}
 
           <div className="flex-spacer" />
 
@@ -177,10 +176,9 @@ export default class Header extends React.Component {
     } else {
       return (
         <header className={className}>
-          {this.renderPresence()}
           {this.renderProgress()}
           {this.renderHome()}
-
+          {this.renderPresence()}
           <VideoPublishBar
             className="flex-grow"
             video={this.props.video}

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import VideoSearch from './VideoSearch/VideoSearch';
 import VideoPublishBar from './VideoPublishBar/VideoPublishBar';
+import VideoPublishState from './VideoPublishState/VideoPublishState';
 import AdvancedActions from './Videos/AdvancedActions';
 import ComposerPageCreate from './Videos/ComposerPageCreate';
 import Icon from './Icon';
@@ -178,7 +179,9 @@ export default class Header extends React.Component {
         <header className={className}>
           {this.renderProgress()}
           {this.renderHome()}
+          <VideoPublishState video={this.props.publishedVideo} />
           {this.renderPresence()}
+          <div className="flex-spacer" />
           <VideoPublishBar
             className="flex-grow"
             video={this.props.video}

--- a/public/video-ui/src/components/Presence.js
+++ b/public/video-ui/src/components/Presence.js
@@ -40,6 +40,8 @@ export class Presence extends React.Component {
   }
 
   startPresence = (atom, { domain, firstName, lastName, email }) => {
+    const subscriptionId = `media-${atom}`;
+
     const endpoint = `wss://${domain}/socket`;
 
     const client = window.presenceClient(endpoint, {
@@ -51,16 +53,18 @@ export class Presence extends React.Component {
     client.startConnection();
 
     client.on('connection.open', () => {
-      client.subscribe(`media-${atom}`);
-      client.enter(`media-${atom}`, 'document');
+      client.subscribe(subscriptionId);
+      client.enter(subscriptionId, 'document');
     });
 
     client.on('visitor-list-updated', data => {
-      this.setState(
-        Object.assign({}, this.state, {
-          visitors: data.currentState
-        })
-      );
+      if (data.subscriptionId === subscriptionId) {
+        this.setState(
+          Object.assign({}, this.state, {
+            visitors: data.currentState
+          })
+        );
+      }
     });
 
     this.setState(

--- a/public/video-ui/src/components/Presence.js
+++ b/public/video-ui/src/components/Presence.js
@@ -1,7 +1,10 @@
 import React from 'react';
 
 export class Presence extends React.Component {
-  state = null;
+  state = {
+    client: null,
+    visitors: []
+  };
 
   componentDidMount() {
     if (this.props.video.id) {
@@ -14,9 +17,14 @@ export class Presence extends React.Component {
     const previous = prevProps.video.id;
 
     if (current !== previous) {
-      if (this.state) {
-        this.state.closeConnection();
-        this.setState(null);
+      if (this.state.client) {
+        this.state.client.closeConnection();
+        this.setState(
+          Object.assign({}, this.state, {
+            client: null,
+            visitors: []
+          })
+        );
       }
 
       if (current) {
@@ -26,8 +34,8 @@ export class Presence extends React.Component {
   }
 
   componentWillUnmount() {
-    if (this.state) {
-      this.state.closeConnection();
+    if (this.state.client) {
+      this.state.client.closeConnection();
     }
   }
 
@@ -47,11 +55,42 @@ export class Presence extends React.Component {
       client.enter(`media-${atom}`, 'document');
     });
 
-    this.setState(client);
+    client.on('visitor-list-updated', data => {
+      this.setState(
+        Object.assign({}, this.state, {
+          visitors: data.currentState
+        })
+      );
+    });
+
+    this.setState(
+      Object.assign({}, this.state, {
+        client: client
+      })
+    );
   };
 
   render() {
     // No indicator in the UI yet, just reporting back for use in Workflow
-    return false;
+    const visitorsInThisArea = this.state.visitors.filter(
+      state => state.location === 'document'
+    );
+
+    return (
+      <ul className="presence-list">
+        {visitorsInThisArea.map(visitor => {
+          const id = visitor.clientId.connId;
+          const { firstName, lastName } = visitor.clientId.person;
+          const initials = `${firstName.slice(0, 1)}${lastName.slice(0, 1)}`;
+          const fullName = `${firstName} ${lastName}`;
+
+          return (
+            <li key={id} className="presence-list__user" title={fullName}>
+              {initials}
+            </li>
+          );
+        })}
+      </ul>
+    );
   }
 }

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { saveStateVals } from '../../constants/saveStateVals';
-import { isVideoPublished, hasVideoExpired } from '../../util/isVideoPublished';
+import { isVideoPublished } from '../../util/isVideoPublished';
 import { hasUnpublishedChanges } from '../../util/hasUnpublishedChanges';
 import { getVideoBlock } from '../../util/getVideoBlock';
 import { getStore } from '../../util/storeAccessor';
@@ -78,24 +78,13 @@ export default class VideoPublishBar extends React.Component {
     );
   }
 
-  renderVideoPublishedInfo() {
-    if (hasVideoExpired(this.props.publishedVideo)) {
-      return <div className="publish__label label__expired">Expired</div>;
-    } else if (isVideoPublished(this.props.publishedVideo)) {
-      return <div className="publish__label label__live">Live</div>;
-    }
-    return <div className="publish__label label__draft">Draft</div>;
-  }
-
   render() {
     if (!this.props.video) {
       return false;
     }
 
     return (
-      <div className="flex-container flex-grow publish-bar">
-        {this.renderVideoPublishedInfo()}
-        <div className="flex-spacer" />
+      <div className="flex-container publish-bar">
         {this.renderPublishButton()}
       </div>
     );

--- a/public/video-ui/src/components/VideoPublishState/VideoPublishState.js
+++ b/public/video-ui/src/components/VideoPublishState/VideoPublishState.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { isVideoPublished, hasVideoExpired } from '../../util/isVideoPublished';
+
+export default class VideoPublishState extends React.Component {
+  static propTypes = {
+    video: PropTypes.object.isRequired
+  };
+
+  render() {
+    if (hasVideoExpired(this.props.video)) {
+      return <div className="publish__label label__expired">Expired</div>;
+    }
+
+    if (isVideoPublished(this.props.video)) {
+      return <div className="publish__label label__live">Live</div>;
+    }
+
+    return <div className="publish__label label__draft">Draft</div>;
+  }
+}

--- a/public/video-ui/styles/components/_presence.scss
+++ b/public/video-ui/styles/components/_presence.scss
@@ -1,0 +1,18 @@
+.presence-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  align-content: space-between;
+
+  &__user {
+    display: block;
+    padding: 7px;
+    border-radius: 50%;
+    color: $color600Grey;
+    background-color: $cWhite;
+
+    &:not(:last-child) {
+      margin-right: 7px;
+    }
+  }
+}

--- a/public/video-ui/styles/main.scss
+++ b/public/video-ui/styles/main.scss
@@ -45,4 +45,5 @@
   'components/expiry-date',
   'components/pluto-list',
   'components/advanced',
-  'components/scribe';
+  'components/scribe',
+  'components/presence';


### PR DESCRIPTION
The positioning isn't consistent across all pages, but I think there's benefit in shipping this now.

Also refactors out the publish state element into its own component to position the indicators in the right place on the video page.

# Search page
Nothing, obviously.
![image](https://user-images.githubusercontent.com/836140/30647790-4ae9cd12-9e14-11e7-8b2b-d6eb9757a6c8.png)

# Video page
![image](https://user-images.githubusercontent.com/836140/30647807-59900fe8-9e14-11e7-8285-07685756e1af.png)

# Upload page
![image](https://user-images.githubusercontent.com/836140/30647827-6972437c-9e14-11e7-9aa1-2320205781fa.png)

# Audit page
![image](https://user-images.githubusercontent.com/836140/30647846-778513fe-9e14-11e7-9d9f-7eb01676cc2c.png)

# Help page
![image](https://user-images.githubusercontent.com/836140/30647884-8f338b5c-9e14-11e7-82c0-fbdfb337cde1.png)

