### PR TITLE
add GA on legacy app

### DIFF
--- a/app/controllers/MainApp.scala
+++ b/app/controllers/MainApp.scala
@@ -21,9 +21,11 @@ class MainApp (override val stores: DataStores,
   import authActions.AuthAction
 
   def listAtoms = AuthAction { implicit req =>
+    val gaPropertyId = conf.getString("gaPropertyId")
+
     previewDataStore.listAtoms.fold(
       err => InternalServerError(err.msg),
-      atoms => Ok(displayAtomList())
+      atoms => Ok(displayAtomList(gaPropertyId))
     )
   }
 }

--- a/app/views/MediaAtom/displayAtomList.scala.html
+++ b/app/views/MediaAtom/displayAtomList.scala.html
@@ -1,3 +1,5 @@
+@(maybeGaPropertyId: Option[String])
+
 <html ng-app="mediaAtomApp">
     <head>
         <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.8/angular.min.js"></script>
@@ -14,5 +16,22 @@
     </head>
     <body>
         <div data-ng-view></div>
+
+        @defining(maybeGaPropertyId) {
+          case Some(gaPropertyId) => {
+            <!-- Global site tag (gtag.js) - Google Analytics -->
+            <script async src="https://www.googletagmanager.com/gtag/js?id=@gaPropertyId"></script>
+            <script>
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+
+              gtag('config', '@gaPropertyId');
+            </script>
+          }
+          case _ => {
+
+          }
+        }
     </body>
 </html>


### PR DESCRIPTION
this is to track usage to see if we can remove it (see https://github.com/guardian/media-atom-maker/pull/615)

We'll see traffic in GA when anyone lands on `/atoms` or `/atom/<id>`.