### PR TITLE
don't send Pluto warning emails in integration tests

### DIFF
--- a/common/src/main/scala/com/gu/media/aws/UploadAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/UploadAccess.scala
@@ -11,6 +11,7 @@ trait UploadAccess { this: Settings with AwsAccess =>
   val userUploadFolder: String = getMandatoryString("aws.upload.folder")
   val userUploadRole: String = getMandatoryString("aws.upload.role")
   val syncWithPluto: Boolean = getBoolean("pluto.sync").getOrElse(false)
+  val integrationTestUser: String = getMandatoryString("integration.test.user")
 
   val pipelineName: String = s"VideoPipeline$stage"
   lazy val pipelineArn: String = getPipelineArn()

--- a/common/src/main/scala/com/gu/media/model/PlutoIntegrationData.scala
+++ b/common/src/main/scala/com/gu/media/model/PlutoIntegrationData.scala
@@ -64,9 +64,11 @@ object PlutoSyncMetadataMessage {
   implicit val format: Format[PlutoSyncMetadataMessage] = Jsonx.formatCaseClass[PlutoSyncMetadataMessage]
 
   def build(uploadId: String, atom: MediaAtom, awsAccess: AwsAccess with UploadAccess, email: String): PlutoSyncMetadataMessage = {
+    val syncWithPluto = email != awsAccess.integrationTestUser && awsAccess.syncWithPluto
+
     PlutoSyncMetadataMessage(
       "video-upload",
-      awsAccess.syncWithPluto,
+      enabled = syncWithPluto,
       atom.plutoData.flatMap(_.projectId),
       CompleteUploadKey(awsAccess.userUploadFolder, uploadId).toString,
       atom.id,


### PR DESCRIPTION
Currently, we send an email asking you to set pluto data on an atom if its missing. The email address we use during integration tests doesn't accept incoming mail. This has resulted in a high bounce rate in SES and a temporary suspension...