### PR TITLE
remove deprecated field

### DIFF
--- a/common/src/main/scala/com/gu/media/aws/KinesisAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/KinesisAccess.scala
@@ -18,6 +18,8 @@ trait KinesisAccess { this: Settings with AwsAccess with Logging =>
 
   val plutoIntegrationOutgoingStream: String = getMandatoryString("aws.kinesis.uploadsStreamName")
 
+  val syncWithPluto: Boolean = getBoolean("pluto.sync").getOrElse(false)
+
   lazy val crossAccountKinesisClient = region.createClient(classOf[AmazonKinesisClient], credentials.crossAccount, null)
   lazy val kinesisClient = region.createClient(classOf[AmazonKinesisClient], credentials.instance, null)
 

--- a/common/src/main/scala/com/gu/media/aws/SESSettings.scala
+++ b/common/src/main/scala/com/gu/media/aws/SESSettings.scala
@@ -12,4 +12,5 @@ trait SESSettings { this: Settings with AwsAccess =>
 
   val replyToAddresses = getMandatoryString("aws.ses.replyToAddresses").split(",")
 
+  val integrationTestUser: String = getMandatoryString("integration.test.user")
 }

--- a/common/src/main/scala/com/gu/media/aws/UploadAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/UploadAccess.scala
@@ -10,8 +10,6 @@ trait UploadAccess { this: Settings with AwsAccess =>
   val userUploadBucket: String = getMandatoryString("aws.upload.bucket")
   val userUploadFolder: String = getMandatoryString("aws.upload.folder")
   val userUploadRole: String = getMandatoryString("aws.upload.role")
-  val syncWithPluto: Boolean = getBoolean("pluto.sync").getOrElse(false)
-  val integrationTestUser: String = getMandatoryString("integration.test.user")
 
   val pipelineName: String = s"VideoPipeline$stage"
   lazy val pipelineArn: String = getPipelineArn()

--- a/common/src/main/scala/com/gu/media/model/PlutoIntegrationData.scala
+++ b/common/src/main/scala/com/gu/media/model/PlutoIntegrationData.scala
@@ -49,7 +49,6 @@ object PacFileMessage {
 
 case class PlutoSyncMetadataMessage(
   `type`: String,
-  enabled: Boolean,
   projectId: Option[String],
   s3Key: String,
   atomId: String,
@@ -64,11 +63,8 @@ object PlutoSyncMetadataMessage {
   implicit val format: Format[PlutoSyncMetadataMessage] = Jsonx.formatCaseClass[PlutoSyncMetadataMessage]
 
   def build(uploadId: String, atom: MediaAtom, awsAccess: AwsAccess with UploadAccess, email: String): PlutoSyncMetadataMessage = {
-    val syncWithPluto = email != awsAccess.integrationTestUser && awsAccess.syncWithPluto
-
     PlutoSyncMetadataMessage(
       "video-upload",
-      enabled = syncWithPluto,
       atom.plutoData.flatMap(_.projectId),
       CompleteUploadKey(awsAccess.userUploadFolder, uploadId).toString,
       atom.id,


### PR DESCRIPTION
The `enabled` field has been moved to config and doesn't need to be on the model anymore.

NB the config is pretty painful because of all the traits. I've put:
- `syncWithPluto` in `KinesisAccess` because if false, we don't write to kinesis
- `integrationTestUser` in `SESSettings` because if the user matches the integration test user, we won't send an email