### PR TITLE
fix styling

### DIFF
--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -8,7 +8,7 @@
 
 .form__section {
   padding: 20px;
-  min-width: 33%;
+  width: 50%;
 }
 
 .form__row {


### PR DESCRIPTION
we only have 2 columns in VideoData, so give them 50% width

# Before 🤢 
![image](https://user-images.githubusercontent.com/836140/31953511-37dfca6e-b8db-11e7-9c79-e569f97c28d6.png)


# After 🎉 
![image](https://user-images.githubusercontent.com/836140/31953493-2e32019e-b8db-11e7-8908-92ec90aade6a.png)
