### PR TITLE
display more obvious states on search page

### DIFF
--- a/app/model/MediaAtomSummary.scala
+++ b/app/model/MediaAtomSummary.scala
@@ -5,7 +5,13 @@ import org.cvogt.play.json.Jsonx
 import play.api.libs.json.Format
 
 case class MediaAtomList(total: Int, atoms: List[MediaAtomSummary])
-case class MediaAtomSummary(id: String, status: String, title: String, posterImage: Option[Image], contentChangeDetails: ContentChangeDetails)
+
+case class MediaAtomSummary(
+  id: String,
+  title: String,
+  posterImage: Option[Image],
+  contentChangeDetails: ContentChangeDetails
+)
 
 object MediaAtomList {
   implicit val format: Format[MediaAtomList] = Jsonx.formatCaseClass[MediaAtomList]

--- a/public/video-ui/src/components/Videos/VideoItem.js
+++ b/public/video-ui/src/components/Videos/VideoItem.js
@@ -7,24 +7,25 @@ import VideoUtils from '../../util/video';
 import { impossiblyDistantDate } from '../../constants/dates';
 
 export default class VideoItem extends React.Component {
-  renderPill() {
-    switch (this.props.video.status) {
-      case 'Expired':
-        return <span className="publish__label label__expired">Expired</span>;
-      case 'Active':
-        return (
-          <span className="publish__label label__live label__frontpage__overlay">
-            Active
-          </span>
-        );
-      case 'No Video':
-        return (
-          <span className="publish__label label__frontpage__novideo label__frontpage__overlay">
-            No Video
-          </span>
-        );
-      default:
-        return '';
+  renderPublishStatus() {
+    if (VideoUtils.hasExpired(this.props.video)) {
+      return (
+        <span className="publish__label label__expired">Expired</span>
+      );
+    }
+
+    if (VideoUtils.isPublished(this.props.video)) {
+      return (
+        <span className="publish__label label__live label__frontpage__overlay">
+          Published
+        </span>
+      );
+    } else {
+      return (
+        <span className="publish__label label__draft label__frontpage__overlay">
+          Draft
+        </span>
+      )
     }
   }
 
@@ -54,7 +55,7 @@ export default class VideoItem extends React.Component {
             </div>
             <div className="grid__status__overlay">
               <ReactTooltip />
-              {this.renderPill()}
+              {this.renderPublishStatus()}
               {embargo && (
                 <span
                   data-tip={

--- a/public/video-ui/src/util/video.js
+++ b/public/video-ui/src/util/video.js
@@ -112,4 +112,12 @@ export default class VideoUtils {
     const embargo = contentChangeDetails.embargo;
     return embargo ? moment(embargo.date) : null;
   }
+
+  static isPublished({contentChangeDetails}) {
+    return !!contentChangeDetails.published;
+  }
+
+  static hasExpired({contentChangeDetails}) {
+    return !!contentChangeDetails.expiry;
+  }
 }

--- a/public/video-ui/styles/components/_header.scss
+++ b/public/video-ui/styles/components/_header.scss
@@ -25,11 +25,6 @@
   color: $cWhite;
 }
 
-.label__frontpage__novideo {
-  color: $color300Grey;
-  background-color: rgba(51,51,51,0.9);
-}
-
 .label__frontpage__overlay {
   width: 70px;
 }


### PR DESCRIPTION
"no video" and "active" aren't very friendly/obvious terms, replace them in favour of "draft" and "published". Also push this logic client-side, as we're doing similar things client-side too.

Before
![image](https://user-images.githubusercontent.com/836140/34120882-0bd69e4c-e41f-11e7-8846-074c9f5d0147.png)


After
![image](https://user-images.githubusercontent.com/836140/34120853-f3111310-e41e-11e7-81ea-da741f760721.png)

