### PR TITLE
handle case where there are assets but none are active

### DIFF
--- a/public/video-ui/src/util/video.js
+++ b/public/video-ui/src/util/video.js
@@ -26,6 +26,11 @@ export default class VideoUtils {
       return false;
     }
 
+    // no active assets, could be youtube if we wanted
+    if (!activeAsset) {
+      return true;
+    }
+    
     return activeAsset.platform === 'Youtube';
   }
 


### PR DESCRIPTION
atom `ecef4572-d12a-46a5-86b2-13fb928b9dcc` is failing in PROD because of this