### PR TITLE
Remember upload metadata even if state machine changed

### DIFF
--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -90,7 +90,7 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
   }
 
   private def getPart(id: String, key: String): Option[UploadPart] = for {
-    (_, upload) <- stepFunctions.getById(id)
+    upload <- stepFunctions.getById(id)
     part <- upload.parts.find(_.key == key)
   } yield part
 

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import _root_.model.{ClientAsset, ClientAssetMetadata, ClientAssetProcessing, MediaAtom}
+import _root_.model.{ClientAsset, ClientAssetProcessing, MediaAtom}
 import com.amazonaws.services.stepfunctions.model.{ExecutionAlreadyExistsException, ExecutionListItem}
 import com.gu.media.MediaAtomMakerPermissionsProvider
 import com.gu.media.logging.Logging
@@ -12,8 +12,8 @@ import com.gu.pandahmac.HMACAuthActions
 import data.{DataStores, UnpackedDataStores}
 import org.cvogt.play.json.Jsonx
 import play.api.libs.json.{Format, Json}
+import util._
 import util.atom.MediaAtomImplicits
-import util.{AWSConfig, CredentialsGenerator, StepFunctions, UploadBuilder}
 
 import scala.annotation.tailrec
 
@@ -26,10 +26,12 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
   import authActions.APIAuthAction
 
   private val credsGenerator = new CredentialsGenerator(awsConfig)
+  private val uploadDecorator = new UploadDecorator(awsConfig, stepFunctions)
 
   def list(atomId: String) = APIAuthAction { req =>
     val atom = MediaAtom.fromThrift(getPreviewAtom(atomId))
-    val assets = ClientAsset.fromAssets(atom.assets).map(addYouTubeStatus).map(addMetadata(atom.id, _))
+    val withStatus = ClientAsset.fromAssets(atom.assets).map(addYouTubeStatus)
+    val assets = withStatus.map { asset => uploadDecorator.addMetadata(atom.id, asset) }
 
     val jobs = stepFunctions.getJobs(atomId)
     val uploads = jobs.flatMap(getRunning(assets, _))
@@ -85,24 +87,6 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
 
     case _ =>
       video
-  }
-
-  private def addMetadata(atomId: String, video: ClientAsset): ClientAsset = {
-    val id = s"$atomId-${video.id}"
-
-    stepFunctions.getById(id) match {
-      case Some((startTimestamp, upload)) =>
-        video.copy(metadata = Some(
-          ClientAssetMetadata(
-            upload.metadata.originalFilename,
-            startTimestamp,
-            upload.metadata.user
-          )
-        ))
-
-      case None =>
-        video
-    }
   }
 
   private def getPart(id: String, key: String): Option[UploadPart] = for {

--- a/app/model/ClientAsset.scala
+++ b/app/model/ClientAsset.scala
@@ -10,7 +10,7 @@ import play.api.libs.json.Format
 
 case class ClientAsset(id: String, asset: Option[VideoAsset] = None, processing: Option[ClientAssetProcessing] = None, metadata: Option[ClientAssetMetadata] = None)
 case class ClientAssetProcessing(status: String, failed: Boolean, current: Option[Long], total: Option[Long])
-case class ClientAssetMetadata(originalFilename: Option[String], startTimestamp: Long, user: String)
+case class ClientAssetMetadata(originalFilename: Option[String], startTimestamp: Option[Long], user: String)
 
 object ClientAsset {
   implicit val format: Format[ClientAsset] = Jsonx.formatCaseClass[ClientAsset]
@@ -34,7 +34,7 @@ object ClientAsset {
 
     base.copy(metadata = Some(ClientAssetMetadata(
       originalFilename = upload.metadata.originalFilename,
-      startTimestamp = startTimestamp,
+      startTimestamp = Some(startTimestamp),
       user = upload.metadata.user
     )))
   }
@@ -80,7 +80,6 @@ object ClientAsset {
         )
 
       case None =>
-        val fullyUploaded = upload.progress.fullyUploaded
         val current = upload.progress.chunksInYouTube
         val total = upload.parts.length
 

--- a/app/util/UploadBuilder.scala
+++ b/app/util/UploadBuilder.scala
@@ -1,5 +1,7 @@
 package util
 
+import java.time.Instant
+
 import com.gu.media.aws.{AwsAccess, UploadAccess}
 import com.gu.media.model.{SelfHostedAsset, VideoSource}
 import com.gu.media.upload.{CompleteUploadKey, TranscoderOutputKey, UploadPartKey}
@@ -31,7 +33,8 @@ object UploadBuilder {
       runtime = getRuntimeMetadata(request.selfHost, atom.channelId),
       asset = getAsset(request.selfHost, atom.title, id),
       originalFilename = Some(request.filename),
-      version = Some(version)
+      version = Some(version),
+      startTimestamp = Some(Instant.now().getEpochSecond)
     )
 
     val progress = UploadProgress(

--- a/app/util/UploadBuilder.scala
+++ b/app/util/UploadBuilder.scala
@@ -34,7 +34,7 @@ object UploadBuilder {
       asset = getAsset(request.selfHost, atom.title, id),
       originalFilename = Some(request.filename),
       version = Some(version),
-      startTimestamp = Some(Instant.now().getEpochSecond)
+      startTimestamp = Some(Instant.now().toEpochMilli)
     )
 
     val progress = UploadProgress(

--- a/app/util/UploadDecorator.scala
+++ b/app/util/UploadDecorator.scala
@@ -1,0 +1,39 @@
+package util
+
+import com.gu.media.aws.{DynamoAccess, UploadAccess}
+import com.gu.media.upload.model.Upload
+import com.gu.scanamo.{Scanamo, Table}
+import com.gu.scanamo.syntax._
+import model.{ClientAsset, ClientAssetMetadata}
+
+class UploadDecorator(aws: DynamoAccess with UploadAccess, stepFunctions: StepFunctions) {
+  private val table = Table[Upload](aws.cacheTableName)
+
+  def addMetadata(atomId: String, video: ClientAsset): ClientAsset = {
+    val id = s"$atomId-${video.id}"
+
+    getUpload(id) match {
+      case Some((startTimestamp, upload)) =>
+        video.copy(metadata = Some(
+          ClientAssetMetadata(
+            upload.metadata.originalFilename,
+            startTimestamp,
+            upload.metadata.user
+          )
+        ))
+
+      case None =>
+        video
+    }
+  }
+
+  private def getUpload(id: String): Option[(Long, Upload)] = {
+    // TODO MRB: startTimestamp
+    stepFunctions.getById(id) orElse {
+      val op = table.get('id -> id)
+      val result = Scanamo.exec(aws.dynamoDB)(op)
+
+      result.flatMap(_.right.toOption)
+    }.map((0, _))
+  }
+}

--- a/app/util/UploadDecorator.scala
+++ b/app/util/UploadDecorator.scala
@@ -17,7 +17,7 @@ class UploadDecorator(aws: DynamoAccess with UploadAccess, stepFunctions: StepFu
         video.copy(metadata = Some(
           ClientAssetMetadata(
             upload.metadata.originalFilename,
-            upload.metadata.startTimestamp.getOrElse(0),
+            upload.metadata.startTimestamp,
             upload.metadata.user
           )
         ))

--- a/build.sbt
+++ b/build.sbt
@@ -90,6 +90,9 @@ lazy val uploader = (project in file("uploader"))
       ),
       "AddAssetToAtom" -> LambdaConfig(
         description = "Adds the resulting asset to the atom"
+      ),
+      "AddUploadDataToCache" -> LambdaConfig(
+        description = "Adds the upload information to a Dynamo table so it is preserved even if the pipeline changes"
       )
     ),
 

--- a/cloudformation/media-atom-maker.yaml
+++ b/cloudformation/media-atom-maker.yaml
@@ -728,6 +728,9 @@ Resources:
           Effect: Allow
           Resource: !Join ['', ['arn:aws:dynamodb:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId',
               ':table/', !Ref 'PlutoProjectDynamoTable']]
+        - Action: dynamodb:*
+          Effect: Allow
+          Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/media-atom-pipeline-cache-${Stage}"
       Roles:
       - !Ref 'DistributionRole'
   PanDomainPolicy:

--- a/common/src/main/scala/com/gu/media/aws/UploadAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/UploadAccess.scala
@@ -15,6 +15,8 @@ trait UploadAccess { this: Settings with AwsAccess =>
   val pipelineName: String = s"VideoPipeline$stage"
   lazy val pipelineArn: String = getPipelineArn()
 
+  val cacheTableName: String = s"$app-cache-$stage"
+
   lazy val uploadSTSClient = createUploadSTSClient()
 
   lazy val stepFunctionsClient = region.createClient(

--- a/common/src/main/scala/com/gu/media/aws/UploadAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/UploadAccess.scala
@@ -15,7 +15,7 @@ trait UploadAccess { this: Settings with AwsAccess =>
   val pipelineName: String = s"VideoPipeline$stage"
   lazy val pipelineArn: String = getPipelineArn()
 
-  val cacheTableName: String = s"$app-cache-$stage"
+  val cacheTableName: String = s"media-atom-pipeline-cache-$stage"
 
   lazy val uploadSTSClient = createUploadSTSClient()
 

--- a/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
@@ -14,7 +14,8 @@ case class UploadMetadata(
   version: Option[Long] = None,
   selfHost: Boolean = false,
   asset: Option[VideoAsset] = None,
-  originalFilename: Option[String] = None
+  originalFilename: Option[String] = None,
+  startTimestamp: Option[Long] = None // unix timestamp
 )
 
 case class PlutoSyncMetadata (

--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -53,5 +53,6 @@ deployments:
         - "media-atom-pipeline-SendToTranscoder-"
         - "media-atom-pipeline-GetTranscodingProgress-"
         - "media-atom-pipeline-AddAssetToAtom-"
+        - "media-atom-pipeline-AddUploadDataToCache-"
     dependencies:
       - media-atom-pipeline-cloudformation

--- a/uploader/src/main/resources/cfn-template.yaml
+++ b/uploader/src/main/resources/cfn-template.yaml
@@ -87,6 +87,7 @@ Resources:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${MediaAtomTable}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${AuditTable}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ManualPlutoTable}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-cache-${Stage}"
               - Effect: "Allow"
                 Action: ["elastictranscoder:CreateJob", "elastictranscoder:ReadJob"]
                 Resource: "arn:aws:elastictranscoder:*"
@@ -106,6 +107,7 @@ Resources:
                   - kinesis:PutRecords
                 Resource:
                   - !Sub "arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${PlutoSendbackStreamName}"
+
   ContentAtomCrossAccountPolicyCODE:
     Type: AWS::IAM::Policy
     Condition: CreateCodeResources
@@ -173,6 +175,23 @@ Resources:
   {{GetTranscodingProgress}}
 
   {{AddAssetToAtom}}
+
+  {{AddUploadDataToCache}}
+
+  # Remembers completed uploads since the data is deleted if the pipeline definition is updated
+  VideoPipelineCache:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      TableName: !Sub "${App}-cache-${Stage}"
+      AttributeDefinitions:
+      - AttributeName: id
+        AttributeType: S
+      KeySchema:
+      - AttributeName: id
+        KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: '5'
+        WriteCapacityUnits: '5'
 
   VideoPipelinePROD:
     Type: "AWS::StepFunctions::StateMachine"

--- a/uploader/src/main/resources/lambda-template.yaml
+++ b/uploader/src/main/resources/lambda-template.yaml
@@ -13,7 +13,7 @@
       Variables:
         REGION: !Ref AWS::Region
         STACK: !Ref Stack
-        APP: "media-atom-uploader"
+        APP: !Ref App
         STAGE: !Ref Stage
         CONFIG_BUCKET: !Ref ConfigBucket
         CONFIG_KEY: !Sub

--- a/uploader/src/main/resources/state-machine.json
+++ b/uploader/src/main/resources/state-machine.json
@@ -1,7 +1,12 @@
 {
   "Comment": "A pipeline for uploading video to YouTube or an S3 bucket",
-  "StartAt": "GetChunkFromS3",
+  "StartAt": "AddInitialUploadDataToCache",
   "States": {
+    "AddInitialUploadDataToCache": {
+      "Type": "Task",
+      "Resource": "${AddUploadDataToCache.Arn}",
+      "Next": "GetChunkFromS3"
+    },
     "GetChunkFromS3": {
       "Type": "Task",
       "Resource": "${GetChunkFromS3.Arn}",
@@ -110,7 +115,7 @@
           "Next": "SendToTranscoder"
         }
       ],
-      "Default": "AddUploadDataToCache"
+      "Default": "AddCompleteUploadDataToCache"
     },
     "SendToTranscoder": {
       "Type": "Task",
@@ -141,9 +146,9 @@
     "AddSelfHostedAssetToAtom": {
       "Type": "Task",
       "Resource": "${AddAssetToAtom.Arn}",
-      "Next": "AddUploadDataToCache"
+      "Next": "AddCompleteUploadDataToCache"
     },
-    "AddUploadDataToCache": {
+    "AddCompleteUploadDataToCache": {
       "Type": "Task",
       "Resource": "${AddUploadDataToCache.Arn}",
       "Next": "Complete"

--- a/uploader/src/main/resources/state-machine.json
+++ b/uploader/src/main/resources/state-machine.json
@@ -110,7 +110,7 @@
           "Next": "SendToTranscoder"
         }
       ],
-      "Default": "Complete"
+      "Default": "AddUploadDataToCache"
     },
     "SendToTranscoder": {
       "Type": "Task",
@@ -141,6 +141,11 @@
     "AddSelfHostedAssetToAtom": {
       "Type": "Task",
       "Resource": "${AddAssetToAtom.Arn}",
+      "Next": "AddUploadDataToCache"
+    },
+    "AddUploadDataToCache": {
+      "Type": "Task",
+      "Resource": "${AddUploadDataToCache.Arn}",
       "Next": "Complete"
     },
     "Complete": {

--- a/uploader/src/main/scala/com/gu/media/upload/AddUploadDataToCache.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/AddUploadDataToCache.scala
@@ -1,0 +1,15 @@
+package com.gu.media.upload
+
+import com.gu.media.aws.{DynamoAccess, UploadAccess}
+import com.gu.media.lambda.LambdaWithParams
+import com.gu.media.upload.model.Upload
+import com.gu.scanamo.{Scanamo, Table}
+
+class AddUploadDataToCache extends LambdaWithParams[Upload, Upload] with DynamoAccess with UploadAccess {
+  private val table = Table[Upload](this.cacheTableName)
+
+  override def handle(input: Upload) = {
+    Scanamo.exec(this.dynamoDB)(table.put(input))
+    input
+  }
+}


### PR DESCRIPTION
tl;dr - we can now change the upload pipeline without losing metadata (user and filename) about each upload.

The Cloud Formation support for Step Functions will delete the old state machine rather than modify it. We rely on this `Upload` data to show the user and filename for each upload in the assets page.

This PR adds a dynamo table to cache the `Upload` data. It is written to at the start and end of each run of the state machine. The upload controller will then look in the cache first **for metadata only**. This does not affect looking up the progress of an upload which is still read from the state machine.

To support this, I've added  `startTimestamp` to `Upload`. This was originally read directly from the state machine execution and is backfilled from there if not present.

TODO:
- [x] ~save executions from CODE~
- [x] deploy CFN to CODE
- [x] ~upload executions to new cache table in CODE~
- [x] test in CODE
- [x] save executions from PROD
- [ ] deploy pipeline CFN to PROD
- [ ] deploy app CFN to PROD
- [ ] merge and deploy to PROD
- [ ] upload executions to new cache table in PROD