### PR TITLE
fix AU production office

### DIFF
--- a/public/video-ui/src/components/Workflow/Workflow.js
+++ b/public/video-ui/src/components/Workflow/Workflow.js
@@ -68,6 +68,8 @@ class Workflow extends React.Component {
   }
 
   renderStatusInWorkflow() {
+    const {title, prodOffice, section, status, scheduledLaunchDate } = this.props.workflow.status;
+
     return (
       <table>
         <thead>
@@ -77,18 +79,18 @@ class Workflow extends React.Component {
             <th>Section</th>
             <th>Status</th>
             <th>Scheduled Launch Date</th>
-            <th></th>
+            <th/>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>{this.props.workflow.status.title}</td>
-            <td>{this.props.workflow.status.prodOffice}</td>
-            <td>{this.props.workflow.status.section}</td>
-            <td>{this.props.workflow.status.status}</td>
-            <td>{this.props.workflow.status.scheduledLaunchDate
-              ? moment(this.props.workflow.status.scheduledLaunchDate).format("DD MMM YYYY HH:mm")
-              : 'n/a'}</td>
+            <td>{title}</td>
+            <td>
+              <span className={`production-office production-office--${prodOffice}`}>{prodOffice}</span>
+            </td>
+            <td>{section}</td>
+            <td>{status}</td>
+            <td>{scheduledLaunchDate ? moment(scheduledLaunchDate).format("DD MMM YYYY HH:mm") : 'n/a'}</td>
             <td>
               <a target="_blank"
                  rel="noopener noreferrer"

--- a/public/video-ui/src/util/getProductionOffice.js
+++ b/public/video-ui/src/util/getProductionOffice.js
@@ -24,7 +24,7 @@ function getTimezoneOffset() {
 
 export default function getProductionOffice() {
   const timezoneProductionOfficeMap = {
-    SYD: 'AUS',
+    SYD: 'AU',
     SFO: 'US',
     NYC: 'US',
     LON: 'UK'

--- a/public/video-ui/styles/abstracts/_variables.scss
+++ b/public/video-ui/styles/abstracts/_variables.scss
@@ -49,6 +49,7 @@ $cRedB5: #b51800;
 $cRedE3: #e31f26;
 $cRedFF: #ff7272;
 $cYellow: #ffbc01;
+$cGreen00: #008751;
 $cGreen1c: #1c6326;
 $cGreen33: #33a22b;
 $cGreen32: #325f37;

--- a/public/video-ui/styles/components/_workflow.scss
+++ b/public/video-ui/styles/components/_workflow.scss
@@ -1,0 +1,21 @@
+.production-office {
+  padding: 5px;
+  font-weight: bold;
+
+  &--UK {
+    background-color: $cBlue00;
+    color: $cWhite;
+  }
+
+  &--US {
+    background-color: $cRedB5;
+    color: $cWhite;
+  }
+
+  // see #613 for why AUS is here 😳
+  &--AU,
+  &--AUS {
+    background-color: $cYellow;
+    color: $cGreen00;
+  }
+}

--- a/public/video-ui/styles/main.scss
+++ b/public/video-ui/styles/main.scss
@@ -46,4 +46,5 @@
   'components/pluto-list',
   'components/advanced',
   'components/scribe',
-  'components/presence';
+  'components/presence',
+  'components/workflow';


### PR DESCRIPTION
Workflow stores Australia as AU not AUS...

Also adds some styling to the production office value, similar to Workflow. I don't think its worth correcting past atoms in Workflow, so the css looks a little horrible with the `&--AU, &--AUS` rule...

![image](https://user-images.githubusercontent.com/836140/30736558-21ab89f0-9f7b-11e7-9962-a0ff1a8df050.png)
