### PR TITLE
Reset video usages reducer on atom creation

### DIFF
--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -22,6 +22,7 @@ class VideoDisplay extends React.Component {
     if (this.props.route.mode === 'create') {
       this.props.videoActions.updateVideo(blankVideoData);
       this.props.videoActions.updateVideoEditState(true);
+      this.props.videoActions.getUsages();
     } else {
       this.props.videoActions.getVideo(this.props.params.id);
       this.props.videoActions.getUsages(this.props.params.id);


### PR DESCRIPTION
Calling `getUsages()` without an `id`parameter allows to update the usages reducer with blank data, so that when an atom is created, the usages reducer is cleared of the data from the last visited atom