### PR TITLE
reduce character count

### DIFF
--- a/public/video-ui/src/constants/youTubeKeywords.js
+++ b/public/video-ui/src/constants/youTubeKeywords.js
@@ -1,5 +1,5 @@
 export default class YouTubeKeywords {
   static get maxCharacters() {
-    return 500;
+    return 450;
   }
 }


### PR DESCRIPTION
Youtube only allow 500 chars in the tags field. For some reason, we're exceeding that even though we check it client side. I think this is because of the content bundle tag that we add server side.

Reducing the client side limit means we reserve space for the server side addition.