### PR TITLE
add line breaks to youtube description

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -172,9 +172,16 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youtu
   }
 
   private def removeHtmlTagsForYouTube(description: String): String = {
+
       val html = Jsoup.parse(description)
+
+      //Extracting the text removes line breaks
+      //We add them back in before each paragraph except
+      //for the first and before each list element
+      html.select("p:gt(0), li").prepend("\\n");
       html.select("a").unwrap()
-      html.text()
+      val text = html.text()
+      html.text().replace("\\n", "\n")
   }
 
   private def getComposerLinkText(atomId: String): String = {
@@ -190,7 +197,7 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youtu
     })
 
     composerPage match {
-      case Some(page) => "\n View the video at https://www.theguardian.com/" + page
+      case Some(page) => "\nView the video at https://www.theguardian.com/" + page
       case None => ""
     }
   }
@@ -200,7 +207,7 @@ case class PublishAtomCommand(id: String, override val stores: DataStores, youtu
     val description = previewAtom.description.map(description => {
       removeHtmlTagsForYouTube(description) + getComposerLinkText(previewAtom.id)
     })
-
+    
     val metadata = YouTubeMetadataUpdate(
       title = Some(previewAtom.title),
       categoryId = previewAtom.youtubeCategoryId,


### PR DESCRIPTION
When we are extracting the text from the html, we also break the formatting of the text. This pr makes sure that we add a newline on top of each paragraph (except for the first) and list item to preserve line breaks. I have confirmed with Adam that descriptions don't start with a list so we don't have to worry about adding an extra newline to descriptions starting with a list.