### PR TITLE
filter channel list based on category

### DIFF
--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -65,8 +65,8 @@ export default class TagPicker extends React.Component {
     switch (this.props.tagType) {
       case TagTypes.keyword:
         return defaultTagTypes;
-      case TagTypes.paidContentKeywords:
-        return [TagTypes.paidContentKeywords, ...defaultTagTypes];
+      case TagTypes.commercial:
+        return [TagTypes.commercial, ...defaultTagTypes];
       default:
         return [this.props.tagType];
     }

--- a/public/video-ui/src/constants/TagTypes.js
+++ b/public/video-ui/src/constants/TagTypes.js
@@ -23,7 +23,7 @@ export default class TagTypes {
     return 'tone';
   }
 
-  static get paidContentKeywords() {
+  static get commercial() {
     return 'paid-content';
   }
 }

--- a/public/video-ui/src/constants/blankVideoData.js
+++ b/public/video-ui/src/constants/blankVideoData.js
@@ -5,7 +5,7 @@ export const blankVideoData = {
   duration: 0,
   channelId: '',
   youtubeCategoryId: '',
-  privacyStatus: 'Unlisted',
+  privacyStatus: '',
   assets: [],
   trailText: '',
   tags: [],

--- a/public/video-ui/src/constants/videoCategories.js
+++ b/public/video-ui/src/constants/videoCategories.js
@@ -9,7 +9,8 @@ const editorialCategories = [
 // title is for ui
 // see https://github.com/guardian/content-atom/blob/master/thrift/src/main/thrift/atoms/media.thrift#L22-L29
 const labsCategories = [
-  {id: 'Hosted', title: 'GLabs - Hosted by'}
+  {id: 'Hosted', title: 'GLabs - Hosted by'},
+  {id: 'Paid', title: 'GLabs - Paid for'}
 ];
 
 export const videoCategories = [

--- a/public/video-ui/src/util/getTagDisplayNames.js
+++ b/public/video-ui/src/util/getTagDisplayNames.js
@@ -20,7 +20,7 @@ export default function getTagDisplayNames(tags) {
       const appendTagTypes = [
         TagTypes.series,
         TagTypes.tone,
-        TagTypes.paidContentKeywords
+        TagTypes.commercial
       ];
 
       tagForDisplay.detailedTitle = appendTagTypes.includes(tagType)

--- a/public/video-ui/src/util/getTagDisplayNames.js
+++ b/public/video-ui/src/util/getTagDisplayNames.js
@@ -7,7 +7,6 @@ export default function getTagDisplayNames(tags) {
     }
 
     const tagType = tag.type;
-
     const tagForDisplay = {id: tag.id, webTitle: tag.webTitle};
 
     if (tagType === TagTypes.keyword) {

--- a/public/video-ui/src/util/video.js
+++ b/public/video-ui/src/util/video.js
@@ -1,0 +1,71 @@
+import { getStore } from './storeAccessor';
+import PrivacyStates from '../constants/privacyStates';
+
+export default class VideoUtils {
+  static hasAssets({ assets }) {
+    return assets.length > 0;
+  }
+
+  static getActiveAsset({ assets, activeVersion }) {
+    if (activeVersion) {
+      const active = assets.filter(_ => _.version === activeVersion);
+      return active.length === 1 ? active[0] : active;
+    }
+  }
+
+  static isYoutube(atom) {
+    // no assets, could be youtube if we wanted
+    if (!VideoUtils.hasAssets(atom)) {
+      return true;
+    }
+
+    const activeAsset = VideoUtils.getActiveAsset(atom);
+
+    // not possible to have multiple assets w/same version for youtube
+    if (Array.isArray(activeAsset)) {
+      return false;
+    }
+
+    return activeAsset.platform === 'Youtube';
+  }
+
+  static getYoutubeChannel({ channelId }) {
+    if (!channelId) {
+      return false;
+    }
+
+    const state = getStore().getState();
+    const stateChannels = state.youtube.channels;
+    return stateChannels.find(_ => _.id === channelId);
+  }
+
+  static hasYoutubeWriteAccess({ channelId }) {
+    return !!VideoUtils.getYoutubeChannel({ channelId });
+  }
+
+  static getAvailableChannels({ category }) {
+    const state = getStore().getState();
+    const stateChannels = state.youtube.channels;
+    const isCommercialType = VideoUtils.isCommercialType({ category });
+    return stateChannels.filter(_ => _.isCommercial === isCommercialType);
+  }
+
+  static getAvailablePrivacyStates({ channelId }) {
+    const channel = VideoUtils.getYoutubeChannel({ channelId });
+    return channel ? channel.privacyStates : PrivacyStates.defaultStates;
+  }
+
+  static isCommercialType({ category }) {
+    return ['Hosted', 'Paid'].includes(category);
+  }
+
+  static isEligibleForAds(atom) {
+    const minDurationForAds = getStore().getState().config.minDurationForAds;
+
+    if (VideoUtils.isCommercialType(atom)) {
+      return false;
+    }
+
+    return atom.duration > 0 && atom.duration < minDurationForAds;
+  }
+}


### PR DESCRIPTION
Now that we have `isCommercial` in the channel api, the `Hosted` and `Paid` categories should only be able to upload to commercial channels.

Also:
- refactors useful functions to `VideoUtils`
- adds `GLabs - Paid for` category to UI (the thrift model already has this as a value in the category enum)

![labs](https://user-images.githubusercontent.com/836140/31656246-ee0989a6-b322-11e7-9f74-a608f60de84c.gif)

