### PR TITLE
allow hosted atoms to block ads

### DIFF
--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -162,7 +162,7 @@ class VideoData extends React.Component {
             <ManagedField
               fieldLocation="blockAds"
               name="Block ads"
-              fieldDetails="Ads will not be displayed with this video"
+              fieldDetails={isCommercialType ? 'Block ads on Composer page': 'Ads will not be displayed with this video'}
               disabled={!isYoutubeAtom || !isEligibleForAds}
               tooltip={!isEligibleForAds ? `Not eligible for pre-roll.` : ''}
             >

--- a/public/video-ui/src/util/video.js
+++ b/public/video-ui/src/util/video.js
@@ -78,11 +78,11 @@ export default class VideoUtils {
   }
 
   static isEligibleForAds(atom) {
-    if (VideoUtils.isCommercialType(atom)) {
-      return false;
+    if (!VideoUtils.hasAssets(atom)) {
+      return true;
     }
 
-    if (!VideoUtils.hasAssets(atom)) {
+    if (VideoUtils.isCommercialType(atom)) {
       return true;
     }
 


### PR DESCRIPTION
Labs want to be able to toggle blockAds on Composer pages, so enable the checkbox to allow them to. The `fieldDetails` changes if the atom is a commercial type as we always block ads on the video server side.