### PR TITLE
Remove pluto sync check

### DIFF
--- a/uploader/src/main/resources/state-machine.json
+++ b/uploader/src/main/resources/state-machine.json
@@ -104,18 +104,7 @@
     "CompleteMultipartCopy": {
       "Type": "Task",
       "Resource": "${CompleteMultipartCopy.Arn}",
-      "Next": "CheckSyncWithPluto"
-    },
-    "CheckSyncWithPluto": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.metadata.pluto.enabled",
-          "BooleanEquals": true,
-          "Next": "SendToPluto"
-        }
-      ],
-      "Default": "CheckSelfHosted"
+      "Next": "SendToPluto"
     },
     "SendToPluto": {
       "Type": "Task",


### PR DESCRIPTION
#742 removed a field that was still referenced in the step functions state machine. The check it was doing is now done in code directly so we can safely remove it.