### PR TITLE
Publish button

### DIFF
--- a/public/video-ui/src/constants/imageFields.js
+++ b/public/video-ui/src/constants/imageFields.js
@@ -1,0 +1,1 @@
+export const imageFields = ['posterImage', 'trailImage'];

--- a/public/video-ui/src/reducers/publishedVideoReducer.js
+++ b/public/video-ui/src/reducers/publishedVideoReducer.js
@@ -1,10 +1,16 @@
+import { blankVideoData } from '../constants/blankVideoData';
+
 export default function video(state = null, action) {
   switch (action.type) {
     case 'PUBLISHED_VIDEO_GET_RECEIVE':
-      return action.publishedVideo || false;
+      return action.publishedVideo
+        ? Object.assign({}, blankVideoData, action.publishedVideo)
+        : false;
 
     case 'VIDEO_PUBLISH_RECEIVE':
-      return action.publishedVideo || false;
+      return action.publishedVideo
+        ? Object.assign({}, blankVideoData, action.publishedVideo)
+        : false;
 
     default:
       return state;

--- a/public/video-ui/src/util/hasUnpublishedChanges.js
+++ b/public/video-ui/src/util/hasUnpublishedChanges.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { appUpdatedFields } from '../constants/appUpdatedFields';
+import { imageFields } from '../constants/imageFields';
 
 export function hasUnpublishedChanges(
   previewVideo,
@@ -14,7 +15,11 @@ export function hasUnpublishedChanges(
     return true;
   }
 
-  const allFields = editableFields.concat(appUpdatedFields);
+  const allFields = [
+    ...editableFields,
+    ...appUpdatedFields,
+    ...imageFields
+  ];
 
   return !allFields.every(key => {
     return _.isEqual(previewVideo[key], publishedVideo[key]);


### PR DESCRIPTION
- Fix checks to see if video has unpublished changes 
- Adding poster and trail images to these checks is annoying. The function finds out what the other fields that need checking are by looking at validated form fields on a page so that we don't have to hard code new fields to a list every time we add them but the image fields are not part of a form so they need adding manually. 