### PR TITLE
all update functions expected to return a promise

### DIFF
--- a/public/video-ui/src/components/Workflow/Workflow.js
+++ b/public/video-ui/src/components/Workflow/Workflow.js
@@ -42,6 +42,7 @@ class Workflow extends React.Component {
 
   updateWorkflowDetails(update) {
     Object.assign(this.state.videoInWorkflow, update);
+    return Promise.resolve();
   }
 
   renderTrackInWorkflow() {


### PR DESCRIPTION
This fix gets rid of a javascript error when choosing the workflow section.