### PR TITLE
Time out upload after 20 minutes (per chunk)

### DIFF
--- a/uploader/src/main/resources/state-machine.json
+++ b/uploader/src/main/resources/state-machine.json
@@ -17,7 +17,7 @@
         },
         {
           "Variable": "$.progress.retries",
-          "NumericGreaterThanEquals": 120,
+          "NumericGreaterThanEquals": 240,
           "Next": "FailS3Upload"
         }
       ],
@@ -29,7 +29,7 @@
     },
     "WaitForChunkInS3": {
       "Type": "Wait",
-      "Seconds": 1,
+      "Seconds": 5,
       "Next": "GetChunkFromS3"
     },
     "CheckNotSelfHosted": {


### PR DESCRIPTION
A user had some difficulty yesterday uploading a video on a crappy home internet connection. It wasn't very big but it didn't manage to upload the first 100MB chunk before the timeout at 2 minutes.

This PR bumps up the timeout per chunk to 20 minutes and only checks S3 every 5 seconds. Step Functions are charged per state transition so this keeps costs down (not that they were high anyway).