### PR TITLE
simplify SSA lookup in DEV

### DIFF
--- a/common/src/main/scala/com/gu/media/aws/AwsAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/AwsAccess.scala
@@ -18,8 +18,9 @@ trait AwsAccess { this: Settings =>
     .getOrElse(defaultRegion)
 
   // These are injected as environment variables when running in a Lambda (unfortunately they cannot be tagged)
-  final val stack: Option[String] = readTag("Stack")
-  final val app: String = readTag("App").getOrElse("media-atom-maker")
-  final val stage: String = readTag("Stage").getOrElse("DEV")
+  final val stage = sys.env.getOrElse("STAGE", readTag("Stage").getOrElse("DEV"))
   final val isDev: Boolean = stage == "DEV"
+
+  final val stack: Option[String] = if (isDev) Some("media-atom-maker") else readTag("Stack")
+  final val app: String = if (isDev) "media-atom-maker" else readTag("App").getOrElse("media-atom-maker")
 }

--- a/sbt
+++ b/sbt
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export STAGE=DEV
+
 # Debug option
 DEBUG_PARAMS=""
 for arg in "$@"


### PR DESCRIPTION
- get stage from envvar first, falling back to tag
- get stack and app in relation to stage

It was a little tricky testing https://github.com/guardian/kinesis-logback-appender/pull/17 otherwise as had to hardcode the values.