### PR TITLE
on update should always return a promise

### DIFF
--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -98,10 +98,12 @@ export default class TagPicker extends React.Component {
     this.setState({
       tagValue: newValue
     });
-    this.props.onUpdateField(tagsToStringList(newValue));
+    return this.props.onUpdateField(tagsToStringList(newValue))
+    .then(() => {
 
-    this.setState({
-      capiTags: []
+      return this.setState({
+        capiTags: []
+      });
     });
   };
 

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.js
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.js
@@ -103,9 +103,11 @@ export default class TextInputTagPicker extends React.Component {
 
           const newFieldValue = newInput ? this.props.tagValue.concat([newInput]) : this.props.tagValue;
 
-          this.props.onUpdate(newFieldValue);
-          this.setState({
-            inputString: '',
+          this.props.onUpdate(newFieldValue)
+          .then(() => {
+            this.setState({
+              inputString: '',
+            });
           });
         }
       }

--- a/public/video-ui/src/components/ManagedForm/ManagedField.js
+++ b/public/video-ui/src/components/ManagedForm/ManagedField.js
@@ -95,11 +95,11 @@ export class ManagedField extends React.Component {
 
     this.checkErrorsAndWarnings(newValue);
 
-    this.props.updateData(
+    return this.props.updateData(
       _set(this.props.fieldLocation, newValue === '' ? null : newValue, this.props.data)
     ).then(() => {
       if (this.props.updateSideEffects) {
-        this.props.updateSideEffects(this.props.data);
+        return this.props.updateSideEffects(this.props.data);
       }
     });
   };

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -41,6 +41,7 @@ class VideoDisplay extends React.Component {
 
   updateVideo = video => {
     this.props.videoActions.updateVideo(video);
+    return Promise.resolve();
   };
 
   composerKeywordsToYouTube = () => {


### PR DESCRIPTION
`onUpdate` sometimes only updates the video and does not save it so it wasn't always returning a promise and was throwing an error when we were assuming it was in `managedForm`. This pr makes sure that all `onUpdate` functions return promises.