### PR TITLE
Remove 500 alarm

### DIFF
--- a/cloudformation/media-atom-maker.yaml
+++ b/cloudformation/media-atom-maker.yaml
@@ -763,23 +763,6 @@ Resources:
       Subscription:
       - Endpoint: !Ref 'AlertWebhook'
         Protocol: https
-  MediaAtomMaker5XXAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      ActionsEnabled: !Ref 'AlertActive'
-      AlarmDescription: 500 Error reported from media-atom-maker
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: '10'
-      Namespace: AWS/ELB
-      MetricName: HTTPCode_Backend_5XX
-      Dimensions:
-      - Name: LoadBalancerName
-        Value: !Ref 'MediaAtomMakerLoadBalancer'
-      Period: '300'
-      EvaluationPeriods: '1'
-      Statistic: Sum
-      AlarmActions:
-      - !Ref 'AlertTopic'
   MediaAtomMakerLatency:
     Type: AWS::CloudWatch::Alarm
     Properties:


### PR DESCRIPTION
The 5XX alarm goes off all the time due to Google login 500s not directly caused by the app. I've not seen any genuine prod bugs be caught by this so lets turn it off.