### PR TITLE
continue populating pluto table when no project selected

### DIFF
--- a/common/src/main/scala/com/gu/media/upload/PlutoUploadActions.scala
+++ b/common/src/main/scala/com/gu/media/upload/PlutoUploadActions.scala
@@ -16,6 +16,8 @@ class PlutoUploadActions(config: Settings with DynamoAccess with KinesisAccess w
         plutoData.projectId match {
           case Some(_) => sendKinesisMessage(plutoIntegrationData)
           case None => {
+            plutoStore.put(plutoData)
+            
             // TODO MRB: re-enable this once the project selector has been fixed
             //        log.info(s"Sending missing Pluto ID email user=${metadata.user} atom=${plutoData.atomId}")
             //
@@ -25,7 +27,6 @@ class PlutoUploadActions(config: Settings with DynamoAccess with KinesisAccess w
             //          config.fromEmailAddress,
             //          config.replyToAddresses)
             //
-            //        plutoStore.put(plutoData)
           }
         }
       }


### PR DESCRIPTION
the `pluto-list` endpoint renders items from this table, if there's nothing in the table, there are no atoms that need a pluto project

we probably need to manually fill this table now too 😢 