### PR TITLE
add isCommercial to channel api response

### DIFF
--- a/app/util/YouTube.scala
+++ b/app/util/YouTube.scala
@@ -1,6 +1,7 @@
 package util
 
 import com.gu.media.logging.Logging
+import com.gu.media.model.PrivacyStatus
 import com.gu.media.youtube._
 import com.typesafe.config.Config
 import play.api.cache.CacheApi
@@ -21,8 +22,17 @@ trait YouTube extends Logging with YouTubeAccess with YouTubeVideos with YouTube
 
   def getCommercialVideoInfo(videoId: String) = {
     getVideo(videoId, "snippet,contentDetails,status").map(video => {
+      val channelId = video.getSnippet.getChannelId
+
+      val channel = YouTubeChannel(
+        id = channelId,
+        title = video.getSnippet.getChannelTitle,
+        privacyStates = if (strictlyUnlistedChannels.contains(channelId)) Set(PrivacyStatus.Unlisted, PrivacyStatus.Private) else PrivacyStatus.all,
+        isCommercial = commercialChannels.contains(channelId)
+      )
+
       val advertisingOptions = getAdvertisingOptions(videoId)
-      YouTubeVideoCommercialInfo.build(video, advertisingOptions)
+      YouTubeVideoCommercialInfo.build(video, advertisingOptions, channel)
     })
   }
 }

--- a/app/util/YouTube.scala
+++ b/app/util/YouTube.scala
@@ -23,13 +23,8 @@ trait YouTube extends Logging with YouTubeAccess with YouTubeVideos with YouTube
   def getCommercialVideoInfo(videoId: String) = {
     getVideo(videoId, "snippet,contentDetails,status").map(video => {
       val channelId = video.getSnippet.getChannelId
-
-      val channel = YouTubeChannel(
-        id = channelId,
-        title = video.getSnippet.getChannelTitle,
-        privacyStates = if (strictlyUnlistedChannels.contains(channelId)) Set(PrivacyStatus.Unlisted, PrivacyStatus.Private) else PrivacyStatus.all,
-        isCommercial = commercialChannels.contains(channelId)
-      )
+      val channelTitle = video.getSnippet.getChannelTitle
+      val channel = YouTubeChannel.build(this, channelId, channelTitle)
 
       val advertisingOptions = getAdvertisingOptions(videoId)
       YouTubeVideoCommercialInfo.build(video, advertisingOptions, channel)

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
@@ -77,9 +77,8 @@ trait YouTubeAccess extends Settings {
         val channelId = channel.getId
 
         YouTubeChannel.build(
-          channel,
-          allowPublic = !strictlyUnlistedChannels.contains(channelId),
-          isCommercial = commercialChannels.contains(channelId)
+          this,
+          channel
         )
       })
       .sortBy(_.title)

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
@@ -73,14 +73,7 @@ trait YouTubeAccess extends Settings {
       .setOnBehalfOfContentOwner(contentOwner)
 
     request.execute().getItems.asScala.toList
-      .map(channel => {
-        val channelId = channel.getId
-
-        YouTubeChannel.build(
-          this,
-          channel
-        )
-      })
+      .map(YouTubeChannel.build(this, _))
       .sortBy(_.title)
   }
 

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
@@ -16,7 +16,8 @@ trait YouTubeAccess extends Settings {
 
   val allowedChannels: Set[String] = getStringSet("youtube.channels.allowed")
   val strictlyUnlistedChannels: Set[String] = getStringSet("youtube.channels.unlisted")
-  val allChannels: Set[String] = allowedChannels ++ strictlyUnlistedChannels
+  val commercialChannels: Set[String] = getStringSet("youtube.channels.commercial")
+  val allChannels: Set[String] = allowedChannels ++ strictlyUnlistedChannels ++ commercialChannels
 
   val trainingChannels: Set[String] = getStringSet("youtube.channels.training")
 
@@ -72,7 +73,15 @@ trait YouTubeAccess extends Settings {
       .setOnBehalfOfContentOwner(contentOwner)
 
     request.execute().getItems.asScala.toList
-      .map(c => YouTubeChannel.build(c, allowPublic = !strictlyUnlistedChannels.contains(c.getId)))
+      .map(channel => {
+        val channelId = channel.getId
+
+        YouTubeChannel.build(
+          channel,
+          allowPublic = !strictlyUnlistedChannels.contains(channelId),
+          isCommercial = commercialChannels.contains(channelId)
+        )
+      })
       .sortBy(_.title)
   }
 

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -72,12 +72,19 @@ package object youtube {
     implicit val reads: Reads[YouTubeChannel] = Json.reads[YouTubeChannel]
     implicit val writes: Writes[YouTubeChannel] = Json.writes[YouTubeChannel]
 
-    def build(channel: Channel, allowPublic: Boolean, isCommercial: Boolean): YouTubeChannel = {
+    def build(youtubeAccess: YouTubeAccess, channel: Channel): YouTubeChannel = {
+      val id = channel.getId
+      val title = channel.getSnippet.getTitle
+
+      build(youtubeAccess, id, title)
+    }
+
+    def build(youtubeAccess: YouTubeAccess, id: String, title: String): YouTubeChannel = {
       YouTubeChannel(
-        id = channel.getId,
-        title = channel.getSnippet.getTitle,
-        privacyStates = if (allowPublic) PrivacyStatus.all else Set(PrivacyStatus.Unlisted, PrivacyStatus.Private),
-        isCommercial = isCommercial
+        id = id,
+        title = title,
+        privacyStates = if (youtubeAccess.strictlyUnlistedChannels.contains(id)) Set(PrivacyStatus.Unlisted, PrivacyStatus.Private) else PrivacyStatus.all,
+        isCommercial = youtubeAccess.commercialChannels.contains(id)
       )
     }
   }


### PR DESCRIPTION
we'd want to distinguish commercial channels within the Tool for Labs support (Labs shouldn't be able to upload to Editorial channels)