### PR TITLE
sharing is caring

### DIFF
--- a/app/data/AtomListStore.scala
+++ b/app/data/AtomListStore.scala
@@ -4,9 +4,10 @@ import java.time.Instant
 
 import com.gu.atom.data.PreviewDynamoDataStore
 import com.gu.media.CapiAccess
+import com.gu.media.model.Image
 import com.gu.media.util.TestFilters
 import model.commands.CommandExceptions.AtomDataStoreError
-import model.{Image, MediaAtom, MediaAtomList, MediaAtomSummary}
+import model.{MediaAtom, MediaAtomList, MediaAtomSummary}
 import play.api.libs.json.{JsArray, JsValue}
 
 trait AtomListStore {

--- a/app/model/MediaAtom.scala
+++ b/app/model/MediaAtom.scala
@@ -2,7 +2,7 @@ package model
 
 import com.gu.contentatom.thrift.atom.media.{MediaAtom => ThriftMediaAtom, Metadata => ThriftMetadata}
 import com.gu.contentatom.thrift.{AtomData, Atom => ThriftAtom, AtomType => ThriftAtomType, Flags => ThriftFlags}
-import com.gu.media.model.{Asset, Platform, PrivacyStatus}
+import com.gu.media.model._
 import org.cvogt.play.json.Jsonx
 import util.atom.MediaAtomImplicits
 

--- a/app/model/MediaAtomSummary.scala
+++ b/app/model/MediaAtomSummary.scala
@@ -1,5 +1,6 @@
 package model
 
+import com.gu.media.model.Image
 import org.cvogt.play.json.Jsonx
 import play.api.libs.json.Format
 

--- a/app/model/commands/CreateAtomCommand.scala
+++ b/app/model/commands/CreateAtomCommand.scala
@@ -4,15 +4,16 @@ import java.util.Date
 import java.util.UUID._
 
 import com.gu.atom.data.IDConflictError
-import com.gu.contentatom.thrift.atom.media.{Category => ThriftCategory, MediaAtom => ThriftMediaAtom, Metadata => ThriftMetadata}
-import com.gu.contentatom.thrift.{Atom => ThriftAtom, _}
+import com.gu.contentatom.thrift.{ContentAtomEvent, EventType}
+import com.gu.media
 import com.gu.media.logging.Logging
 import com.gu.pandomainauth.model.{User => PandaUser}
 import data.DataStores
 import model.commands.CommandExceptions._
-import model.{ChangeRecord, Image, MediaAtom, MediaAtomBeforeCreation, ContentChangeDetails}
+import model.{MediaAtom, MediaAtomBeforeCreation}
 import org.cvogt.play.json.Jsonx
 import play.api.libs.json.Format
+import com.gu.media.model.ChangeRecord
 
 import scala.util.{Failure, Success}
 
@@ -26,7 +27,7 @@ case class CreateAtomCommand(data: MediaAtomBeforeCreation, override val stores:
     val atomId = randomUUID().toString
     val createdChangeRecord = Some(ChangeRecord.now(user))
 
-    val details = ContentChangeDetails(
+    val details = media.model.ContentChangeDetails(
       lastModified = createdChangeRecord,
       created = createdChangeRecord,
       published = None,

--- a/app/model/commands/CreateWorkflowAtomCommand.scala
+++ b/app/model/commands/CreateWorkflowAtomCommand.scala
@@ -5,12 +5,13 @@ import java.util.UUID._
 
 import com.gu.atom.data.IDConflictError
 import com.gu.contentatom.thrift.atom.media.{Category => ThriftCategory, MediaAtom => ThriftMediaAtom, Metadata => ThriftMetadata}
-import com.gu.contentatom.thrift.{Atom => ThriftAtom, _}
+import com.gu.contentatom.thrift.{AtomData, AtomType, ContentAtomEvent, ContentChangeDetails, EventType, Atom => ThriftAtom}
 import com.gu.media.logging.Logging
 import com.gu.pandomainauth.model.{User => PandaUser}
 import data.DataStores
 import model.commands.CommandExceptions._
-import model.{ChangeRecord, MediaAtom, WorkflowMediaAtom}
+import model.{MediaAtom, WorkflowMediaAtom}
+import com.gu.media.model.ChangeRecord
 
 import scala.util.{Failure, Success}
 

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -8,7 +8,7 @@ import com.gu.atom.play.AtomAPIActions
 import com.gu.contentatom.thrift.{ContentAtomEvent, EventType}
 import com.gu.media.Capi
 import com.gu.media.logging.Logging
-import com.gu.media.model.{Asset, PrivacyStatus}
+import com.gu.media.model.{Asset, ChangeRecord, ImageAsset, PrivacyStatus}
 import com.gu.media.youtube.YouTubeMetadataUpdate
 import com.gu.pandomainauth.model.{User => PandaUser}
 import data.DataStores

--- a/app/model/commands/UpdateAtomCommand.scala
+++ b/app/model/commands/UpdateAtomCommand.scala
@@ -8,8 +8,9 @@ import com.gu.pandomainauth.model.{User => PandaUser}
 import com.gu.media.logging.Logging
 import data.DataStores
 import model.commands.CommandExceptions._
-import model.{ChangeRecord, MediaAtom}
+import model.MediaAtom
 import util.atom.MediaAtomImplicits
+import com.gu.media.model.ChangeRecord
 
 import scala.util.{Failure, Success}
 

--- a/common/src/main/scala/com/gu/media/model/ChangeRecord.scala
+++ b/common/src/main/scala/com/gu/media/model/ChangeRecord.scala
@@ -1,9 +1,9 @@
-package model
+package com.gu.media.model
 
 import com.gu.contentatom.thrift.{ChangeRecord => ThriftChangeRecord}
+import com.gu.pandomainauth.model.{User => PandaUser}
 import org.cvogt.play.json.Jsonx
 import org.joda.time.DateTime
-import com.gu.pandomainauth.model.{User => PandaUser}
 import play.api.libs.json.Format
 
 case class ChangeRecord(date: DateTime, user: Option[User]) {

--- a/common/src/main/scala/com/gu/media/model/ContentChangeDetails.scala
+++ b/common/src/main/scala/com/gu/media/model/ContentChangeDetails.scala
@@ -1,4 +1,4 @@
-package model
+package com.gu.media.model
 
 import com.gu.contentatom.thrift.{ContentChangeDetails => ThriftContentChangeDetails}
 import org.cvogt.play.json.Jsonx

--- a/common/src/main/scala/com/gu/media/model/Image.scala
+++ b/common/src/main/scala/com/gu/media/model/Image.scala
@@ -1,7 +1,7 @@
-package model
+package com.gu.media.model
 
-import org.cvogt.play.json.Jsonx
 import com.gu.contentatom.thrift.{Image => ThriftImage, ImageAsset => ThriftImageAsset, ImageAssetDimensions => ThriftImageAssetDimensions}
+import org.cvogt.play.json.Jsonx
 
 case class ImageAssetDimensions(height: Int, width: Int) {
   def asThrift = ThriftImageAssetDimensions(height, width)

--- a/common/src/main/scala/com/gu/media/model/User.scala
+++ b/common/src/main/scala/com/gu/media/model/User.scala
@@ -1,4 +1,4 @@
-package model
+package com.gu.media.model
 
 import com.gu.contentatom.thrift.{User => ThriftUser}
 import org.cvogt.play.json.Jsonx

--- a/common/src/main/scala/com/gu/media/upload/model/UploadCredentials.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadCredentials.scala
@@ -8,3 +8,7 @@ case class UploadCredentials(temporaryAccessId: String, temporarySecretKey: Stri
 object UploadCredentials {
   implicit val format: Format[UploadCredentials] = Jsonx.formatCaseClass[UploadCredentials]
 }
+
+case class UploadCredentialsRequest (
+  atomId: String
+)

--- a/common/src/main/scala/com/gu/media/util/MediaAtomHelpers.scala
+++ b/common/src/main/scala/com/gu/media/util/MediaAtomHelpers.scala
@@ -15,12 +15,16 @@ object MediaAtomHelpers {
     )
   }
 
-  def getNextAssetVersion(mediaAtom: MediaAtom): Long = {
+  def getCurrentAssetVersion(mediaAtom: MediaAtom): Option[Long] = {
     if (mediaAtom.assets.isEmpty) {
-      1
+      None
     } else {
-      mediaAtom.assets.map(_.version).max + 1
+      Some(mediaAtom.assets.map(_.version).max)
     }
+  }
+
+  def getNextAssetVersion(mediaAtom: MediaAtom): Long = {
+    getCurrentAssetVersion(mediaAtom).getOrElse(0L) + 1
   }
 
   def addAsset(mediaAtom: MediaAtom, asset: VideoAsset, version: Long): MediaAtom = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,7 +82,7 @@ object Dependencies {
   val partnerApiDepencies = Seq(guava, googleHttpJackson, googleOauth, googleBugs, googleHttp, commonsLogging,
     apacheHttpClient, apacheHttpCore)
 
-  val commonDependencies = googleApi ++ atomMaker ++ Seq(
+  val commonDependencies = panda ++ googleApi ++ atomMaker ++ Seq(
     typesafeConfig, awsLambdaCore, awsS3, awsDynamo, playJsonExtensions, logstashLogbackEncoder, kinesisLogbackAppender,
     awsTranscoder, scanamo, okHttp, scalaTest, scalaCheck, awsSQS, awsSNS, permissionsClient, awsStepFunctions, awsSES
   ) ++ partnerApiDepencies


### PR DESCRIPTION
move the following models out of `app` and into `common`:
- `User`
- `ChangeRecord`
- `ContentChangeDetails`
- `Image`

allows for code-reuse and less 🤕

other model movement upcoming!