### PR TITLE
disable scheduler when info missing

### DIFF
--- a/public/video-ui/src/components/ScheduledLaunch/ScheduledLaunch.js
+++ b/public/video-ui/src/components/ScheduledLaunch/ScheduledLaunch.js
@@ -17,7 +17,8 @@ export default class ScheduledLaunch extends React.Component {
   static propTypes = {
     video: PropTypes.object.isRequired,
     saveVideo: PropTypes.func.isRequired,
-    videoEditOpen: PropTypes.bool.isRequired
+    videoEditOpen: PropTypes.bool.isRequired,
+    hasPublishedVideoPageUsages: PropTypes.func.isRequired
   };
 
   state = {

--- a/public/video-ui/src/components/ScheduledLaunch/ScheduledLaunch.js
+++ b/public/video-ui/src/components/ScheduledLaunch/ScheduledLaunch.js
@@ -11,6 +11,7 @@ import {
 import { impossiblyDistantDate }  from '../../constants/dates';
 import datesProperties from '../../constants/datesProperties';
 import VideoUtils from '../../util/video';
+import ReactTooltip from 'react-tooltip';
 
 export default class ScheduledLaunch extends React.Component {
   static propTypes = {
@@ -130,6 +131,18 @@ export default class ScheduledLaunch extends React.Component {
     this.setState({ showDatePicker: false, [propertyName]: null });
   };
 
+  getNoScheduleReason = () => {
+    if (!this.props.video.title) {
+      return 'You must add a title before scheduling';
+    }
+
+    if (this.props.hasPublishedVideoPageUsages()) {
+      return 'The atom cannot be scheduled because it has a published video page';
+    }
+
+    return null;
+  }
+
   /* Render functions */
 
   renderScheduleOptions = (video, videoEditOpen, scheduledLaunch, embargo) => {
@@ -242,25 +255,33 @@ export default class ScheduledLaunch extends React.Component {
     </button>
   )
 
-  renderSchedulerButton = (showScheduleOptions) => (
-    <button
-      className="btn btn--list"
-      onClick={() =>
-        this.setState({
-          showScheduleOptions: !showScheduleOptions,
-          propertyName: null
-        })
-      }
-    >
-      <Icon icon="access_time" />
-    </button>
-  )
+  renderSchedulerButton = (showScheduleOptions) => {
+
+    const notAbleToScheduleReason = this.getNoScheduleReason();
+
+    return (
+      <div data-tip={notAbleToScheduleReason}>
+        <button
+          disabled={!!notAbleToScheduleReason}
+          className="btn btn--list"
+          onClick={() =>
+            this.setState({
+              showScheduleOptions: !showScheduleOptions,
+              propertyName: null
+            })
+          }
+        >
+          <Icon icon="access_time" />
+        </button>
+      </div>
+    );
+  }
 
   render() {
     const {
       video,
       videoEditOpen,
-      hasPublishedVideoUsages
+      hasPublishedVideoPageUsages
     } = this.props;
     const {
       selectedScheduleDate,
@@ -286,8 +307,7 @@ export default class ScheduledLaunch extends React.Component {
           )}
         {this.renderDatePicker(showDatePicker, propertyName, selectedScheduleDate, selectedEmbargoDate)}
         {showDatePicker && this.renderAlert(invalidDateError)}
-        {!hasPublishedVideoUsages() &&
-          !showDatePicker && (
+        {!showDatePicker && (
             <div className="scheduleOptionsWrapper">
             {this.renderSchedulerButton(showScheduleOptions)}
               {showScheduleOptions &&
@@ -304,6 +324,7 @@ export default class ScheduledLaunch extends React.Component {
           (propertyName === datesProperties.selectedEmbargoDate && embargo)) &&
           showDatePicker && this.renderRemoveButton(propertyName)}
         {showDatePicker && this.renderCancelButton()}
+        <ReactTooltip />
       </div>
     );
   }

--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.js
@@ -53,7 +53,7 @@ export default class VideoPublishBar extends React.Component {
     this.props.publishVideo();
   };
 
-  hasPublishedVideoUsages = () =>
+  hasPublishedVideoPageUsages = () =>
     this.props.usages.data.published.video.length > 0;
 
   renderPublishButtonText() {
@@ -94,7 +94,7 @@ export default class VideoPublishBar extends React.Component {
         video={this.props.video}
         videoEditOpen={this.props.videoEditOpen}
         saveVideo={this.props.saveVideo}
-        hasPublishedVideoUsages={this.hasPublishedVideoUsages}
+        hasPublishedVideoPageUsages={this.hasPublishedVideoPageUsages}
       />
     );
   }


### PR DESCRIPTION
There were already checks hiding the scheduler button if there are published video page usages. I thought it might be clearer to disable the button instead and display a message to the user, the same applies if the user erases the title from the atom.