### PR TITLE
Revert "default source field to The Guardian"

### DIFF
--- a/public/video-ui/src/constants/blankVideoData.js
+++ b/public/video-ui/src/constants/blankVideoData.js
@@ -22,6 +22,5 @@ export const blankVideoData = {
   },
   trailImage: {
     assets: []
-  },
-  source: 'The Guardian'
+  }
 };

--- a/public/video-ui/src/reducers/videoReducer.js
+++ b/public/video-ui/src/reducers/videoReducer.js
@@ -4,7 +4,7 @@ export default function video(state = null, action) {
   switch (action.type) {
     case 'VIDEO_GET_RECEIVE':
       return action.video
-        ? Object.assign({}, blankVideoData, {source: null}, action.video)
+        ? Object.assign({}, blankVideoData, action.video)
         : false;
 
     case 'VIDEO_CREATE_RECEIVE':


### PR DESCRIPTION
Reverts guardian/media-atom-maker#668

Katie has expressed this is causing more problems than its benefit:

> Hey dude 
Please can you undo. 
Its causing more problems 
I'd rather have it blank than say The Guardian when it's not supposed to. 