### PR TITLE
retain link text in YT description

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -165,7 +165,7 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youtu
 
   private def removeHtmlTagsForYouTube(description: String): String = {
       val html = Jsoup.parse(description)
-      html.select("a").remove()
+      html.select("a").unwrap()
       html.text()
   }
 


### PR DESCRIPTION
Use [unwrap](https://jsoup.org/apidocs/org/jsoup/select/Elements.html#unwrap--) rather than remove to retain the anchor text tag.

This keeps the descriptions on YouTube more understandable, for example, before:

<p>A short film shot by <a href=\"http://www.heathpattersonfilm.com/\">Heath Patterson</a> captures photographer Vaughan Brookfield<p>

became:

A short film shot by captures photographer Vaughan Brookfield

whereas its more desirable for it to read:

A short film shot by Heath Patterson captures photographer Vaughan Brookfield