### PR TITLE
Capi preview

### DIFF
--- a/cloudformation/media-atom-maker.yaml
+++ b/cloudformation/media-atom-maker.yaml
@@ -80,6 +80,9 @@ Parameters:
   TranscoderPipelineId:
     Description: Name of the pipeline that will transcode videos for self-hosted route
     Type: String
+  CapiPreviewRole:
+    Type: String
+    Description: ARN of the CAPI preview role
 Mappings:
   StageMap:
     PROD:
@@ -889,6 +892,20 @@ Resources:
       Statistic: Minimum
       AlarmActions:
       - !Ref 'AlertTopic'
+
+  AssumeCapiPreviewRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: assume-capi-preview-role
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action: sts:AssumeRole
+          Resource:
+            Ref: CapiPreviewRole
+      Roles:
+      - !Ref 'DistributionRole'
+
 Outputs:
   UserUploadRole:
     Value: !Ref 'LimitedUploadRole'

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,6 +20,8 @@ object Dependencies {
 
   val scanamo = "com.gu" %% "scanamo" % scanamoVersion
 
+  val capiAws = "com.gu" %% "content-api-client-aws" % "0.2"
+
   val scalaTest = "org.scalatest" %% "scalatest" % "2.2.6" % "test"
   val scalaTestPlusPlay = "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % "test"
   val mockito = "org.mockito" %  "mockito-core" % mockitoVersion % "test"
@@ -84,7 +86,8 @@ object Dependencies {
 
   val commonDependencies = panda ++ googleApi ++ atomMaker ++ Seq(
     typesafeConfig, awsLambdaCore, awsS3, awsDynamo, playJsonExtensions, logstashLogbackEncoder, kinesisLogbackAppender,
-    awsTranscoder, scanamo, okHttp, scalaTest, scalaCheck, awsSQS, awsSNS, permissionsClient, awsStepFunctions, awsSES
+    awsTranscoder, scanamo, okHttp, scalaTest, scalaCheck, awsSQS, awsSNS, permissionsClient, awsStepFunctions, awsSES,
+    capiAws
   ) ++ partnerApiDepencies
 
   val appDependencies = panda ++ slf4j ++ atomMaker ++ Seq(


### PR DESCRIPTION
Send capi preview requests to the new IAM-authorised api-gateway. This requires the app to assume a cross-account role.

Tested in CODE