### PR TITLE
fix expiry cron schedule in cloudformation

### DIFF
--- a/cloudformation/media-atom-maker.yaml
+++ b/cloudformation/media-atom-maker.yaml
@@ -518,7 +518,7 @@ Resources:
   ExpirerLambdaTrigger:
     Type: AWS::Events::Rule
     Properties:
-      ScheduleExpression: cron(0/1 * * * ? *)
+      ScheduleExpression: cron(0/15 * * * ? *)
       Targets:
       - Arn: !GetAtt [ExpirerLambda, Arn]
         Id: ExpirerLambda


### PR DESCRIPTION
Do this in cloudformation. This also allows us to fix it for code as well which seems to go over quota occasionally.