### PR TITLE
allow hosted to add paid-content tags

### DIFF
--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -59,9 +59,21 @@ export default class TagPicker extends React.Component {
     }
   }
 
-  fetchTags = searchText => {
+  _getTagTypes() {
+    const defaultTagTypes = [TagTypes.tone, TagTypes.series, TagTypes.keyword];
 
-     const tagTypes = this.props.tagType === TagTypes.keyword ? [TagTypes.tone, TagTypes.series, TagTypes.keyword] : [this.props.tagType];
+    switch (this.props.tagType) {
+      case TagTypes.keyword:
+        return defaultTagTypes;
+      case TagTypes.paidContent:
+        return [TagTypes.paidContent, ...defaultTagTypes];
+      default:
+        return [this.props.tagType];
+    }
+  }
+
+  fetchTags = searchText => {
+    const tagTypes = this._getTagTypes();
 
     ContentApi.getTagsByType(searchText, tagTypes)
       .then(capiResponses => {

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -65,8 +65,8 @@ export default class TagPicker extends React.Component {
     switch (this.props.tagType) {
       case TagTypes.keyword:
         return defaultTagTypes;
-      case TagTypes.paidContent:
-        return [TagTypes.paidContent, ...defaultTagTypes];
+      case TagTypes.paidContentKeywords:
+        return [TagTypes.paidContentKeywords, ...defaultTagTypes];
       default:
         return [this.props.tagType];
     }

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -120,7 +120,7 @@ class VideoData extends React.Component {
               fieldLocation="keywords"
               name="Composer Keywords"
               formRowClass="form__row__byline"
-              tagType={TagTypes.keyword}
+              tagType={isHosted ? TagTypes.paidContent : TagTypes.keyword}
               isDesired={true}
               inputPlaceholder="Search keywords (type '*' to show all)"
               customValidation={this.props.validateKeywords}

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -120,7 +120,7 @@ class VideoData extends React.Component {
               fieldLocation="keywords"
               name="Composer Keywords"
               formRowClass="form__row__byline"
-              tagType={isHosted ? TagTypes.paidContent : TagTypes.keyword}
+              tagType={isHosted ? TagTypes.paidContentKeywords : TagTypes.keyword}
               isDesired={true}
               inputPlaceholder="Search keywords (type '*' to show all)"
               customValidation={this.props.validateKeywords}

--- a/public/video-ui/src/constants/TagTypes.js
+++ b/public/video-ui/src/constants/TagTypes.js
@@ -23,7 +23,7 @@ export default class TagTypes {
     return 'tone';
   }
 
-  static get paidContent() {
+  static get paidContentKeywords() {
     return 'paid-content';
   }
 }

--- a/public/video-ui/src/constants/TagTypes.js
+++ b/public/video-ui/src/constants/TagTypes.js
@@ -22,4 +22,8 @@ export default class TagTypes {
   static get tone() {
     return 'tone';
   }
+
+  static get paidContent() {
+    return 'paid-content';
+  }
 }

--- a/public/video-ui/src/util/getTagDisplayNames.js
+++ b/public/video-ui/src/util/getTagDisplayNames.js
@@ -25,7 +25,7 @@ export default function getTagDisplayNames(tags) {
       detailedTitle = tag.webTitle + ' (series)';
     } else if (tagType === TagTypes.tone) {
       detailedTitle = tag.webTitle + ' (tone)';
-    } else if (tagType === TagTypes.paidContent) {
+    } else if (tagType === TagTypes.paidContentKeywords) {
       detailedTitle = tag.webTitle + ' (paid-content)';
     } else detailedTitle = tag.webTitle;
 

--- a/public/video-ui/src/util/getTagDisplayNames.js
+++ b/public/video-ui/src/util/getTagDisplayNames.js
@@ -25,6 +25,8 @@ export default function getTagDisplayNames(tags) {
       detailedTitle = tag.webTitle + ' (series)';
     } else if (tagType === TagTypes.tone) {
       detailedTitle = tag.webTitle + ' (tone)';
+    } else if (tagType === TagTypes.paidContent) {
+      detailedTitle = tag.webTitle + ' (paid-content)';
     } else detailedTitle = tag.webTitle;
 
     return {


### PR DESCRIPTION
if you're a hosted atom, you should be allowed to add a paid-content tag, because, well, that's what they're for 😁

the implementation feels a bit hacky...

TODO
- [x] test on CODE