### PR TITLE
get more space by using more icons

### DIFF
--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -96,7 +96,7 @@ export default class Header extends React.Component {
           className="button__secondary"
           to={auditLink}
         >
-          View audit trail
+          <Icon icon="history">View audit trail</Icon>
         </Link>
       </nav>
     );

--- a/public/video-ui/src/components/Videos/AdvancedActions.js
+++ b/public/video-ui/src/components/Videos/AdvancedActions.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { getStore } from '../../util/storeAccessor';
+import Icon from '../Icon';
 
 export default class AdvancedActions extends React.Component {
   static propTypes = {
@@ -45,7 +46,9 @@ export default class AdvancedActions extends React.Component {
             onClick={doDelete}
             disabled={disabled}
           >
-            {deleteMsg}
+            <Icon icon={this.state.deleteDoubleCheck ? 'delete_forever' : 'delete'}>
+              {deleteMsg}
+            </Icon>
           </button>
         </span>
       </li>

--- a/public/video-ui/src/components/Videos/ComposerPageCreate.js
+++ b/public/video-ui/src/components/Videos/ComposerPageCreate.js
@@ -58,10 +58,14 @@ export default class ComposerPageCreate extends React.Component {
   render() {
     const { canonicalVideoPageExists, videoEditOpen, requiredComposerFieldsMissing } = this.props;
     const showOpenPage = canonicalVideoPageExists() || this.isHosted();
-    
+
     if (showOpenPage) {
-      return <a className="button__secondary" href={this.getComposerLink()} target="_blank">Open in Composer</a>;
-    } 
+      return (
+        <a className="button__secondary" href={this.getComposerLink()} target="_blank">
+          <Icon icon="pageview">Open in Composer</Icon>
+        </a>
+      );
+    }
     else {
       return (
         <button
@@ -69,7 +73,7 @@ export default class ComposerPageCreate extends React.Component {
           onClick={this.pageCreate}
           disabled={videoEditOpen || this.state.composerUpdateInProgress || requiredComposerFieldsMissing()}
         >
-          <span><Icon icon="add_to_queue" /> Create Video Page</span>
+          <Icon icon="add_to_queue">Create Video Page</Icon>
         </button>
       );
     }


### PR DESCRIPTION
icons are responsive, so on a small screen the text is hidden, giving more real estate to use

Before
![image](https://user-images.githubusercontent.com/836140/32384423-c0b4d328-c0b2-11e7-978e-035811ddc8a7.png)

After
![image](https://user-images.githubusercontent.com/836140/32384402-b2aa2b3e-c0b2-11e7-9f9b-2ff7da672e5c.png)
