### PR TITLE
more verbose WF section message

### DIFF
--- a/public/video-ui/src/actions/WorkflowActions/getSections.js
+++ b/public/video-ui/src/actions/WorkflowActions/getSections.js
@@ -18,7 +18,7 @@ function receiveSections(sections) {
 function errorReceivingSections(error) {
   return {
     type: 'SHOW_ERROR',
-    message: 'Could not get Workflow sections',
+    message: `Could not get Workflow sections. <a href="${WorkflowApi.workflowUrl}" target="_blank" rel="noopener">Open Workflow to get a cookie.</a>`,
     error: error,
     receivedAt: Date.now()
   };


### PR DESCRIPTION
add link to open Workflow to get a new cookie for auth

because opening a new tab and typing in the workflow url is too much effort 😜 

![image](https://user-images.githubusercontent.com/836140/33026803-2e2bf3ba-ce09-11e7-83ce-d19cb586ea69.png)

![img](https://media.giphy.com/media/EKUvB9uFnm2Xe/giphy.gif)