### PR TITLE
remove schedule launch and embargo on publish

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -116,7 +116,9 @@ case class PublishAtomCommand(
       contentChangeDetails = atom.contentChangeDetails.copy(
         published = changeRecord,
         lastModified = changeRecord,
-        revision = atom.contentChangeDetails.revision + 1
+        revision = atom.contentChangeDetails.revision + 1,
+        scheduledLaunch = None,
+        embargo = None
       )
     )
 


### PR DESCRIPTION
- these properties do not apply once published, so set them to None
- this is the same behaviour as Composer
- results in these atoms not being returned by capi too when searching for things to launch 🎉 