### PR TITLE
refactor tag display name function

### DIFF
--- a/public/video-ui/src/util/getTagDisplayNames.js
+++ b/public/video-ui/src/util/getTagDisplayNames.js
@@ -7,32 +7,27 @@ export default function getTagDisplayNames(tags) {
     }
 
     const tagType = tag.type;
-    let detailedTitle;
+
+    const tagForDisplay = {id: tag.id, webTitle: tag.webTitle};
 
     if (tagType === TagTypes.keyword) {
       //Some webtitles on keyword tags are too unspecific and we need to add
       //the section name to them to know what tags they are referring to
+      tagForDisplay.detailedTitle = tag.webTitle !== tag.sectionName
+        ? `${tag.webTitle} (${tag.sectionName})`
+        : tag.webTitle;
+    } else {
+      const appendTagTypes = [
+        TagTypes.series,
+        TagTypes.tone,
+        TagTypes.paidContentKeywords
+      ];
 
-      if (
-        tag.webTitle !== tag.sectionName &&
-        tag.webTitle.split(' ').length <= 2
-      ) {
-        detailedTitle = tag.webTitle + ' (' + tag.sectionName + ')';
-      } else {
-        detailedTitle = tag.webTitle;
-      }
-    } else if (tagType === TagTypes.series) {
-      detailedTitle = tag.webTitle + ' (series)';
-    } else if (tagType === TagTypes.tone) {
-      detailedTitle = tag.webTitle + ' (tone)';
-    } else if (tagType === TagTypes.paidContentKeywords) {
-      detailedTitle = tag.webTitle + ' (paid-content)';
-    } else detailedTitle = tag.webTitle;
+      tagForDisplay.detailedTitle = appendTagTypes.includes(tagType)
+        ? `${tag.webTitle} (${tagType})`
+        : tag.webTitle;
+    }
 
-    return {
-      id: tag.id,
-      webTitle: tag.webTitle,
-      detailedTitle: detailedTitle
-    };
+    return tagForDisplay;
   });
 }


### PR DESCRIPTION
- reduces the number of branches
- always append sectionName to tag regardless how may spaces there are

should help avoid [this scenario](https://www.theguardian.com/books/video/2017/oct/17/its-just-marmite-taste-testing-the-new-vegemite-blend-17-video) in the future where a video has been launched with the `Books` `food and drink` tag and thus has `books` in its url

![image](https://user-images.githubusercontent.com/836140/31663564-71e23a4a-b33a-11e7-85ff-02ec172b35ad.png)