### PR TITLE
Fix video uploads from file

### DIFF
--- a/public/video-ui/src/util/video.js
+++ b/public/video-ui/src/util/video.js
@@ -80,14 +80,12 @@ export default class VideoUtils {
   }
 
   static isRecentlyModified({ contentChangeDetails }) {
-    if (!contentChangeDetails) {
-      return false;
+    if (contentChangeDetails && contentChangeDetails.lastModified) {
+      const lastModified = moment(contentChangeDetails.lastModified.date);
+      const diff = moment().diff(lastModified, 'days');
+      return diff < 1;
     }
-
-    const lastModified = moment(contentChangeDetails.lastModified.date);
-    const diff = moment().diff(lastModified, 'days');
-
-    return diff < 1;
+    return false;
   }
 
   static getScheduledLaunch({ contentChangeDetails }) {


### PR DESCRIPTION
This fixes a client side error that occurred with direct uploads. The error was due to having transformed `contentChangeDetails` into a required field in #657, which subsequently broke a javascript condition.