### PR TITLE
allow blocking ads on create form

### DIFF
--- a/public/video-ui/src/util/video.js
+++ b/public/video-ui/src/util/video.js
@@ -67,12 +67,15 @@ export default class VideoUtils {
   }
 
   static isEligibleForAds(atom) {
-    const minDurationForAds = getStore().getState().config.minDurationForAds;
-
     if (VideoUtils.isCommercialType(atom)) {
       return false;
     }
 
+    if (!VideoUtils.hasAssets(atom)) {
+      return true;
+    }
+
+    const minDurationForAds = getStore().getState().config.minDurationForAds;
     return atom.duration > 0 && atom.duration > minDurationForAds;
   }
 


### PR DESCRIPTION
Request from James C.

The current workflow is:
- Create atom
- Block ads field is disabled
- Upload video
- Block ads field becomes enabled

A faster process is:
- Block ads field is enabled in the creation form from the start