### PR TITLE
refactor Public Permissions

### DIFF
--- a/app/controllers/Api2.scala
+++ b/app/controllers/Api2.scala
@@ -69,7 +69,7 @@ class Api2 (override val stores: DataStores, conf: Configuration, override val a
   }
 
   def publishMediaAtom(id: String) = APIAuthAction.async { implicit req =>
-      val command = PublishAtomCommand(id, stores, youtube, req.user, capi)
+      val command = PublishAtomCommand(id, stores, youtube, req.user, capi, permissions)
 
       val updatedAtom: Future[MediaAtom] = command.process()
 

--- a/app/controllers/Youtube.scala
+++ b/app/controllers/Youtube.scala
@@ -22,12 +22,12 @@ class Youtube (val authActions: HMACAuthActions, youtube: YouTube, permissions: 
     val user = req.user
 
     permissions.getStatusPermissions(user.email).map(permissions => {
-      val setAllVideosPublic = permissions.setVideosOnAllChannelsPublic
+      val hasMakePublicPermission = permissions.setVideosOnAllChannelsPublic
 
       val channels = if (isTrainingMode) {
-        youtube.channelsWithData(setAllVideosPublic).filter(c => youtube.trainingChannels.contains(c.id))
+        youtube.channelsWithData(hasMakePublicPermission).filter(c => youtube.trainingChannels.contains(c.id))
       } else {
-        youtube.channelsWithData(setAllVideosPublic).filter(c => youtube.allChannels.contains(c.id))
+        youtube.channelsWithData(hasMakePublicPermission).filter(c => youtube.allChannels.contains(c.id))
       }
 
       Ok(Json.toJson(channels))

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
@@ -15,9 +15,9 @@ trait YouTubeAccess extends Settings {
   def contentOwner: String = getMandatoryString("youtube.contentOwner")
 
   val allowedChannels: Set[String] = getStringSet("youtube.channels.allowed")
-  val strictlyUnlistedChannels: Set[String] = getStringSet("youtube.channels.unlisted")
+  val unlistedWithoutPermissionChannels: Set[String] = getStringSet("youtube.channels.unlisted")
   val commercialChannels: Set[String] = getStringSet("youtube.channels.commercial")
-  val allChannels: Set[String] = allowedChannels ++ strictlyUnlistedChannels ++ commercialChannels
+  val allChannels: Set[String] = allowedChannels ++ unlistedWithoutPermissionChannels ++ commercialChannels
 
   val trainingChannels: Set[String] = getStringSet("youtube.channels.training")
 
@@ -76,8 +76,8 @@ trait YouTubeAccess extends Settings {
       .map(YouTubeChannel.build(this, _))
   }
 
-  def channelsWithData(setAllVideosPublic: Boolean): List[YouTubeChannelWithData] = {
-    channels.map(channel => YouTubeChannelWithData.build(this, channel.id, channel.title, setAllVideosPublic))
+  def channelsWithData(hasMakePublicPermission: Boolean): List[YouTubeChannelWithData] = {
+    channels.map(channel => YouTubeChannelWithData.build(this, channel.id, channel.title, hasMakePublicPermission))
       .sortBy(_.title)
   }
 

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -72,17 +72,19 @@ package object youtube {
     implicit val reads: Reads[YouTubeChannelWithData] = Json.reads[YouTubeChannelWithData]
     implicit val writes: Writes[YouTubeChannelWithData] = Json.writes[YouTubeChannelWithData]
 
-    private def getPrivacyStates(id: String, canSetAllVideosPublic: Boolean, youtubeAccess: YouTubeAccess): Set[PrivacyStatus] = {
-      if (youtubeAccess.strictlyUnlistedChannels.contains(id) && !canSetAllVideosPublic)
-        Set(PrivacyStatus.Unlisted, PrivacyStatus.Private)
-      else PrivacyStatus.all
+    private def getPrivacyStates(id: String, hasMakePublicPermission: Boolean, youtubeAccess: YouTubeAccess): Set[PrivacyStatus] = {
+      if (!youtubeAccess.unlistedWithoutPermissionChannels.contains(id)) {
+        PrivacyStatus.all
+      } else {
+        if (hasMakePublicPermission) PrivacyStatus.all else Set(PrivacyStatus.Unlisted, PrivacyStatus.Private)
+      }
     }
 
-    def build(youtubeAccess: YouTubeAccess, id: String, title: String, setAllVideosPublic: Boolean): YouTubeChannelWithData = {
+    def build(youtubeAccess: YouTubeAccess, id: String, title: String, hasMakePublicPermission: Boolean): YouTubeChannelWithData = {
       YouTubeChannelWithData(
         id = id,
         title = title,
-        privacyStates = getPrivacyStates(id, setAllVideosPublic, youtubeAccess),
+        privacyStates = getPrivacyStates(id, hasMakePublicPermission, youtubeAccess),
         isCommercial = youtubeAccess.commercialChannels.contains(id)
       )
     }


### PR DESCRIPTION
Currently, you need permission to make a video Public on YouTube. This means if you've got permission to make a public video on the culture channel, you can also make it public on the main channel.

This PR changes that so you can always upload as Public unless the channel is in the `youtube.channels.unlisted` config, in which case you need permission.

This means we can give the general user the ability to upload as Public on the culture channel and grant specific people access to make a public video on the main channel.

If the user tries to publish an atom as public and they don't have permissions, it will be set as unlisted.