### PR TITLE
update email copy

### DIFF
--- a/common/src/main/scala/com/gu/media/ses/Mailer.scala
+++ b/common/src/main/scala/com/gu/media/ses/Mailer.scala
@@ -6,19 +6,21 @@ import com.amazonaws.services.simpleemail.model._
 import scala.collection.JavaConversions._
 
 class Mailer(sesClient: AmazonSimpleEmailServiceClient, host: String) {
-  def sendPlutoIdMissingEmail(atomTitle: String, sendTo: String, fromAddress: String, replyToAddresses: Array[String]): Unit = {
+  def sendPlutoIdMissingEmail(atomId: String, atomTitle: String, sendTo: String, fromAddress: String, replyToAddresses: Array[String]): Unit = {
 
     val emailBody =
       s"""
-        |<div>A video with title $atomTitle you uploaded to youtube recently was missing a pluto project id</div>
-        |<div>Please visit <a href='https://$host/videos/pluto-list'>this address</a> to add a project id.
-        |<div>Without this id Pluto cannot ingest the video</div>
+        |<div>The video “$atomTitle” that you uploaded via Media Atom Maker recently, does not have a Pluto project associated with it.</div>
+        |<div>Please visit <a href="https://$host/videos/$atomId/upload" target="_blank" rel="noopener noreferrer">this address</a> to set its Pluto project.
+        |<div>Without a project, the video won’t be archived and won't maintain a link to its original Adobe Premiere project and assets.</div>
+        |
+        |<div>For a complete list of incomplete Atoms, <a href="https://$host/videos/pluto-list" target="_blank" rel="noopener noreferrer">click here</a>.
       """.stripMargin
 
     sesClient.sendEmail(new SendEmailRequest()
       .withDestination(new Destination().withToAddresses(sendTo))
       .withMessage(new Message()
-        .withSubject(new Content("Failed Pluto Video Ingest - Action Required"))
+        .withSubject(new Content("[Media Atom Maker] Failed Pluto Video Ingest - Action Required"))
         .withBody(new Body().withHtml(new Content(emailBody)))
       )
       .withSource(fromAddress)

--- a/common/src/main/scala/com/gu/media/upload/PlutoUploadActions.scala
+++ b/common/src/main/scala/com/gu/media/upload/PlutoUploadActions.scala
@@ -21,6 +21,7 @@ class PlutoUploadActions(config: Settings with DynamoAccess with KinesisAccess w
             log.info(s"Sending missing Pluto ID email user=${plutoData.user} atom=${plutoData.atomId}")
 
             mailer.sendPlutoIdMissingEmail(
+              plutoData.atomId,
               plutoData.title,
               plutoData.user,
               config.fromEmailAddress,


### PR DESCRIPTION
linking to uploads page where the project can be set (saves having to trall through the list of incomplete Atoms)

requested by Yusuf

```html
<div>The video “$atomTitle” that you uploaded via Media Atom Maker recently, does not have a Pluto project associated with it.</div>
<div>Please visit <a href="https://$host/videos/$atomId/upload" target="_blank" rel="noopener noreferrer">this address</a> to set its Pluto project.
<div>Without a project, the video won’t be archived and won't maintain a link to its original Adobe Premiere project and assets.</div>

<div>For a complete list of incomplete Atoms, <a href="https://$host/videos/pluto-list" target="_blank" rel="noopener noreferrer">click here</a>.
```