### PR TITLE
Fix url encoding for capi preview

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
 
   val scanamo = "com.gu" %% "scanamo" % scanamoVersion
 
-  val capiAws = "com.gu" %% "content-api-client-aws" % "0.2"
+  val capiAws = "com.gu" %% "content-api-client-aws" % "0.3"
 
   val scalaTest = "org.scalatest" %% "scalatest" % "2.2.6" % "test"
   val scalaTestPlusPlay = "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % "test"


### PR DESCRIPTION
api-gateway requires the query param encoding to use `%20`, not `+`
I've updated the library to provide a `IAMEncoder` helper - https://github.com/guardian/content-api-scala-client/pull/250

This hasn't yet been a problem elsewhere because we generally use the correctly-encoded raw query params as they were sent by the client.