### PR TITLE
fetch more tags from capi

### DIFF
--- a/public/video-ui/src/services/capi.js
+++ b/public/video-ui/src/services/capi.js
@@ -59,7 +59,7 @@ export default class ContentApi {
         }
         const encodedQuery = encodeURIComponent(query);
         return pandaReqwest({
-          url: `${ContentApi.proxyUrl}/tags?page-size=100&type=${type}&web-title=${encodedQuery}`
+          url: `${ContentApi.proxyUrl}/tags?page-size=200&type=${type}&web-title=${encodedQuery}`
         });
       })
     );


### PR DESCRIPTION
Turns out that 100 is not big enough page size to find tags with very short but common names, for example, London. A large number of tags with the search term in the title get returned but not necessarily the the tag that was looked for.