### PR TITLE
add higher opacity

### DIFF
--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -417,5 +417,5 @@ progress::-moz-progress-bar {
 }
 
 .form-element--hidden {
-  opacity: 0.1;
+  opacity: 0.3;
 }


### PR DESCRIPTION
It's difficult to see the disabled fields in mam - this should make them a bit more visible.
![screen shot 2017-11-17 at 12 03 24](https://user-images.githubusercontent.com/3066534/32946874-329fe6b0-cb91-11e7-89e0-7250d28cee89.png)
