### PR TITLE
Fix video status logic in AtomListStore.scala

### DIFF
--- a/app/data/AtomListStore.scala
+++ b/app/data/AtomListStore.scala
@@ -44,11 +44,12 @@ class CapiBackedAtomListStore(capi: CapiAccess) extends AtomListStore {
     else {
       val posterImage = (atom \ "posterImage").asOpt[Image]
 
-      val expiryDate = (atom \ "expiryDate").asOpt[Long]
       val activeVersion = (atom \ "activeVersion").asOpt[Long]
 
 
       val contentChangeDetails = (wrapper \ "contentChangeDetails").as[ContentChangeDetails]
+
+      val expiryDate = (wrapper \ "contentChangeDetails" \ "expiry" \ "date").asOpt[Long]
 
       val versions = (atom \ "assets").as[JsArray].value.map { asset =>
         (asset \ "version").as[Long]


### PR DESCRIPTION
This fixes a bug with "Expired" labels not showing in the homepage of the video tool. The expiryDate hasn't been in the CAPI response and so it was not accessible in AtomListStore.scala. This change fixes the problem for atoms with an expiry date set after #699 (which adds the expiry field to `ContentChangeDetails`, which is present in the CAPI response and therefore can be used in AtomListStore). This is not going to work for atoms without an `expiry` key in their `ContentChangeDetails`field.