### PR TITLE
Av expiry date new

### DIFF
--- a/app/data/AtomListStore.scala
+++ b/app/data/AtomListStore.scala
@@ -44,7 +44,7 @@ class CapiBackedAtomListStore(capi: CapiAccess) extends AtomListStore {
     else {
       val posterImage = (atom \ "posterImage").asOpt[Image]
 
-      val expiryDate = (wrapper \ "contentChangeDetails" \ "expiry" \ "date").asOpt[Long]
+      val expiryDate = (atom \ "expiryDate").asOpt[Long]
       val activeVersion = (atom \ "activeVersion").asOpt[Long]
 
 

--- a/app/data/AtomListStore.scala
+++ b/app/data/AtomListStore.scala
@@ -44,7 +44,7 @@ class CapiBackedAtomListStore(capi: CapiAccess) extends AtomListStore {
     else {
       val posterImage = (atom \ "posterImage").asOpt[Image]
 
-      val expiryDate = (atom \ "expiryDate").asOpt[Long]
+      val expiryDate = (wrapper \ "contentChangeDetails" \ "expiry" \ "date").asOpt[Long]
       val activeVersion = (atom \ "activeVersion").asOpt[Long]
 
 

--- a/app/model/commands/CreateAtomCommand.scala
+++ b/app/model/commands/CreateAtomCommand.scala
@@ -27,12 +27,14 @@ case class CreateAtomCommand(data: MediaAtomBeforeCreation, override val stores:
     val atomId = randomUUID().toString
     val createdChangeRecord = Some(ChangeRecord.now(user))
     val scheduledLaunchDate: Option[DateTime] = data.contentChangeDetails.scheduledLaunch.map(scheduledLaunch => new DateTime(scheduledLaunch.date))
+    val expiry: Option[DateTime] = data.contentChangeDetails.expiry.map(expiry => new DateTime(expiry.date))
     val details = media.model.ContentChangeDetails(
       lastModified = createdChangeRecord,
       created = createdChangeRecord,
       published = None,
       revision = 1L,
-      scheduledLaunch = scheduledLaunchDate.map(ChangeRecord.build(_, user))
+      scheduledLaunch = scheduledLaunchDate.map(ChangeRecord.build(_, user)),
+      expiry = expiry.map(ChangeRecord.build(_, user))
     )
 
     log.info(s"Request to create new atom $atomId [${data.title}]")

--- a/app/model/commands/CreateAtomCommand.scala
+++ b/app/model/commands/CreateAtomCommand.scala
@@ -27,7 +27,7 @@ case class CreateAtomCommand(data: MediaAtomBeforeCreation, override val stores:
     val atomId = randomUUID().toString
     val createdChangeRecord = Some(ChangeRecord.now(user))
     val scheduledLaunchDate: Option[DateTime] = data.contentChangeDetails.scheduledLaunch.map(scheduledLaunch => new DateTime(scheduledLaunch.date))
-    val expiry: Option[DateTime] = data.contentChangeDetails.expiry.map(expiry => new DateTime(expiry.date))
+    val expiry: Option[DateTime] = data.expiryDate.map(expiry => new DateTime(expiry))
     val details = media.model.ContentChangeDetails(
       lastModified = createdChangeRecord,
       created = createdChangeRecord,

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -265,8 +265,6 @@ case class PublishAtomCommand(
   }
 
   private def updateInactiveAssets(atom: MediaAtom): Unit = {
-    val nowMillis = Instant.now().toEpochMilli
-    val expired = atom.expiryDate.exists(_ < nowMillis)
 
     MediaAtom.getActiveYouTubeAsset(atom).foreach { activeAsset =>
       val youTubeAssets = atom.assets.filter(_.platform == Youtube)

--- a/app/model/commands/UpdateAtomCommand.scala
+++ b/app/model/commands/UpdateAtomCommand.scala
@@ -36,7 +36,7 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom, override val stores: D
     val changeRecord = ChangeRecord.now(user)
 
     val scheduledLaunchDate: Option[DateTime] = atom.contentChangeDetails.scheduledLaunch.map(scheduledLaunch => new DateTime(scheduledLaunch.date))
-    val expiry: Option[DateTime] = atom.contentChangeDetails.expiry.map(expiry => new DateTime(expiry.date))
+    val expiry: Option[DateTime] = atom.expiryDate.map(expiry => new DateTime(expiry))
 
     val details = atom.contentChangeDetails.copy(
       revision = existingAtom.contentChangeDetails.revision + 1,

--- a/app/model/commands/UpdateAtomCommand.scala
+++ b/app/model/commands/UpdateAtomCommand.scala
@@ -36,11 +36,13 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom, override val stores: D
     val changeRecord = ChangeRecord.now(user)
 
     val scheduledLaunchDate: Option[DateTime] = atom.contentChangeDetails.scheduledLaunch.map(scheduledLaunch => new DateTime(scheduledLaunch.date))
+    val expiry: Option[DateTime] = atom.contentChangeDetails.expiry.map(expiry => new DateTime(expiry.date))
 
     val details = atom.contentChangeDetails.copy(
       revision = existingAtom.contentChangeDetails.revision + 1,
       lastModified = Some(changeRecord),
-      scheduledLaunch = scheduledLaunchDate.map(ChangeRecord.build(_, user))
+      scheduledLaunch = scheduledLaunchDate.map(ChangeRecord.build(_, user)),
+      expiry = expiry.map(ChangeRecord.build(_, user))
     )
     val thrift = atom.copy(contentChangeDetails = details).asThrift
 

--- a/common/src/main/scala/com/gu/media/model/ContentChangeDetails.scala
+++ b/common/src/main/scala/com/gu/media/model/ContentChangeDetails.scala
@@ -8,9 +8,10 @@ case class ContentChangeDetails(
   created: Option[ChangeRecord],
   published: Option[ChangeRecord],
   revision: Long,
-  scheduledLaunch: Option[ChangeRecord]
+  scheduledLaunch: Option[ChangeRecord],
+  expiry: Option[ChangeRecord]
 ) {
-    def asThrift = ThriftContentChangeDetails(lastModified.map(_.asThrift), created.map(_.asThrift), published.map(_.asThrift), revision, scheduledLaunch = scheduledLaunch.map(_.asThrift))
+    def asThrift = ThriftContentChangeDetails(lastModified.map(_.asThrift), created.map(_.asThrift), published.map(_.asThrift), revision, scheduledLaunch = scheduledLaunch.map(_.asThrift), expiry = expiry.map(_.asThrift))
 }
 
 object ContentChangeDetails {
@@ -21,6 +22,7 @@ object ContentChangeDetails {
     ccd.created.map(ChangeRecord.fromThrift),
     ccd.published.map(ChangeRecord.fromThrift),
     ccd.revision,
-    ccd.scheduledLaunch.map(ChangeRecord.fromThrift)
+    ccd.scheduledLaunch.map(ChangeRecord.fromThrift),
+    ccd.expiry.map(ChangeRecord.fromThrift)
   )
 }

--- a/common/src/main/scala/com/gu/media/util/JsonConversions.scala
+++ b/common/src/main/scala/com/gu/media/util/JsonConversions.scala
@@ -134,14 +134,16 @@ object JsonConversions {
     (__ \ "created").writeNullable[ChangeRecord] and
     (__ \ "published").writeNullable[ChangeRecord] and
     (__ \ "revision").write[Long] and
-    (__ \ "scheduledLaunch").writeNullable[ChangeRecord]
+    (__ \ "scheduledLaunch").writeNullable[ChangeRecord] and
+    (__ \ "expiry").writeNullable[ChangeRecord]
     ) { contentChangeDetails: ContentChangeDetails =>
     (
       contentChangeDetails.lastModified,
       contentChangeDetails.created,
       contentChangeDetails.published,
       contentChangeDetails.revision,
-      contentChangeDetails.scheduledLaunch
+      contentChangeDetails.scheduledLaunch,
+      contentChangeDetails.expiry
       )
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val awsVersion = "1.11.125"
   val pandaVersion = "0.4.0"
   val mockitoVersion = "2.0.97-beta"
-  val atomMakerVersion = "1.1.9"
+  val atomMakerVersion = "1.1.15"
   val slf4jVersion = "1.7.21"
   val typesafeConfigVersion = "1.3.0" // to match what we get from Play transitively
   val scanamoVersion = "0.9.1" // to match what we get from atom-publisher-lib transitively

--- a/test/ThriftUtilSpec.scala
+++ b/test/ThriftUtilSpec.scala
@@ -57,7 +57,7 @@ class ThriftUtilSpec extends FunSpec
           inside(atom) {
             case Atom(_, AtomType.Media, Nil, defaultHtml, _, changeDetails, None, _, _) =>
               changeDetails should matchPattern {
-                case ContentChangeDetails(None, None, None, 1L, None, None) =>
+                case ContentChangeDetails(None, None, None, 1L, None, None, None, None) =>
               }
 
               val iframe = Jsoup.parse(defaultHtml).getElementsByTag("iframe")


### PR DESCRIPTION
- Add expiry field to `contentChangeDetails`
- Keep `atom.contentChangeDetails.expiry.date` and `atom.expiryDate` in sync server side
