### PR TITLE
compare apples to apples

### DIFF
--- a/public/video-ui/src/components/VideoUpload/VideoTrail.js
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.js
@@ -57,7 +57,7 @@ export default class VideoTrail extends React.Component {
       <Asset
         key={upload.id}
         upload={upload}
-        active={upload.id === this.props.activeVersion}
+        active={parseInt(upload.id) === this.props.activeVersion}
         selectAsset={() => this.props.selectAsset(Number(upload.id))}
       />
     ));


### PR DESCRIPTION
upload.id is a string...

we changed from `==` to `===` [recently](https://github.com/guardian/media-atom-maker/pull/640/files#diff-e7f07317cc9574be7a20ed5d64c64a9fR60)...