### PR TITLE
Privacy status

### DIFF
--- a/app/controllers/Youtube.scala
+++ b/app/controllers/Youtube.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import com.gu.media.youtube.YouTubeChannel
 import com.gu.pandahmac.HMACAuthActions
 import play.api.libs.json.Json
 import play.api.mvc.Controller
@@ -15,11 +16,13 @@ class Youtube (val authActions: HMACAuthActions, youtube: YouTube) extends Contr
 
   def listChannels() = AuthAction { req =>
     val isTrainingMode = isInTrainingMode(req)
+    val user = req.user
 
     val channels = if (isTrainingMode) {
-      youtube.channels.filter(c => youtube.trainingChannels.contains(c.id))
+
+      youtube.channelsWithData.filter(c => youtube.trainingChannels.contains(c.id))
     } else {
-      youtube.channels.filter(c => youtube.allChannels.contains(c.id))
+      youtube.channelsWithData.filter(c => youtube.allChannels.contains(c.id))
     }
 
     Ok(Json.toJson(channels))

--- a/app/controllers/Youtube.scala
+++ b/app/controllers/Youtube.scala
@@ -6,26 +6,32 @@ import play.api.libs.json.Json
 import play.api.mvc.Controller
 import util.{TrainingMode, YouTube}
 import model.commands.CommandExceptions._
+import com.gu.media.MediaAtomMakerPermissionsProvider
+import scala.concurrent.ExecutionContext.Implicits.global
 
-class Youtube (val authActions: HMACAuthActions, youtube: YouTube) extends Controller with TrainingMode {
+class Youtube (val authActions: HMACAuthActions, youtube: YouTube, permissions: MediaAtomMakerPermissionsProvider)
+  extends Controller with TrainingMode {
   import authActions.AuthAction
 
   def listCategories() = AuthAction {
     Ok(Json.toJson(youtube.categories))
   }
 
-  def listChannels() = AuthAction { req =>
+  def listChannels() = AuthAction.async { req =>
     val isTrainingMode = isInTrainingMode(req)
     val user = req.user
 
-    val channels = if (isTrainingMode) {
+    permissions.getStatusPermissions(user.email).map(permissions => {
+      val setAllVideosPublic = permissions.setVideosOnAllChannelsPublic
 
-      youtube.channelsWithData.filter(c => youtube.trainingChannels.contains(c.id))
-    } else {
-      youtube.channelsWithData.filter(c => youtube.allChannels.contains(c.id))
-    }
+      val channels = if (isTrainingMode) {
+        youtube.channelsWithData(setAllVideosPublic).filter(c => youtube.trainingChannels.contains(c.id))
+      } else {
+        youtube.channelsWithData(setAllVideosPublic).filter(c => youtube.allChannels.contains(c.id))
+      }
 
-    Ok(Json.toJson(channels))
+      Ok(Json.toJson(channels))
+    })
   }
 
   def commercialVideoInfo(id: String) = AuthAction {

--- a/app/di.scala
+++ b/app/di.scala
@@ -54,7 +54,7 @@ class MediaAtomMaker(context: Context)
   private val uploads = new UploadController(hmacAuthActions, aws, stepFunctions, stores, permissions, youTube)
 
   private val support = new Support(hmacAuthActions, capi)
-  private val youTubeController = new Youtube(hmacAuthActions, youTube)
+  private val youTubeController = new Youtube(hmacAuthActions, youTube, permissions)
 
   private val pluto = new PlutoProjectController(hmacAuthActions, stores)
 

--- a/app/util/YouTube.scala
+++ b/app/util/YouTube.scala
@@ -5,7 +5,6 @@ import com.gu.media.model.PrivacyStatus
 import com.gu.media.youtube._
 import com.typesafe.config.Config
 import play.api.cache.CacheApi
-import com.gu.pandomainauth.model.{User => PandaUser}
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -17,12 +16,12 @@ trait YouTube extends Logging with YouTubeAccess with YouTubeVideos with YouTube
     cache.getOrElse("categories", duration) { super.categories }
   }
 
-  override def channels(): List[YouTubeChannel] = {
+  override def channels: List[YouTubeChannel] = {
     cache.getOrElse("channels", duration) { super.channels }
   }
 
-  override def channelsWithData(): List[YouTubeChannelWithData] = {
-    cache.getOrElse("channelsWithData", duration) { super.channelsWithData }
+  override def channelsWithData(setAllVideosPublic: Boolean): List[YouTubeChannelWithData] = {
+    super.channelsWithData(setAllVideosPublic)
   }
 
   def getCommercialVideoInfo(videoId: String) = {

--- a/app/util/YouTube.scala
+++ b/app/util/YouTube.scala
@@ -19,11 +19,7 @@ trait YouTube extends Logging with YouTubeAccess with YouTubeVideos with YouTube
   override def channels: List[YouTubeChannel] = {
     cache.getOrElse("channels", duration) { super.channels }
   }
-
-  override def channelsWithData(setAllVideosPublic: Boolean): List[YouTubeChannelWithData] = {
-    super.channelsWithData(setAllVideosPublic)
-  }
-
+  
   def getCommercialVideoInfo(videoId: String) = {
     getVideo(videoId, "snippet,contentDetails,status").map(video => {
       val channelId = video.getSnippet.getChannelId

--- a/app/util/YouTube.scala
+++ b/app/util/YouTube.scala
@@ -5,6 +5,7 @@ import com.gu.media.model.PrivacyStatus
 import com.gu.media.youtube._
 import com.typesafe.config.Config
 import play.api.cache.CacheApi
+import com.gu.pandomainauth.model.{User => PandaUser}
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -16,8 +17,12 @@ trait YouTube extends Logging with YouTubeAccess with YouTubeVideos with YouTube
     cache.getOrElse("categories", duration) { super.categories }
   }
 
-  override def channels: List[YouTubeChannel] = {
+  override def channels(): List[YouTubeChannel] = {
     cache.getOrElse("channels", duration) { super.channels }
+  }
+
+  override def channelsWithData(): List[YouTubeChannelWithData] = {
+    cache.getOrElse("channelsWithData", duration) { super.channelsWithData }
   }
 
   def getCommercialVideoInfo(videoId: String) = {

--- a/common/src/main/scala/com/gu/media/Permissions.scala
+++ b/common/src/main/scala/com/gu/media/Permissions.scala
@@ -7,24 +7,25 @@ import play.api.libs.json.Format
 
 import scala.concurrent.Future
 
-case class Permissions(deleteAtom: Boolean, addSelfHostedAsset: Boolean)
+case class Permissions(deleteAtom: Boolean, addSelfHostedAsset: Boolean, setVideosOnAllChannelsPublic: Boolean)
 object Permissions {
   implicit val format: Format[Permissions] = Jsonx.formatCaseClass[Permissions]
 
   val app = "atom-maker"
   val deleteAtom = Permission("delete_atom", app, defaultVal = PermissionDenied)
   val addSelfHostedAsset = Permission("add_self_hosted_asset", app, defaultVal = PermissionDenied)
+  val setVideosOnAllChannelsPublic = Permission("set_videos_on_all_channels_public", app, defaultVal = PermissionDenied)
 }
 
 class MediaAtomMakerPermissionsProvider(stage: String, credsProvider: AWSCredentialsProvider) extends PermissionsProvider {
   import Permissions._
 
-  val all = Seq(deleteAtom, addSelfHostedAsset)
-  val none = Permissions(deleteAtom = false, addSelfHostedAsset = false)
+  val all = Seq(deleteAtom, addSelfHostedAsset, setVideosOnAllChannelsPublic)
+  val none = Permissions(deleteAtom = false, addSelfHostedAsset = false, setVideosOnAllChannelsPublic = false )
 
   implicit def config = PermissionsConfig(
     app = "media-atom-maker",
-    all = Seq(deleteAtom, addSelfHostedAsset),
+    all = Seq(deleteAtom, addSelfHostedAsset, setVideosOnAllChannelsPublic),
     s3BucketPrefix = if(stage == "PROD") "PROD" else "CODE",
     awsCredentials = credsProvider
   )
@@ -32,13 +33,20 @@ class MediaAtomMakerPermissionsProvider(stage: String, credsProvider: AWSCredent
   def getAll(email: String): Future[Permissions] = for {
     deleteAtom <- hasPermission(deleteAtom, email)
     selfHostedMediaAtom <- hasPermission(addSelfHostedAsset, email)
-  } yield Permissions(deleteAtom, selfHostedMediaAtom)
+    publicStatusPermissions <- hasPermission(setVideosOnAllChannelsPublic, email)
+  } yield Permissions(deleteAtom, selfHostedMediaAtom, publicStatusPermissions)
 
 
   def getUploadPermissions(email: String): Future[Permissions] = for {
     selfHostedMediaAtom <- hasPermission(addSelfHostedAsset, email)
   } yield {
-    Permissions(deleteAtom = false, selfHostedMediaAtom)
+    Permissions(deleteAtom = false, selfHostedMediaAtom, setVideosOnAllChannelsPublic = false)
+  }
+
+  def getStatusPermissions(email: String): Future[Permissions] = for {
+    publicStatus <- hasPermission(setVideosOnAllChannelsPublic, email)
+  } yield {
+    Permissions(deleteAtom = false, addSelfHostedAsset = false, publicStatus)
   }
 
   private def hasPermission(permission: Permission, email: String): Future[Boolean] = {

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
@@ -72,15 +72,13 @@ trait YouTubeAccess extends Settings {
       .setManagedByMe(true)
       .setOnBehalfOfContentOwner(contentOwner)
 
-    val channels =  request.execute().getItems.asScala.toList
-
     request.execute().getItems.asScala.toList
       .map(YouTubeChannel.build(this, _))
   }
 
-  def channelsWithData: List[YouTubeChannelWithData] = {
-    channels.map(channel => YouTubeChannelWithData.build(this, channel.id, channel.title))
-    .sortBy(_.title)
+  def channelsWithData(setAllVideosPublic: Boolean): List[YouTubeChannelWithData] = {
+    channels.map(channel => YouTubeChannelWithData.build(this, channel.id, channel.title, setAllVideosPublic))
+      .sortBy(_.title)
   }
 
   def accessToken(): String = {

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
@@ -72,9 +72,15 @@ trait YouTubeAccess extends Settings {
       .setManagedByMe(true)
       .setOnBehalfOfContentOwner(contentOwner)
 
+    val channels =  request.execute().getItems.asScala.toList
+
     request.execute().getItems.asScala.toList
       .map(YouTubeChannel.build(this, _))
-      .sortBy(_.title)
+  }
+
+  def channelsWithData: List[YouTubeChannelWithData] = {
+    channels.map(channel => YouTubeChannelWithData.build(this, channel.id, channel.title))
+    .sortBy(_.title)
   }
 
   def accessToken(): String = {

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -61,11 +61,30 @@ package object youtube {
     }
   }
 
+  case class YouTubeChannelWithData(
+     id: String,
+     title: String,
+     privacyStates: Set[PrivacyStatus] = PrivacyStatus.all,
+     isCommercial: Boolean
+  )
+
+  object YouTubeChannelWithData {
+    implicit val reads: Reads[YouTubeChannelWithData] = Json.reads[YouTubeChannelWithData]
+    implicit val writes: Writes[YouTubeChannelWithData] = Json.writes[YouTubeChannelWithData]
+
+    def build(youtubeAccess: YouTubeAccess, id: String, title: String): YouTubeChannelWithData = {
+      YouTubeChannelWithData(
+        id = id,
+        title = title,
+        privacyStates = if (youtubeAccess.strictlyUnlistedChannels.contains(id)) Set(PrivacyStatus.Unlisted, PrivacyStatus.Private) else PrivacyStatus.all,
+        isCommercial = youtubeAccess.commercialChannels.contains(id)
+      )
+    }
+  }
+
   case class YouTubeChannel(
     id: String,
-    title: String,
-    privacyStates: Set[PrivacyStatus] = PrivacyStatus.all,
-    isCommercial: Boolean
+    title: String
   )
 
   object YouTubeChannel {
@@ -82,9 +101,7 @@ package object youtube {
     def build(youtubeAccess: YouTubeAccess, id: String, title: String): YouTubeChannel = {
       YouTubeChannel(
         id = id,
-        title = title,
-        privacyStates = if (youtubeAccess.strictlyUnlistedChannels.contains(id)) Set(PrivacyStatus.Unlisted, PrivacyStatus.Private) else PrivacyStatus.all,
-        isCommercial = youtubeAccess.commercialChannels.contains(id)
+        title = title
       )
     }
   }

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -72,11 +72,17 @@ package object youtube {
     implicit val reads: Reads[YouTubeChannelWithData] = Json.reads[YouTubeChannelWithData]
     implicit val writes: Writes[YouTubeChannelWithData] = Json.writes[YouTubeChannelWithData]
 
-    def build(youtubeAccess: YouTubeAccess, id: String, title: String): YouTubeChannelWithData = {
+    private def getPrivacyStates(id: String, canSetAllVideosPublic: Boolean, youtubeAccess: YouTubeAccess): Set[PrivacyStatus] = {
+      if (youtubeAccess.strictlyUnlistedChannels.contains(id) && !canSetAllVideosPublic)
+        Set(PrivacyStatus.Unlisted, PrivacyStatus.Private)
+      else PrivacyStatus.all
+    }
+
+    def build(youtubeAccess: YouTubeAccess, id: String, title: String, setAllVideosPublic: Boolean): YouTubeChannelWithData = {
       YouTubeChannelWithData(
         id = id,
         title = title,
-        privacyStates = if (youtubeAccess.strictlyUnlistedChannels.contains(id)) Set(PrivacyStatus.Unlisted, PrivacyStatus.Private) else PrivacyStatus.all,
+        privacyStates = getPrivacyStates(id, setAllVideosPublic, youtubeAccess),
         isCommercial = youtubeAccess.commercialChannels.contains(id)
       )
     }

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -34,9 +34,9 @@ class VideoData extends React.Component {
     const isCommercialType = VideoUtils.isCommercialType(this.props.video);
     const hasAssets = VideoUtils.hasAssets(this.props.video);
     const isEligibleForAds = VideoUtils.isEligibleForAds(this.props.video);
-    const hasYoutubeWriteAccess = VideoUtils.hasYoutubeWriteAccess(this.props.video);
     const availableChannels = VideoUtils.getAvailableChannels(this.props.video);
     const availablePrivacyStates = VideoUtils.getAvailablePrivacyStates(this.props.video);
+    const hasYoutubeWriteAccess = VideoUtils.hasYoutubeWriteAccess(this.props.video, availablePrivacyStates);
 
     return (
       <div className="form__group">

--- a/public/video-ui/src/util/video.js
+++ b/public/video-ui/src/util/video.js
@@ -46,7 +46,10 @@ export default class VideoUtils {
     return stateChannels.find(_ => _.id === channelId);
   }
 
-  static hasYoutubeWriteAccess({ channelId }) {
+  static hasYoutubeWriteAccess({ channelId, privacyStatus }, availablePrivacyStates) {
+    if (!!privacyStatus && !availablePrivacyStates.includes(privacyStatus)) {
+      return false;
+    }
     return !!VideoUtils.getYoutubeChannel({ channelId });
   }
 


### PR DESCRIPTION
Determine the privacy statuses of a channel according to the permissions of the user. 

Not everything that needs a list of youtube channels needs to know about privacy statuses so this pr also separates adding additional data to the channels from fetching them from youtube and caching the results. 

See also:
https://github.com/guardian/permissions/pull/87