### PR TITLE
default source field to The Guardian

### DIFF
--- a/public/video-ui/src/constants/blankVideoData.js
+++ b/public/video-ui/src/constants/blankVideoData.js
@@ -19,5 +19,6 @@ export const blankVideoData = {
   },
   trailImage: {
     assets: []
-  }
+  },
+  source: 'The Guardian'
 };

--- a/public/video-ui/src/reducers/videoReducer.js
+++ b/public/video-ui/src/reducers/videoReducer.js
@@ -4,7 +4,7 @@ export default function video(state = null, action) {
   switch (action.type) {
     case 'VIDEO_GET_RECEIVE':
       return action.video
-        ? Object.assign({}, blankVideoData, action.video)
+        ? Object.assign({}, blankVideoData, {source: null}, action.video)
         : false;
 
     case 'VIDEO_CREATE_RECEIVE':


### PR DESCRIPTION
This is frequently requested. Defaulting means a faster workflow and fewer mistakes.

Create page now looks like this:
![image](https://user-images.githubusercontent.com/836140/32385865-54ccae6a-c0b7-11e7-8ff5-ab0cbf2dacf2.png)
