### PR TITLE
go back to previous version of aws libs

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import play.sbt.PlayImport
 
 object Dependencies {
   val scroogeVersion = "4.12.0"
-  val awsVersion = "1.11.227"
+  val awsVersion = "1.11.125"
   val pandaVersion = "0.4.0"
   val mockitoVersion = "2.0.97-beta"
   val atomMakerVersion = "1.1.9"


### PR DESCRIPTION
Some of the PROD boxes were trying to access a DEV table, as the table name is derived from the stage tag. For some reason, the box failed to read the stage tag and defaulted to `DEV`.

Reverting the aws bump to make sure the other library bumps of #674 are ok