### PR TITLE
send a payload to credentials endpoint

### DIFF
--- a/common/src/main/scala/com/gu/media/upload/model/UploadCredentials.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadCredentials.scala
@@ -8,3 +8,12 @@ case class UploadCredentials(temporaryAccessId: String, temporarySecretKey: Stri
 object UploadCredentials {
   implicit val format: Format[UploadCredentials] = Jsonx.formatCaseClass[UploadCredentials]
 }
+
+case class UploadCredentialsRequest (
+  atomId: String,
+  key: String
+)
+
+object UploadCredentialsRequest {
+  implicit val format: Format[UploadCredentialsRequest] = Jsonx.formatCaseClass[UploadCredentialsRequest]
+}

--- a/conf/routes
+++ b/conf/routes
@@ -27,7 +27,7 @@ POST    /api2/workflow/atoms            controllers.Api2.createWorkflowMediaAtom
 # user uploaded videos
 GET     /api2/uploads                   controllers.UploadController.list(atomId)
 POST    /api2/uploads                   controllers.UploadController.create
-POST    /api2/uploads/:id/credentials   controllers.UploadController.credentials(id, key)
+POST    /api2/uploads/credentials       controllers.UploadController.credentials
 
 GET     /api2/audits/:id                controllers.Api2.getAuditTrailForAtomId(id)
 

--- a/public/video-ui/src/services/UploadsApi.js
+++ b/public/video-ui/src/services/UploadsApi.js
@@ -26,8 +26,12 @@ export function createUpload(atomId, file, selfHost) {
 
 function getCredentials(id, key) {
   return pandaReqwest({
-    url: `/api2/uploads/${id}/credentials?key=${key}`,
-    method: 'post'
+    url: `/api2/uploads/credentials`,
+    method: 'post',
+    data: {
+      atomId: id,
+      key: key
+    }
   });
 }
 


### PR DESCRIPTION
allows for easier extensibility for uploading other files (xml!) as we can pattern match on the request body rather than using query string values