### PR TITLE
stricter capi query

### DIFF
--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -9,10 +9,10 @@ class Support(val authActions: HMACAuthActions, val capi: CapiAccess) extends Co
   import authActions.APIAuthAction
 
   def capiProxy(path: String, queryLive: Boolean) = APIAuthAction { request =>
-    val query = s"$path?${request.rawQueryString}"
+    val qs: Map[String, Seq[String]] = request.queryString
 
     try {
-      val result = capi.capiQuery(query, queryLive)
+      val result = capi.complexCapiQuery(path, qs, queryLive)
       Ok(result)
     } catch {
       case CapiException(err, _) =>

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -202,14 +202,14 @@ case class PublishAtomCommand(
   }
 
   private def getComposerLinkText(atomId: String): String = {
+    val path = s"/atom/media/$atomId/usage"
+    val emptyQs: Map[String, String] = Map()
 
-
-    val usages: JsValue = (capi.capiQuery("/atom/media/" + atomId + "/usage", true) \ "response" \ "results").get
+    val usages: JsValue = (capi.capiQuery(path, emptyQs, queryLive = true) \ "response" \ "results").get
     val usagesList = usages.as[List[String]]
 
     val composerPage = usagesList.find(usage => {
-      val query = capi.capiQuery(usage, true)
-      val contentType = (capi.capiQuery(usage, true) \ "response" \ "content" \ "type").get.as[String]
+      val contentType = (capi.capiQuery(usage, emptyQs, queryLive = true) \ "response" \ "content" \ "type").get.as[String]
       contentType == "video"
     })
 

--- a/expirer/src/test/scala/com/gu/media/ExpirerLambdaTest.scala
+++ b/expirer/src/test/scala/com/gu/media/ExpirerLambdaTest.scala
@@ -43,7 +43,7 @@ class ExpirerLambdaTest extends FunSuite with MustMatchers {
   class TestExpirerLambda(var capiResults: List[String], isMyVideo: Boolean = true) extends ExpirerLambda with TestSettings {
     var madePrivate = List.empty[String]
 
-    override def capiQuery(query: String, isLive: Boolean = false): JsValue = {
+    override def capiQuery(path: String, qs: Map[String, String], queryLive: Boolean = false): JsValue = {
       val ret = capiResults.head
       capiResults = capiResults.tail
 


### PR DESCRIPTION
use stricter types in the capi query interface

`Map[String, String]` is more comforting than `String`