### PR TITLE
Allow block ads if greater than YouTube min

### DIFF
--- a/public/video-ui/src/util/video.js
+++ b/public/video-ui/src/util/video.js
@@ -71,6 +71,6 @@ export default class VideoUtils {
       return false;
     }
 
-    return atom.duration > 0 && atom.duration < minDurationForAds;
+    return atom.duration > 0 && atom.duration > minDurationForAds;
   }
 }


### PR DESCRIPTION
Ronseal. Boolean typo meaning block ads was disabled for atoms where it should've been allowed