### PR TITLE
Temporarily disable Pluto sync

### DIFF
--- a/common/src/main/scala/com/gu/media/upload/PlutoUploadActions.scala
+++ b/common/src/main/scala/com/gu/media/upload/PlutoUploadActions.scala
@@ -18,15 +18,16 @@ class PlutoUploadActions(config: Settings with DynamoAccess with KinesisAccess w
         config.sendOnKinesis(config.uploadsStreamName, plutoData.s3Key, plutoData)
 
       case None =>
-        log.info(s"Sending missing Pluto ID email user=${metadata.user} atom=${plutoData.atomId}")
-
-        mailer.sendPlutoIdMissingEmail(
-          metadata.title,
-          metadata.user,
-          config.fromEmailAddress,
-          config.replyToAddresses)
-
-        plutoStore.put(plutoData)
+        // TODO MRB: re-enable this once the project selector has been fixed
+//        log.info(s"Sending missing Pluto ID email user=${metadata.user} atom=${plutoData.atomId}")
+//
+//        mailer.sendPlutoIdMissingEmail(
+//          metadata.title,
+//          metadata.user,
+//          config.fromEmailAddress,
+//          config.replyToAddresses)
+//
+//        plutoStore.put(plutoData)
     }
   }
 }

--- a/public/video-ui/src/services/UploadsApi.js
+++ b/public/video-ui/src/services/UploadsApi.js
@@ -20,7 +20,7 @@ export function createUpload(atomId, file, selfHost) {
       filename: file.name,
       size: file.size,
       selfHost: selfHost,
-      syncWithPluto: true // TODO get this from config injection
+      syncWithPluto: false // TODO MRB: re-enable this once the project selector is fixed
     }
   });
 }

--- a/public/video-ui/src/services/UploadsApi.js
+++ b/public/video-ui/src/services/UploadsApi.js
@@ -20,7 +20,7 @@ export function createUpload(atomId, file, selfHost) {
       filename: file.name,
       size: file.size,
       selfHost: selfHost,
-      syncWithPluto: false // TODO MRB: re-enable this once the project selector is fixed
+      syncWithPluto: true
     }
   });
 }


### PR DESCRIPTION
There are a number of issues with the Pluto sync flow as it stands:

- https://video.code.dev-gutools.co.uk/videos/pluto-list is hardcoded to `[1,2,3,4,5,6,7]`
- The project selector on the upload page shows all projects (gonna get massive)
- US and AU don't even use Pluto but still get emails about it

I'm disabling it until we review how to move forward with this feature.