### PR TITLE
observe schedule and embargo property on publish

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -49,7 +49,7 @@ case class PublishAtomCommand(
     val now = Instant.now().toEpochMilli
 
     (contentChangeDetails.scheduledLaunch, contentChangeDetails.embargo) match {
-      case (_, Some(embargo)) => {
+      case (_, Some(embargo)) if embargo.date > now => {
         log.error(s"Unable to publish atom with embargo date. atom=${previewAtom.id} embargo=${embargo.date}")
         AtomPublishFailed("Atom embargoed")
       }


### PR DESCRIPTION
- if embargo set, don't publish
- if schedule set for future, don't publish
- if schedule < embargo, don't publish
- else, publish

also extracted some code into functions for maintainability

easier to review w/out whitespace - https://github.com/guardian/media-atom-maker/pull/717/files?w=1