### PR TITLE
Automatic composer updates

### DIFF
--- a/public/video-ui/src/actions/VideoActions/saveVideo.js
+++ b/public/video-ui/src/actions/VideoActions/saveVideo.js
@@ -8,10 +8,26 @@ function requestVideoSave(video) {
   };
 }
 
+function receiveVideoPageUpdate(newTitle) {
+  return {
+    type: 'VIDEO_PAGE_UPDATE_POST_RECEIVE',
+    newTitle: newTitle,
+    receivedAt: Date.now()
+  };
+}
+
 function receiveVideoSave(video) {
   return {
     type: 'VIDEO_SAVE_RECEIVE',
     video: video,
+    receivedAt: Date.now()
+  };
+}
+
+function receiveVideoUsages(usages) {
+  return {
+    type: 'VIDEO_USAGE_GET_RECEIVE',
+    usages: usages,
     receivedAt: Date.now()
   };
 }
@@ -25,11 +41,24 @@ function errorVideoSave(error) {
   };
 }
 
-export function saveVideo(video) {
+export function saveVideo(video, composerUrl) {
   return dispatch => {
     dispatch(requestVideoSave(video));
     return VideosApi.saveVideo(video.id, video)
-      .then(res => dispatch(receiveVideoSave(res)))
-      .catch(error => dispatch(errorVideoSave(error)));
+    .then(res => {
+      dispatch(receiveVideoSave(res))
+      return VideosApi.getVideoUsages(video.id)
+    })
+    .then(usages => {
+      dispatch(receiveVideoUsages(usages));
+      return VideosApi.updateCanonicalPages(
+        video,
+        composerUrl,
+        usages,
+        'preview'
+      )
+      .then(() => dispatch(receiveVideoPageUpdate(video.title)))
+    })
+    .catch(error => dispatch(errorVideoSave(error)));
   };
 }

--- a/public/video-ui/src/actions/VideoActions/saveVideo.js
+++ b/public/video-ui/src/actions/VideoActions/saveVideo.js
@@ -41,7 +41,7 @@ function errorVideoSave(error) {
   };
 }
 
-export function saveVideo(video, composerUrl) {
+export function saveVideo(video) {
   return dispatch => {
     dispatch(requestVideoSave(video));
     return VideosApi.saveVideo(video.id, video)
@@ -53,7 +53,6 @@ export function saveVideo(video, composerUrl) {
       dispatch(receiveVideoUsages(usages));
       return VideosApi.updateCanonicalPages(
         video,
-        composerUrl,
         usages,
         'preview'
       )

--- a/public/video-ui/src/actions/VideoActions/videoPageCreate.js
+++ b/public/video-ui/src/actions/VideoActions/videoPageCreate.js
@@ -25,7 +25,7 @@ function errorReceivingVideoPageCreate(error) {
   };
 }
 
-export function createVideoPage(id, video, composerUrl, videoBlock, isTrainingMode) {
+export function createVideoPage(id, video, composerUrl, isTrainingMode) {
   return dispatch => {
     dispatch(requestVideoPageCreate());
 
@@ -36,9 +36,8 @@ export function createVideoPage(id, video, composerUrl, videoBlock, isTrainingMo
 
         const addVideo = VideosApi.addVideoToComposerPage({
           composerId,
-          previewData: videoBlock,
           composerUrlBase: composerUrl,
-          state: ContentApi.preview
+          video
         });
 
         const postCreation = isTrainingMode

--- a/public/video-ui/src/actions/VideoActions/videoPageCreate.js
+++ b/public/video-ui/src/actions/VideoActions/videoPageCreate.js
@@ -25,23 +25,22 @@ function errorReceivingVideoPageCreate(error) {
   };
 }
 
-export function createVideoPage(id, video, composerUrl, isTrainingMode) {
+export function createVideoPage(id, video, isTrainingMode) {
   return dispatch => {
     dispatch(requestVideoPageCreate());
 
-    return VideosApi.createComposerPage(id, video, composerUrl)
+    return VideosApi.createComposerPage(id, video)
       .then(res => {
         const composerId = res.data.id;
         const pagePath = res.data.identifiers.path.data;
 
         const addVideo = VideosApi.addVideoToComposerPage({
           composerId,
-          composerUrlBase: composerUrl,
           video
         });
 
         const postCreation = isTrainingMode
-          ? [VideosApi.preventPublication(composerId, composerUrl), addVideo]
+          ? [VideosApi.preventPublication(composerId), addVideo]
           : [addVideo];
 
         return Promise.all(postCreation).then(() => {

--- a/public/video-ui/src/actions/VideoActions/videoPageUpdate.js
+++ b/public/video-ui/src/actions/VideoActions/videoPageUpdate.js
@@ -24,7 +24,7 @@ function errorReceivingVideoPageUpdate({error, message}) {
   };
 }
 
-export function updateVideoPage(video, composerUrl, videoBlock, usages) {
+export function updateVideoPage(video, composerUrl, videoBlock, usages, updatesTo) {
   return dispatch => {
     dispatch(requestVideoPageUpdate());
 
@@ -32,7 +32,8 @@ export function updateVideoPage(video, composerUrl, videoBlock, usages) {
       video,
       composerUrl,
       videoBlock,
-      usages
+      usages,
+      updatesTo
     )
       .then(() => dispatch(receiveVideoPageUpdate(video.title)))
       .catch(error => {

--- a/public/video-ui/src/actions/VideoActions/videoPageUpdate.js
+++ b/public/video-ui/src/actions/VideoActions/videoPageUpdate.js
@@ -1,4 +1,5 @@
 import VideosApi from '../../services/VideosApi';
+import { getVideoBlock } from '../../util/getVideoBlock';
 
 function requestVideoPageUpdate() {
   return {
@@ -24,14 +25,14 @@ function errorReceivingVideoPageUpdate({error, message}) {
   };
 }
 
-export function updateVideoPage(video, composerUrl, videoBlock, usages, updatesTo) {
+export function updateVideoPage(video, composerUrl, usages, updatesTo) {
+
   return dispatch => {
     dispatch(requestVideoPageUpdate());
 
     return VideosApi.updateCanonicalPages(
       video,
       composerUrl,
-      videoBlock,
       usages,
       updatesTo
     )

--- a/public/video-ui/src/actions/VideoActions/videoPageUpdate.js
+++ b/public/video-ui/src/actions/VideoActions/videoPageUpdate.js
@@ -25,14 +25,13 @@ function errorReceivingVideoPageUpdate({error, message}) {
   };
 }
 
-export function updateVideoPage(video, composerUrl, usages, updatesTo) {
+export function updateVideoPage(video, usages, updatesTo) {
 
   return dispatch => {
     dispatch(requestVideoPageUpdate());
 
     return VideosApi.updateCanonicalPages(
       video,
-      composerUrl,
       usages,
       updatesTo
     )

--- a/public/video-ui/src/components/FormFields/ScribeEditor.js
+++ b/public/video-ui/src/components/FormFields/ScribeEditor.js
@@ -6,7 +6,7 @@ import scribePluginToolbar from 'scribe-plugin-toolbar';
 import scribePluginLinkPromptCommand from 'scribe-plugin-link-prompt-command';
 import scribePluginSanitizer from 'scribe-plugin-sanitizer';
 import {keyCodes} from '../../constants/keyCodes';
-import {requiredForComposerWarning} from '../../constants/requiredForComposerWarning';
+import RequiredForComposer from '../../constants/requiredForComposer';
 import ReactTooltip from 'react-tooltip';
 
 export default class ScribeEditorField extends React.Component {
@@ -106,6 +106,7 @@ export default class ScribeEditorField extends React.Component {
 
   renderField() {
     const hasWarning = this.state.wordCount === 0  && this.props.fieldLocation === 'trailText';
+    const hasError = false;
 
     if (!this.props.editable) {
       if (this.state.wordCount === 0) {
@@ -139,7 +140,12 @@ export default class ScribeEditorField extends React.Component {
         </div>
         {hasWarning
           ? <p className="form__message form__message--warning">
-            {requiredForComposerWarning}
+            {RequiredForComposer.warning}
+            </p>
+          : ''}
+        {hasError
+          ? <p className="form__message form__message--warning">
+            {RequiredForComposer.error}
             </p>
           : ''}
       </div>

--- a/public/video-ui/src/components/FormFields/ScribeEditor.js
+++ b/public/video-ui/src/components/FormFields/ScribeEditor.js
@@ -105,8 +105,9 @@ export default class ScribeEditorField extends React.Component {
   };
 
   renderField() {
-    const hasWarning = this.state.wordCount === 0  && this.props.fieldLocation === 'trailText';
-    const hasError = false;
+    const requiresValidation = this.state.wordCount === 0  && this.props.fieldLocation === 'trailText';
+    const hasWarning = requiresValidation && this.props.isDesired;
+    const hasError = requiresValidation && this.props.isRequired;
 
     if (!this.props.editable) {
       if (this.state.wordCount === 0) {
@@ -144,7 +145,7 @@ export default class ScribeEditorField extends React.Component {
             </p>
           : ''}
         {hasError
-          ? <p className="form__message form__message--warning">
+          ? <p className="form__message form__message--error">
             {RequiredForComposer.error}
             </p>
           : ''}

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -12,7 +12,6 @@ import CapiUnavailable from '../CapiSearch/CapiUnavailable';
 import DragSortableList from 'react-drag-sortable';
 import removeTagDuplicates from '../../util/removeTagDuplicates';
 import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
-import {requiredForComposerWarning} from '../../constants/requiredForComposerWarning';
 import ReactTooltip from 'react-tooltip';
 import { getYouTubeTagCharCount } from '../../util/getYouTubeTagCharCount';
 import YouTubeKeywords from '../../constants/youTubeKeywords';

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -7,7 +7,6 @@ import AdvancedActions from './Videos/AdvancedActions';
 import ComposerPageCreate from './Videos/ComposerPageCreate';
 import Icon from './Icon';
 import { Presence } from './Presence';
-import RequiredForComposer from '../constants/requiredForComposer';
 import { canonicalVideoPageExists } from '../util/canonicalVideoPageExists';
 
 export default class Header extends React.Component {
@@ -187,10 +186,11 @@ export default class Header extends React.Component {
             editableFields={this.props.editableFields}
             saveState={this.props.saveState}
             videoEditOpen={this.props.videoEditOpen}
+            updateVideoPage={this.props.updateVideoPage}
+            requiredComposerFieldsMissing={this.requiredComposerFieldsMissing}
             usages={this.props.usages}
             publishVideo={this.publishVideo}
             formFieldsWarning={this.props.formFieldsWarning}
-            requiredComposerFieldsMissing={this.requiredComposerFieldsMissing}
             updateVideo={this.props.updateVideo}
             saveVideo={this.props.saveVideo}
             query={this.props.query}

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -7,6 +7,7 @@ import AdvancedActions from './Videos/AdvancedActions';
 import ComposerPageCreate from './Videos/ComposerPageCreate';
 import Icon from './Icon';
 import { Presence } from './Presence';
+import RequiredForComposer from '../constants/requiredForComposer';
 
 export default class Header extends React.Component {
   state = { presence: null };
@@ -189,12 +190,10 @@ export default class Header extends React.Component {
             editableFields={this.props.editableFields}
             saveState={this.props.saveState}
             videoEditOpen={this.props.videoEditOpen}
-            updateVideoPage={this.props.updateVideoPage}
             usages={this.props.usages}
             publishVideo={this.publishVideo}
             formFieldsWarning={this.props.formFieldsWarning}
             requiredComposerFieldsMissing={this.requiredComposerFieldsMissing}
-            canonicalVideoPageExists={this.canonicalVideoPageExists}
             updateVideo={this.props.updateVideo}
             saveVideo={this.props.saveVideo}
             query={this.props.query}

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -8,6 +8,7 @@ import ComposerPageCreate from './Videos/ComposerPageCreate';
 import Icon from './Icon';
 import { Presence } from './Presence';
 import RequiredForComposer from '../constants/requiredForComposer';
+import { canonicalVideoPageExists } from '../util/canonicalVideoPageExists';
 
 export default class Header extends React.Component {
   state = { presence: null };
@@ -20,10 +21,6 @@ export default class Header extends React.Component {
     return Object.keys(this.props.formFieldsWarning).some(key => {
       return this.props.formFieldsWarning[key];
     });
-  };
-
-  canonicalVideoPageExists = () => {
-    return this.props.usages.totalVideoPages > 0;
   };
 
   renderProgress() {
@@ -128,7 +125,7 @@ export default class Header extends React.Component {
       return null;
     }
 
-    if (this.canonicalVideoPageExists()) {
+    if (canonicalVideoPageExists(this.props.usages)) {
       return (
         <div className="header__fields__missing__warning">
           Fill in required composer fields before publishing
@@ -208,7 +205,7 @@ export default class Header extends React.Component {
             video={this.props.video || {}}
             createVideoPage={this.props.createVideoPage}
             requiredComposerFieldsMissing={this.requiredComposerFieldsMissing}
-            canonicalVideoPageExists={this.canonicalVideoPageExists}
+            usages={this.props.usages}
           />
           {this.renderComposerMissingWarning()}
           <div className="flex-container">

--- a/public/video-ui/src/components/ManagedForm/ManagedField.js
+++ b/public/video-ui/src/components/ManagedForm/ManagedField.js
@@ -6,6 +6,7 @@ import validateField from '../../util/validateField';
 import {getTextFromHtml} from '../../util/getTextFromHtml';
 import FieldNotification from '../../constants/FieldNotification';
 import {fieldsWithHtml} from '../../constants/fieldsWithHtml';
+import RequiredForComposer from '../../constants/requiredForComposer';
 
 export class ManagedField extends React.Component {
   static propTypes = {
@@ -53,11 +54,14 @@ export class ManagedField extends React.Component {
       value = getTextFromHtml(value);
     }
 
+    const composerValidation = RequiredForComposer.fields.includes(this.props.fieldLocation);
+
     const notification = validateField(
       value,
       this.props.isRequired,
       this.props.isDesired,
-      this.props.customValidation
+      this.props.customValidation,
+      composerValidation
     );
 
     if (this.props.updateFormErrors) {

--- a/public/video-ui/src/components/ReactApp.js
+++ b/public/video-ui/src/components/ReactApp.js
@@ -67,6 +67,7 @@ class ReactApp extends React.Component {
           publishVideo={this.props.appActions.publishVideo}
           saveState={this.props.saveState}
           editableFields={this.getEditableFields()}
+          updateVideoPage={this.props.appActions.updateVideoPage}
           createVideoPage={this.props.appActions.createVideoPage}
           videoEditOpen={this.props.videoEditOpen}
           usages={this.props.usages || {}}
@@ -98,6 +99,7 @@ import * as getPublishedVideo from '../actions/VideoActions/getPublishedVideo';
 import * as publishVideo from '../actions/VideoActions/publishVideo';
 import * as saveVideo from '../actions/VideoActions/saveVideo';
 import * as getUploads from '../actions/UploadActions/getUploads';
+import * as videoPageUpdate from '../actions/VideoActions/videoPageUpdate';
 import * as videoPageCreate from '../actions/VideoActions/videoPageCreate';
 import * as videoUsages from '../actions/VideoActions/videoUsages';
 import * as deleteVideo from '../actions/VideoActions/deleteVideo';
@@ -131,6 +133,7 @@ function mapDispatchToProps(dispatch) {
         publishVideo,
         saveVideo,
         getUploads,
+        videoPageUpdate,
         videoPageCreate,
         videoUsages,
         deleteVideo,

--- a/public/video-ui/src/components/ReactApp.js
+++ b/public/video-ui/src/components/ReactApp.js
@@ -67,7 +67,6 @@ class ReactApp extends React.Component {
           publishVideo={this.props.appActions.publishVideo}
           saveState={this.props.saveState}
           editableFields={this.getEditableFields()}
-          updateVideoPage={this.props.appActions.updateVideoPage}
           createVideoPage={this.props.appActions.createVideoPage}
           videoEditOpen={this.props.videoEditOpen}
           usages={this.props.usages || {}}
@@ -99,7 +98,6 @@ import * as getPublishedVideo from '../actions/VideoActions/getPublishedVideo';
 import * as publishVideo from '../actions/VideoActions/publishVideo';
 import * as saveVideo from '../actions/VideoActions/saveVideo';
 import * as getUploads from '../actions/UploadActions/getUploads';
-import * as videoPageUpdate from '../actions/VideoActions/videoPageUpdate';
 import * as videoPageCreate from '../actions/VideoActions/videoPageCreate';
 import * as videoUsages from '../actions/VideoActions/videoUsages';
 import * as deleteVideo from '../actions/VideoActions/deleteVideo';
@@ -133,7 +131,6 @@ function mapDispatchToProps(dispatch) {
         publishVideo,
         saveVideo,
         getUploads,
-        videoPageUpdate,
         videoPageCreate,
         videoUsages,
         deleteVideo,

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -128,6 +128,13 @@ class VideoDisplay extends React.Component {
           return keyword.match(/^tone/);
         })
        ) {
+        if (this.canonicalVideoPageExists()) {
+          return new FieldNotification(
+            'error',
+            'A series or a keyword tag is required for updating composer pages',
+            FieldNotification.error
+          );
+        }
         return new FieldNotification(
           'desired',
           'A series or a keyword tag is required for creating composer pages',
@@ -261,6 +268,7 @@ class VideoDisplay extends React.Component {
           validateKeywords={this.validateKeywords}
           validateYouTubeKeywords={this.validateYouTubeKeywords}
           composerKeywordsToYouTube={this.composerKeywordsToYouTube}
+          canonicalVideoPageExists={this.canonicalVideoPageExists()}
         />
       </div>
     );

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -50,11 +50,15 @@ class VideoDisplay extends React.Component {
             this.props.video.source
           );
 
+          const updateLive = this.props.usages.data.published.video.length === 0;
+          const updatePreview = true;
+
           this.props.videoActions.updateVideoPage(
             this.props.video,
             this.getComposerUrl(),
             videoBlock,
-            this.props.usages
+            this.props.usages,
+            'preview'
           );
         }
       });

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -15,7 +15,6 @@ import { blankVideoData } from '../../constants/blankVideoData';
 import KeywordsApi from '../../services/KeywordsApi';
 import YouTubeKeywords from '../../constants/youTubeKeywords';
 import { getYouTubeTagCharCount } from '../../util/getYouTubeTagCharCount';
-import { getVideoBlock } from '../../util/getVideoBlock';
 import { canonicalVideoPageExists } from '../../util/canonicalVideoPageExists';
 
 class VideoDisplay extends React.Component {
@@ -41,27 +40,7 @@ class VideoDisplay extends React.Component {
           this.props.videoActions.getUsages(this.props.video.id);
         });
     } else {
-      this.props.videoActions.saveVideo(video)
-      .then(() => {
-        if (canonicalVideoPageExists(this.props.usages)) {
-          const videoBlock = getVideoBlock(
-            this.props.video.id,
-            this.props.video.title,
-            this.props.video.source
-          );
-
-          const updateLive = this.props.usages.data.published.video.length === 0;
-          const updatePreview = true;
-
-          this.props.videoActions.updateVideoPage(
-            this.props.video,
-            this.getComposerUrl(),
-            videoBlock,
-            this.props.usages,
-            'preview'
-          );
-        }
-      });
+      this.props.videoActions.saveVideo(video, this.getComposerUrl())
     }
   };
 

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -10,7 +10,6 @@ import Icon from '../Icon';
 import { formNames } from '../../constants/formNames';
 import FieldNotification from '../../constants/FieldNotification';
 import ReactTooltip from 'react-tooltip';
-import { getStore } from '../../util/storeAccessor';
 import { blankVideoData } from '../../constants/blankVideoData';
 import KeywordsApi from '../../services/KeywordsApi';
 import YouTubeKeywords from '../../constants/youTubeKeywords';
@@ -29,10 +28,6 @@ class VideoDisplay extends React.Component {
     }
   }
 
-  getComposerUrl = () => {
-    return getStore().getState().config.composerUrl;
-  };
-
   saveAndUpdateVideo = video => {
     if (this.props.route.mode === 'create') {
       this.props.videoActions.createVideo(video)
@@ -40,7 +35,7 @@ class VideoDisplay extends React.Component {
           this.props.videoActions.getUsages(this.props.video.id);
         });
     } else {
-      this.props.videoActions.saveVideo(video, this.getComposerUrl())
+      this.props.videoActions.saveVideo(video)
     }
   };
 
@@ -83,10 +78,6 @@ class VideoDisplay extends React.Component {
 
   cannotEditStatus = () => {
     return this.props.video.expiryDate <= Date.now();
-  };
-
-  getComposerUrl = () => {
-    return getStore().getState().config.composerUrl;
   };
 
   cannotCloseEditForm = () => {

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -15,6 +15,7 @@ import { blankVideoData } from '../../constants/blankVideoData';
 import KeywordsApi from '../../services/KeywordsApi';
 import YouTubeKeywords from '../../constants/youTubeKeywords';
 import { getYouTubeTagCharCount } from '../../util/getYouTubeTagCharCount';
+import { getVideoBlock } from '../../util/getVideoBlock';
 
 class VideoDisplay extends React.Component {
   componentWillMount() {
@@ -28,6 +29,14 @@ class VideoDisplay extends React.Component {
     }
   }
 
+  canonicalVideoPageExists = () => {
+    return this.props.usages.totalVideoPages > 0;
+  };
+
+  getComposerUrl = () => {
+    return getStore().getState().config.composerUrl;
+  };
+
   saveAndUpdateVideo = video => {
     if (this.props.route.mode === 'create') {
       this.props.videoActions.createVideo(video)
@@ -35,7 +44,23 @@ class VideoDisplay extends React.Component {
           this.props.videoActions.getUsages(this.props.video.id);
         });
     } else {
-      this.props.videoActions.saveVideo(video);
+      this.props.videoActions.saveVideo(video)
+      .then(() => {
+        if (this.canonicalVideoPageExists()) {
+          const videoBlock = getVideoBlock(
+            this.props.video.id,
+            this.props.video.title,
+            this.props.video.source
+          );
+
+          this.props.videoActions.updateVideoPage(
+            this.props.video,
+            this.getComposerUrl(),
+            videoBlock,
+            this.props.usages
+          );
+        }
+      });
     }
   };
 
@@ -323,6 +348,8 @@ import * as updateFormErrors
   from '../../actions/FormErrorActions/updateFormErrors';
 import * as updateFormWarnings
   from '../../actions/FormErrorActions/updateFormWarnings';
+import * as videoPageUpdate
+  from '../../actions/VideoActions/videoPageUpdate';
 
 function mapStateToProps(state) {
   return {
@@ -347,7 +374,8 @@ function mapDispatchToProps(dispatch) {
         updateVideo,
         videoUsages,
         getPublishedVideo,
-        updateVideoEditState
+        updateVideoEditState,
+        videoPageUpdate
       ),
       dispatch
     ),

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -16,6 +16,7 @@ import KeywordsApi from '../../services/KeywordsApi';
 import YouTubeKeywords from '../../constants/youTubeKeywords';
 import { getYouTubeTagCharCount } from '../../util/getYouTubeTagCharCount';
 import { getVideoBlock } from '../../util/getVideoBlock';
+import { canonicalVideoPageExists } from '../../util/canonicalVideoPageExists';
 
 class VideoDisplay extends React.Component {
   componentWillMount() {
@@ -28,10 +29,6 @@ class VideoDisplay extends React.Component {
       this.props.videoActions.getUsages(this.props.params.id);
     }
   }
-
-  canonicalVideoPageExists = () => {
-    return this.props.usages.totalVideoPages > 0;
-  };
 
   getComposerUrl = () => {
     return getStore().getState().config.composerUrl;
@@ -46,7 +43,7 @@ class VideoDisplay extends React.Component {
     } else {
       this.props.videoActions.saveVideo(video)
       .then(() => {
-        if (this.canonicalVideoPageExists()) {
+        if (canonicalVideoPageExists(this.props.usages)) {
           const videoBlock = getVideoBlock(
             this.props.video.id,
             this.props.video.title,
@@ -128,7 +125,7 @@ class VideoDisplay extends React.Component {
           return keyword.match(/^tone/);
         })
        ) {
-        if (this.canonicalVideoPageExists()) {
+        if (canonicalVideoPageExists(this.props.usages)) {
           return new FieldNotification(
             'error',
             'A series or a keyword tag is required for updating composer pages',
@@ -268,7 +265,7 @@ class VideoDisplay extends React.Component {
           validateKeywords={this.validateKeywords}
           validateYouTubeKeywords={this.validateYouTubeKeywords}
           composerKeywordsToYouTube={this.composerKeywordsToYouTube}
-          canonicalVideoPageExists={this.canonicalVideoPageExists()}
+          canonicalVideoPageExists={canonicalVideoPageExists(this.props.usages)}
         />
       </div>
     );

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -81,13 +81,13 @@ class VideoData extends React.Component {
               name="Trail Text"
               maxCharLength={fieldLengths.description.charMax}
               maxLength={fieldLengths.description.max}
-              isDesired={!this.props.canonicalVideoPageExists ? false : true}
-              isRequired={this.props.canonicalVideoPageExists ? true : false}
+              isDesired={!this.props.canonicalVideoPageExists}
+              isRequired={this.props.canonicalVideoPageExists}
             >
               <ScribeEditorField
                 allowedEdits={['bold', 'italic']}
-                isDesired={this.props.canonicalVideoPageExists ? false : true}
-                isRequired={this.props.canonicalVideoPageExists ? true : false}
+                isDesired={!this.props.canonicalVideoPageExists}
+                isRequired={this.props.canonicalVideoPageExists}
               />
             </ManagedField>
 
@@ -104,8 +104,8 @@ class VideoData extends React.Component {
               name="Commissioning Desks"
               formRowClass="form__row__byline"
               tagType={TagTypes.tracking}
-              isDesired={this.props.canonicalVideoPageExists ? false : true}
-              isRequired={this.props.canonicalVideoPageExists ? true : false}
+              isDesired={!this.props.canonicalVideoPageExists}
+              isRequired={this.props.canonicalVideoPageExists}
               inputPlaceholder="Search commissioning info (type '*' to show all)"
             >
               <TagPicker disableTextInput />

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -81,12 +81,13 @@ class VideoData extends React.Component {
               name="Trail Text"
               maxCharLength={fieldLengths.description.charMax}
               maxLength={fieldLengths.description.max}
-              isDesired={this.props.canonicalVideoPageExists ? false : true}
+              isDesired={!this.props.canonicalVideoPageExists ? false : true}
               isRequired={this.props.canonicalVideoPageExists ? true : false}
             >
               <ScribeEditorField
                 allowedEdits={['bold', 'italic']}
-
+                isDesired={this.props.canonicalVideoPageExists ? false : true}
+                isRequired={this.props.canonicalVideoPageExists ? true : false}
               />
             </ManagedField>
 

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -81,7 +81,8 @@ class VideoData extends React.Component {
               name="Trail Text"
               maxCharLength={fieldLengths.description.charMax}
               maxLength={fieldLengths.description.max}
-              isDesired={true}
+              isDesired={this.props.canonicalVideoPageExists ? false : true}
+              isRequired={this.props.canonicalVideoPageExists ? true : false}
             >
               <ScribeEditorField
                 allowedEdits={['bold', 'italic']}
@@ -102,7 +103,8 @@ class VideoData extends React.Component {
               name="Commissioning Desks"
               formRowClass="form__row__byline"
               tagType={TagTypes.tracking}
-              isDesired={true}
+              isDesired={this.props.canonicalVideoPageExists ? false : true}
+              isRequired={this.props.canonicalVideoPageExists ? true : false}
               inputPlaceholder="Search commissioning info (type '*' to show all)"
             >
               <TagPicker disableTextInput />

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -5,7 +5,6 @@ import { hasUnpublishedChanges } from '../../util/hasUnpublishedChanges';
 import { getStore } from '../../util/storeAccessor';
 import ScheduledLaunch from '../../components/ScheduledLaunch/ScheduledLaunch';
 import { getVideoBlock } from '../../util/getVideoBlock';
-import { publishedCanonicalVideoPageExists } from '../../util/publishedCanonicalVideoPageExists';
 import { canonicalVideoPageExists } from '../../util/canonicalVideoPageExists';
 
 export default class VideoPublishBar extends React.Component {
@@ -35,9 +34,18 @@ export default class VideoPublishBar extends React.Component {
     return getStore().getState().config.composerUrl;
   };
 
+  publishedCanonicalVideoPageExists() {
+    return this.props.usages &&
+      this.props.usages.data &&
+      this.props.usages.data.published &&
+      this.props.usages.data.published.video &&
+      this.props.usages.data.published.video.length > 0;
+
+  }
+
   publishVideo = () => {
 
-    if (publishedCanonicalVideoPageExists(this.props.usages)) {
+    if (this.publishedCanonicalVideoPageExists()) {
 
       const videoBlock = getVideoBlock(
         this.props.video.id,

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { saveStateVals } from '../../constants/saveStateVals';
 import { isVideoPublished } from '../../util/isVideoPublished';
 import { hasUnpublishedChanges } from '../../util/hasUnpublishedChanges';
-import { getStore } from '../../util/storeAccessor';
 import ScheduledLaunch from '../../components/ScheduledLaunch/ScheduledLaunch';
 import { canonicalVideoPageExists } from '../../util/canonicalVideoPageExists';
 
@@ -29,10 +28,6 @@ export default class VideoPublishBar extends React.Component {
     );
   }
 
-  getComposerUrl = () => {
-    return getStore().getState().config.composerUrl;
-  };
-
   publishedCanonicalVideoPageExists() {
     return this.props.usages &&
       this.props.usages.data &&
@@ -48,7 +43,6 @@ export default class VideoPublishBar extends React.Component {
 
       this.props.updateVideoPage(
         this.props.video,
-        this.getComposerUrl(),
         this.props.usages,
         'published'
       );

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -4,6 +4,9 @@ import { isVideoPublished } from '../../util/isVideoPublished';
 import { hasUnpublishedChanges } from '../../util/hasUnpublishedChanges';
 import { getStore } from '../../util/storeAccessor';
 import ScheduledLaunch from '../../components/ScheduledLaunch/ScheduledLaunch';
+import { getVideoBlock } from '../../util/getVideoBlock';
+import { publishedCanonicalVideoPageExists } from '../../util/publishedCanonicalVideoPageExists';
+import { canonicalVideoPageExists } from '../../util/canonicalVideoPageExists';
 
 export default class VideoPublishBar extends React.Component {
   videoIsCurrentlyPublishing() {
@@ -23,11 +26,33 @@ export default class VideoPublishBar extends React.Component {
       this.props.video.contentChangeDetails && this.props.video.contentChangeDetails.scheduledLaunch ||
       this.videoIsCurrentlyPublishing() ||
       this.props.videoEditOpen ||
-      !this.videoHasUnpublishedChanges()
+      !this.videoHasUnpublishedChanges() ||
+      (canonicalVideoPageExists(this.props.usages) && this.props.requiredComposerFieldsMissing())
     );
   }
 
+  getComposerUrl = () => {
+    return getStore().getState().config.composerUrl;
+  };
+
   publishVideo = () => {
+
+    if (publishedCanonicalVideoPageExists(this.props.usages)) {
+
+      const videoBlock = getVideoBlock(
+        this.props.video.id,
+        this.props.video.title,
+        this.props.video.source
+      );
+
+      this.props.updateVideoPage(
+        this.props.video,
+        this.getComposerUrl(),
+        videoBlock,
+        this.props.usages,
+        'published'
+      );
+    }
 
     this.props.publishVideo();
   };

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { saveStateVals } from '../../constants/saveStateVals';
 import { isVideoPublished } from '../../util/isVideoPublished';
 import { hasUnpublishedChanges } from '../../util/hasUnpublishedChanges';
-import { getVideoBlock } from '../../util/getVideoBlock';
 import { getStore } from '../../util/storeAccessor';
 import ScheduledLaunch from '../../components/ScheduledLaunch/ScheduledLaunch';
 
@@ -24,30 +23,11 @@ export default class VideoPublishBar extends React.Component {
       this.props.video.contentChangeDetails && this.props.video.contentChangeDetails.scheduledLaunch ||
       this.videoIsCurrentlyPublishing() ||
       this.props.videoEditOpen ||
-      !this.videoHasUnpublishedChanges() ||
-      (this.props.canonicalVideoPageExists() && this.props.requiredComposerFieldsMissing())
+      !this.videoHasUnpublishedChanges()
     );
   }
 
-  getComposerUrl = () => {
-    return getStore().getState().config.composerUrl;
-  };
-
   publishVideo = () => {
-    const videoBlock = getVideoBlock(
-      this.props.video.id,
-      this.props.video.title,
-      this.props.video.source
-    );
-
-    if (this.props.canonicalVideoPageExists()) {
-      this.props.updateVideoPage(
-        this.props.video,
-        this.getComposerUrl(),
-        videoBlock,
-        this.props.usages
-      );
-    }
 
     this.props.publishVideo();
   };

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -4,7 +4,6 @@ import { isVideoPublished } from '../../util/isVideoPublished';
 import { hasUnpublishedChanges } from '../../util/hasUnpublishedChanges';
 import { getStore } from '../../util/storeAccessor';
 import ScheduledLaunch from '../../components/ScheduledLaunch/ScheduledLaunch';
-import { getVideoBlock } from '../../util/getVideoBlock';
 import { canonicalVideoPageExists } from '../../util/canonicalVideoPageExists';
 
 export default class VideoPublishBar extends React.Component {
@@ -47,16 +46,9 @@ export default class VideoPublishBar extends React.Component {
 
     if (this.publishedCanonicalVideoPageExists()) {
 
-      const videoBlock = getVideoBlock(
-        this.props.video.id,
-        this.props.video.title,
-        this.props.video.source
-      );
-
       this.props.updateVideoPage(
         this.props.video,
         this.getComposerUrl(),
-        videoBlock,
         this.props.usages,
         'published'
       );

--- a/public/video-ui/src/components/Videos/ComposerPageCreate.js
+++ b/public/video-ui/src/components/Videos/ComposerPageCreate.js
@@ -35,18 +35,11 @@ export default class ComposerPageCreate extends React.Component {
       composerUpdateInProgress: true
     });
 
-    const videoBlock = getVideoBlock(
-      this.props.video.id,
-      this.props.video.title,
-      this.props.video.source
-    );
-
     return this.props
       .createVideoPage(
         this.props.video.id,
         this.props.video,
         this.getComposerUrl(),
-        videoBlock,
         getStore().getState().config.isTrainingMode
       )
       .then(() => {

--- a/public/video-ui/src/components/Videos/ComposerPageCreate.js
+++ b/public/video-ui/src/components/Videos/ComposerPageCreate.js
@@ -39,7 +39,6 @@ export default class ComposerPageCreate extends React.Component {
       .createVideoPage(
         this.props.video.id,
         this.props.video,
-        this.getComposerUrl(),
         getStore().getState().config.isTrainingMode
       )
       .then(() => {

--- a/public/video-ui/src/components/Videos/ComposerPageCreate.js
+++ b/public/video-ui/src/components/Videos/ComposerPageCreate.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { getVideoBlock } from '../../util/getVideoBlock';
 import Icon from '../Icon';
 import { getStore } from '../../util/storeAccessor';
+import { canonicalVideoPageExists } from '../../util/canonicalVideoPageExists';
 
 export default class ComposerPageCreate extends React.Component {
   state = {
@@ -56,8 +57,9 @@ export default class ComposerPageCreate extends React.Component {
   };
 
   render() {
-    const { canonicalVideoPageExists, videoEditOpen, requiredComposerFieldsMissing } = this.props;
-    const showOpenPage = canonicalVideoPageExists() || this.isHosted();
+
+    const { usages, videoEditOpen, requiredComposerFieldsMissing } = this.props;
+    const showOpenPage = canonicalVideoPageExists(usages) || this.isHosted();
 
     if (showOpenPage) {
       return (
@@ -66,6 +68,7 @@ export default class ComposerPageCreate extends React.Component {
         </a>
       );
     }
+
     else {
       return (
         <button

--- a/public/video-ui/src/constants/requiredForComposer.js
+++ b/public/video-ui/src/constants/requiredForComposer.js
@@ -1,0 +1,13 @@
+export default class RequiredForComposer {
+  static get warning() {
+    return 'This field is required for creating composer pages';
+  }
+
+  static get error() {
+    return 'This field is required for updating composer pages';
+  }
+
+  static get fields() {
+    return ['commissioningDesks', 'keywords', 'description']
+  }
+}

--- a/public/video-ui/src/constants/requiredForComposerWarning.js
+++ b/public/video-ui/src/constants/requiredForComposerWarning.js
@@ -1,2 +1,0 @@
-export const requiredForComposerWarning =
-  'This field is required for creating composer pages';

--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -152,7 +152,7 @@ export default {
     });
   },
 
-  updateCanonicalPages(video, composerUrlBase, videoBlock, usages) {
+  updateCanonicalPages(video, composerUrlBase, videoBlock, usages, updatesTo) {
     const composerData = getComposerData(video);
     return Promise.all(
       Object.keys(usages.data).map(state => {
@@ -162,16 +162,21 @@ export default {
 
           const pageId = usage.fields.internalComposerCode;
 
-          return pandaReqwest({
-            url: `${composerUrlBase}/api/content/${pageId}/videopage`,
-            method: 'put',
-            crossOrigin: true,
-            withCredentials: true,
-            data: {
-              videoFields: cleanVideoData(composerData),
-              videoBlock: videoBlock
-            }
-          });
+          if (updatesTo === state) {
+
+            return pandaReqwest({
+              url: `${composerUrlBase}/api/content/${pageId}/videopage`,
+              method: 'put',
+              crossOrigin: true,
+              withCredentials: true,
+              data: {
+                videoFields: cleanVideoData(composerData),
+                videoBlock: videoBlock
+              }
+            });
+          }
+
+          return Promise.resolve();
         });
       })
     );
@@ -195,7 +200,7 @@ export default {
     });
   },
 
-  addVideoToComposerPage({ composerId, previewData, composerUrlBase }) {
+  addVideoToComposerPage({ composerId, previewData, composerUrlBase}) {
     function updateMainBlock(stage, data) {
       return pandaReqwest({
         url: `${composerUrlBase}/api/content/${composerId}/${stage}/mainblock`,

--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -5,6 +5,10 @@ import { cleanVideoData } from '../util/cleanVideoData';
 import ContentApi from './capi';
 import { getVideoBlock } from '../util/getVideoBlock';
 
+function getComposerUrl() {
+  return getStore().getState().config.composerUrl;
+};
+
 function getUsages({ id, stage }) {
   return pandaReqwest({
     url: `${ContentApi.getUrl(stage)}/atom/media/${id}/usage`
@@ -153,8 +157,9 @@ export default {
     });
   },
 
-  updateCanonicalPages(video, composerUrlBase, usages, updatesTo) {
+  updateCanonicalPages(video, usages, updatesTo) {
     const composerData = getComposerData(video);
+    const composerUrlBase = getComposerUrl();
     const videoBlock = getVideoBlock(
       video.id,
       video.title,

--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -194,8 +194,9 @@ export default {
     );
   },
 
-  createComposerPage(id, video, composerUrlBase) {
+  createComposerPage(id, video) {
     const composerData = getComposerData(video);
+    const composerUrlBase = getComposerUrl();
 
     const composerUrl =
       composerUrlBase +
@@ -212,7 +213,9 @@ export default {
     });
   },
 
-  addVideoToComposerPage({ composerId, composerUrlBase, video}) {
+  addVideoToComposerPage({ composerId, video}) {
+
+    const composerUrlBase = getComposerUrl();
 
     const previewData = getVideoBlock(
       video.id,
@@ -255,7 +258,10 @@ export default {
     });
   },
 
-  preventPublication(composerId, composerUrl) {
+  preventPublication(composerId) {
+
+    const composerUrlBase = getComposerUrl();
+
     function doEmbargoIndefinitely(stage) {
       return pandaReqwest({
         url: `${composerUrl}/api/content/${composerId}/${stage}/settings/embargoedIndefinitely`,

--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -3,6 +3,7 @@ import { getStore } from '../util/storeAccessor';
 import { getComposerData } from '../util/getComposerData';
 import { cleanVideoData } from '../util/cleanVideoData';
 import ContentApi from './capi';
+import { getVideoBlock } from '../util/getVideoBlock';
 
 function getUsages({ id, stage }) {
   return pandaReqwest({
@@ -152,8 +153,14 @@ export default {
     });
   },
 
-  updateCanonicalPages(video, composerUrlBase, videoBlock, usages, updatesTo) {
+  updateCanonicalPages(video, composerUrlBase, usages, updatesTo) {
     const composerData = getComposerData(video);
+    const videoBlock = getVideoBlock(
+      video.id,
+      video.title,
+      video.source
+    );
+
     return Promise.all(
       Object.keys(usages.data).map(state => {
         const videoPageUsages = usages.data[state].video;
@@ -200,7 +207,14 @@ export default {
     });
   },
 
-  addVideoToComposerPage({ composerId, previewData, composerUrlBase}) {
+  addVideoToComposerPage({ composerId, composerUrlBase, video}) {
+
+    const previewData = getVideoBlock(
+      video.id,
+      video.title,
+      video.source
+    );
+
     function updateMainBlock(stage, data) {
       return pandaReqwest({
         url: `${composerUrlBase}/api/content/${composerId}/${stage}/mainblock`,

--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -7,7 +7,7 @@ import { getVideoBlock } from '../util/getVideoBlock';
 
 function getComposerUrl() {
   return getStore().getState().config.composerUrl;
-};
+}
 
 function getUsages({ id, stage }) {
   return pandaReqwest({
@@ -160,22 +160,16 @@ export default {
   updateCanonicalPages(video, usages, updatesTo) {
     const composerData = getComposerData(video);
     const composerUrlBase = getComposerUrl();
-    const videoBlock = getVideoBlock(
-      video.id,
-      video.title,
-      video.source
-    );
+    const videoBlock = getVideoBlock(video.id, video.title, video.source);
 
     return Promise.all(
       Object.keys(usages.data).map(state => {
         const videoPageUsages = usages.data[state].video;
 
         return videoPageUsages.map(usage => {
-
           const pageId = usage.fields.internalComposerCode;
 
           if (updatesTo === state) {
-
             return pandaReqwest({
               url: `${composerUrlBase}/api/content/${pageId}/videopage`,
               method: 'put',
@@ -213,15 +207,10 @@ export default {
     });
   },
 
-  addVideoToComposerPage({ composerId, video}) {
-
+  addVideoToComposerPage({ composerId, video }) {
     const composerUrlBase = getComposerUrl();
 
-    const previewData = getVideoBlock(
-      video.id,
-      video.title,
-      video.source
-    );
+    const previewData = getVideoBlock(video.id, video.title, video.source);
 
     function updateMainBlock(stage, data) {
       return pandaReqwest({
@@ -259,8 +248,7 @@ export default {
   },
 
   preventPublication(composerId) {
-
-    const composerUrlBase = getComposerUrl();
+    const composerUrl = getComposerUrl();
 
     function doEmbargoIndefinitely(stage) {
       return pandaReqwest({

--- a/public/video-ui/src/util/canonicalVideoPageExists.js
+++ b/public/video-ui/src/util/canonicalVideoPageExists.js
@@ -1,0 +1,4 @@
+export function canonicalVideoPageExists(usages) {
+  return usages.totalVideoPages > 0;
+};
+

--- a/public/video-ui/src/util/validateField.js
+++ b/public/video-ui/src/util/validateField.js
@@ -1,33 +1,42 @@
 import FieldNotification from '../constants/FieldNotification';
-import {
-  requiredForComposerWarning
-} from '../constants/requiredForComposerWarning';
+import RequiredForComposer from '../constants/requiredForComposer';
 
 const validateField = (
   fieldValue,
   isRequired: false,
   isDesired: false,
-  customValidation: null
+  customValidation: null,
+  composerValidation: false
 ) => {
   if (customValidation) {
     return customValidation(fieldValue);
   }
 
-  if (isRequired && !fieldValue) {
+  function fieldValueMissing() {
+    if (!fieldValue) {
+      return true;
+    }
+
+    if (Array.isArray(fieldValue) && fieldValue.length === 0) {
+      return true;
+    }
+
+    return false;
+  }
+
+  if (isRequired && fieldValueMissing()) {
     return new FieldNotification(
       'required',
-      'This field is required',
+      composerValidation ? RequiredForComposer.error : 'This field is required',
       FieldNotification.error
     );
   }
-
   if (
-    isDesired &&
-    (!fieldValue || (Array.isArray(fieldValue) && fieldValue.length === 0))
+    isDesired && fieldValueMissing()
   ) {
     return new FieldNotification(
       'desired',
-      requiredForComposerWarning,
+      composerValidation ? RequiredForComposer.warning : 'This field is desired',
       FieldNotification.warning
     );
   }


### PR DESCRIPTION
- Push updates to canonical video page automatically when saving an atom if video page exists
- If canonical video page exists, required missing composer fields are displayed as errors and atom cannot be saved before they are added back in. If the page does not exist, they are rendered as warnings as before.