### PR TITLE
Expirer should query live capi

### DIFF
--- a/expirer/src/main/scala/com/gu/media/expirer/ExpirerLambda.scala
+++ b/expirer/src/main/scala/com/gu/media/expirer/ExpirerLambda.scala
@@ -48,7 +48,7 @@ class ExpirerLambda extends RequestHandler[Unit, Unit]
       "use-date" -> "expiry"
     )
 
-    val response = (capiQuery("atoms", qs) \ "response").get
+    val response = (capiQuery("atoms", qs, queryLive = true) \ "response").get
     val currentPage = (response \ "currentPage").as[Int]
     val pages = (response \ "pages").as[Int]
 


### PR DESCRIPTION
We should query live capi to find content to expire. 