### PR TITLE
correct expiry logic

### DIFF
--- a/public/video-ui/src/util/video.js
+++ b/public/video-ui/src/util/video.js
@@ -118,6 +118,6 @@ export default class VideoUtils {
   }
 
   static hasExpired({contentChangeDetails}) {
-    return !!contentChangeDetails.expiry;
+    return !!contentChangeDetails.expiry && contentChangeDetails.expiry.date >= Date.now();
   }
 }


### PR DESCRIPTION
an atom has only expired iff the date >= now

related to https://github.com/guardian/media-atom-maker/pull/730