### PR TITLE
fix test after add asset end-point refactor

### DIFF
--- a/integration-tests/src/test/scala/AtomCreationTests.scala
+++ b/integration-tests/src/test/scala/AtomCreationTests.scala
@@ -41,7 +41,7 @@ class AtomCreationTests extends IntegrationTestBase with CancelAfterFailure {
   }
 
   test("Make an asset current for an existing atom") {
-    val currentAssetResponse = gutoolsPut(s"$targetBaseUrl/api2/atom/$atomId/asset-active", Some(jsonBody(s"""{"youtubeId":"${Config.assetId}"}""")))
+    val currentAssetResponse = gutoolsPut(s"$targetBaseUrl/api2/atom/$atomId/asset-active", Some(jsonBody(s"""{"atomId": "$atomId", "version": 1}""")))
 
     currentAssetResponse.code() should be(200)
 


### PR DESCRIPTION
the shape of the payload to the `asset-active` endpoint changed in https://github.com/guardian/media-atom-maker/pull/722