### PR TITLE
don't count spaces

### DIFF
--- a/public/video-ui/src/util/getYouTubeTagCharCount.js
+++ b/public/video-ui/src/util/getYouTubeTagCharCount.js
@@ -1,6 +1,20 @@
 export function getYouTubeTagCharCount(tags) {
   if (Array.isArray(tags)) {
-    return tags.reduce((charCount, keyword) => charCount += keyword.length, 0);
+    const charCount = tags.reduce((charCount, keyword) => {
+
+      //If there is a space in the keyword, youtube adds quotation marks
+      //around the keyword and counts these as spaces
+      if (/\s/g.test(keyword)) {
+        charCount += 2;
+      }
+      return charCount += keyword.length;
+    }, 0);
+
+    //Count commas added between keywords
+    if (tags.length > 0) {
+      return charCount + tags.length - 1;
+    }
+    return charCount;
   }
   return 0;
 }


### PR DESCRIPTION
Adam informs me that youtube doesn't count spaces in keywords as characters - this pr strips those from the count.