### PR TITLE
Error messages

### DIFF
--- a/app/model/YouTubeMessage.scala
+++ b/app/model/YouTubeMessage.scala
@@ -8,7 +8,7 @@ import scala.collection.JavaConverters._
 
 case class YouTubeMessage(atomId: String, videoId: String, reason: String, message: String, isError: Boolean = false) {
 
-  def logMessage() =
+  def logMessage()   =
     if (isError) Logger.logger.error(createMarkers(), "YouTube Video update")
     else Logger.logger.info(createMarkers(), "YouTube Video update")
 

--- a/app/model/YouTubeMessage.scala
+++ b/app/model/YouTubeMessage.scala
@@ -8,7 +8,7 @@ import scala.collection.JavaConverters._
 
 case class YouTubeMessage(atomId: String, videoId: String, reason: String, message: String, isError: Boolean = false) {
 
-  def logMessage =
+  def logMessage() =
     if (isError) Logger.logger.error(createMarkers(), "YouTube Video update")
     else Logger.logger.info(createMarkers(), "YouTube Video update")
 

--- a/app/model/YouTubeMessage.scala
+++ b/app/model/YouTubeMessage.scala
@@ -9,11 +9,9 @@ import scala.collection.JavaConverters._
 case class YouTubeMessage(atomId: String, videoId: String, reason: String, message: String, isError: Boolean = false) {
 
   def logMessage =
-    if (isError) {
-      Logger.logger.error(createMarkers(), "YouTube Video update")
-    } else {
-      Logger.logger.info(createMarkers(), "YouTube Video update")
-    }
+    if (isError) Logger.logger.error(createMarkers(), "YouTube Video update")
+    else Logger.logger.info(createMarkers(), "YouTube Video update")
+
 
 
   private def createMarkers() =

--- a/app/model/YouTubeMessage.scala
+++ b/app/model/YouTubeMessage.scala
@@ -6,14 +6,17 @@ import play.api.Logger
 
 import scala.collection.JavaConverters._
 
-case class YouTubeMessage(atomId: String, videoId: String, reason: String, message: Either[String, String]) {
+case class YouTubeMessage(atomId: String, videoId: String, reason: String, message: String, isError: Boolean = false) {
 
-  def logMessage = message match {
-    case Right(message) => Logger.logger.info(createMarkers(message), "YouTube update")
-    case Left(message) => Logger.logger.error(createMarkers(message), "YouTube update")
-  }
+  def logMessage =
+    if (isError) {
+      Logger.logger.error(createMarkers(), "YouTube Video update")
+    } else {
+      Logger.logger.info(createMarkers(), "YouTube Video update")
+    }
 
-  private def createMarkers(message: String) =
+
+  private def createMarkers() =
     Markers.appendEntries(
       Map(
         "atomId" -> atomId,
@@ -24,3 +27,4 @@ case class YouTubeMessage(atomId: String, videoId: String, reason: String, messa
     )
 
 }
+

--- a/app/model/YouTubeMessage.scala
+++ b/app/model/YouTubeMessage.scala
@@ -1,0 +1,26 @@
+package model
+
+import net.logstash.logback.marker.Markers
+import org.joda.time.DateTime
+import play.api.Logger
+
+import scala.collection.JavaConverters._
+
+case class YouTubeMessage(atomId: String, videoId: String, reason: String, message: Either[String, String]) {
+
+  def logMessage = message match {
+    case Right(message) => Logger.logger.info(createMarkers(message), "YouTube update")
+    case Left(message) => Logger.logger.error(createMarkers(message), "YouTube update")
+  }
+
+  private def createMarkers(message: String) =
+    Markers.appendEntries(
+      Map(
+        "atomId" -> atomId,
+        "videoId" -> videoId,
+        "reason" -> reason,
+        "message" -> message
+      ).asJava
+    )
+
+}

--- a/app/model/commands/DeleteCommand.scala
+++ b/app/model/commands/DeleteCommand.scala
@@ -10,6 +10,7 @@ import com.gu.media.model.{Asset, MediaAtom}
 import com.gu.media.youtube.YouTubeVideos
 import data.DataStores
 import com.gu.media.model.Platform.Youtube
+import model.YouTubeMessage
 
 case class DeleteCommand(id: String, override val stores: DataStores, youTube: YouTubeVideos)
   extends Command with AtomAPIActions with Logging {
@@ -32,7 +33,7 @@ case class DeleteCommand(id: String, override val stores: DataStores, youTube: Y
 
   private def makeYouTubeVideosPrivate(assets: List[Asset]): Unit = assets.collect {
     case Asset(_, _, videoId, Youtube, _) if youTube.isManagedVideo(videoId) =>
-      log.info(s"Marking $videoId as private as parent atom $id is being deleted")
-      youTube.setStatus(videoId, PrivacyStatus.Private)
+      val privacyStatusUpdate = youTube.setStatus(videoId, PrivacyStatus.Private)
+      YouTubeMessage(id, videoId, "Atom deletion", privacyStatusUpdate).logMessage
   }
 }

--- a/app/model/commands/DeleteCommand.scala
+++ b/app/model/commands/DeleteCommand.scala
@@ -36,12 +36,10 @@ case class DeleteCommand(id: String, override val stores: DataStores, youTube: Y
       val privacyStatusUpdate = youTube.setStatus(videoId, PrivacyStatus.Private)
 
       privacyStatusUpdate match {
-        case Right(message: String) => {
-          YouTubeMessage(id, videoId, "Atom Deletion", message).logMessage
-        }
-        case Left(error: VideoUpdateError) => {
-          YouTubeMessage(id, videoId, "Atom Deletion", error.errorToLog, isError = true).logMessage
-        }
+        case Right(message: String) => YouTubeMessage(id, videoId, "Atom Deletion", message).logMessage
+
+        case Left(error: VideoUpdateError) => YouTubeMessage(id, videoId, "Atom Deletion", error.errorToLog, isError = true).logMessage
+
       }
   }
 }

--- a/app/model/commands/DeleteCommand.scala
+++ b/app/model/commands/DeleteCommand.scala
@@ -37,10 +37,10 @@ case class DeleteCommand(id: String, override val stores: DataStores, youTube: Y
 
       privacyStatusUpdate match {
         case Right(message: String) => {
-          YouTubeMessage(id, videoId, "YouTube Deletion", message).logMessage
+          YouTubeMessage(id, videoId, "Atom Deletion", message).logMessage
         }
         case Left(error: VideoUpdateError) => {
-          YouTubeMessage(id, videoId, "YouTube Deletion", error.errorToLog, isError = true).logMessage
+          YouTubeMessage(id, videoId, "Atom Deletion", error.errorToLog, isError = true).logMessage
         }
       }
   }

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -301,7 +301,8 @@ case class PublishAtomCommand(
           ).get
         }
 
-        youtube.updateThumbnail(asset.id, new URL(img.file), img.mimeType.get)
+        val thumbnailUpdate = youtube.updateThumbnail(asset.id, new URL(img.file), img.mimeType.get)
+        YouTubeMessage(atom.id, asset.id, "Thumbnail update", thumbnailUpdate).logMessage
         atom
       }
       case None => atom

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -283,7 +283,10 @@ case class PublishAtomCommand(
 
     YouTubeMessage(previewAtom.id, asset.id, "YouTube Metadata Update", youtubeMetadataUpdate).logMessage
 
-    previewAtom
+    youtubeMetadataUpdate match {
+      case Right(_) => previewAtom
+      case Left =>  AtomPublishFailed("Error in updating metadata")
+    }
   }
 
   private def updateYoutubeThumbnail(atom: MediaAtom, asset: Asset): Future[MediaAtom] = Future{

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -221,7 +221,7 @@ case class PublishAtomCommand(
         }
 
         val claimUpdate = youtube.createOrUpdateClaim(previewAtom.id, asset.id, blockAds)
-        handleYouTubeMessages(claimUpdate, "YouTube Claim Update: creatign a claim", previewAtom, asset.id)
+        handleYouTubeMessages(claimUpdate, "YouTube Claim Update: creating a claim", previewAtom, asset.id)
       }
     }
   }

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -281,7 +281,7 @@ case class PublishAtomCommand(
       if (previewAtom.blockAds) metadata.withoutContentBundleTags() else metadata.withContentBundleTags() // content bundle tags only needed on monetized videos
     )
 
-    YouTubeMessage(previewAtom.id, asset.id, "Atom publish", youtubeMetadataUpdate).logMessage
+    YouTubeMessage(previewAtom.id, asset.id, "YouTube Metadata Update", youtubeMetadataUpdate).logMessage
 
     previewAtom
   }
@@ -302,7 +302,7 @@ case class PublishAtomCommand(
         }
 
         val thumbnailUpdate = youtube.updateThumbnail(asset.id, new URL(img.file), img.mimeType.get)
-        YouTubeMessage(atom.id, asset.id, "Thumbnail update", thumbnailUpdate).logMessage
+        YouTubeMessage(atom.id, asset.id, "YouTube Thumbnail Update", thumbnailUpdate).logMessage
         atom
       }
       case None => atom

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -150,11 +150,11 @@ case class PublishAtomCommand(
           }
           case Left(err) =>
             log.error("Unable to update datastore after publish", err)
-            AtomPublishFailed(s"Could not update published datastore after publish: ${err.toString}")
+            AtomPublishFailed(s"Could not save published atom")
         }
       case Failure(err) =>
         log.error("Unable to publish atom to kinesis", err)
-        AtomPublishFailed(s"Could not publish atom (live kinesis event failed): ${err.toString}")
+        AtomPublishFailed(s"Could not publish atom")
     }
   }
 
@@ -332,7 +332,7 @@ case class PublishAtomCommand(
       }
       case Left(error: VideoUpdateError) => {
         YouTubeMessage(atom.id, assetId, updateType, error.errorToLog, isError = true).logMessage
-        AtomPublishFailed(s"Error in $updateType: ${error.errorToLog}")
+        AtomPublishFailed(s"Error in $updateType: ${error.getErrorToClient()}")
       }
     }
 

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -281,7 +281,7 @@ case class PublishAtomCommand(
       if (previewAtom.blockAds) metadata.withoutContentBundleTags() else metadata.withContentBundleTags() // content bundle tags only needed on monetized videos
     )
 
-    YouTubeMessage(previewAtom.id, asset.id, youtubeMetadataUpdate).logMessage
+    YouTubeMessage(previewAtom.id, asset.id, "Atom publish", youtubeMetadataUpdate).logMessage
 
     previewAtom
   }
@@ -318,8 +318,8 @@ case class PublishAtomCommand(
       val status = PrivacyStatus.Private.asThrift.get
 
       inactiveAssets.foreach { asset =>
-        log.info(s"Marking asset=${asset.id} atom=${atom.id} as private")
-        youtube.setStatus(asset.id, status)
+        val privacyStatusUpdate = youtube.setStatus(asset.id, status)
+        YouTubeMessage(id, asset.id, "Atom deletion", privacyStatusUpdate).logMessage
       }
     }
   }

--- a/common/src/main/scala/com/gu/media/model/VideoUpdateError.scala
+++ b/common/src/main/scala/com/gu/media/model/VideoUpdateError.scala
@@ -1,0 +1,10 @@
+package com.gu.media.model
+
+case class VideoUpdateError(errorToLog: String, errorToClient: Option[String] = None) {
+  def getErrorToClient(): String = {
+    errorToClient match {
+      case Some(error) => error
+      case None => errorToLog
+    }
+  }
+}

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -109,7 +109,7 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
                 .setOnBehalfOfContentOwner(contentOwner)
                 .execute()
 
-              Right(s"marked privacy status as $privacyStatus")
+              Right(s"marked privacy status as ${privacyStatus.name}")
             }
             catch {
               case e: GoogleJsonResponseException =>

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -86,7 +86,7 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
       case _ => Either.left("could not find video to publish")
     }
 
-  def setStatus(id: String, privacyStatus: PrivacyStatus): Unit = {
+  def setStatus(id: String, privacyStatus: PrivacyStatus): Either[String, String] = {
     getVideo(id, "snippet,status") match {
       case Some(video) => {
         protectAgainstMistakesInDev(video)
@@ -94,19 +94,19 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
         video.getStatus.setPrivacyStatus(privacyStatus.name)
 
         try {
-          Some(client.videos()
+          client.videos()
             .update("snippet, status", video)
             .setOnBehalfOfContentOwner(contentOwner)
-            .execute())
+            .execute()
 
-          log.info(s"marked asset=$id as $privacyStatus")
+          Right(s"marked privacy status as $privacyStatus")
         }
         catch {
           case e: Throwable =>
-            log.warn(s"unable to mark asset=$id as $privacyStatus", e)
+            Left(s"unable to mark privacy status as $privacyStatus" + e)
         }
       }
-      case _ =>
+      case _ => Right(s"no privacy status to update")
     }
   }
 

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -8,7 +8,6 @@ import com.google.api.services.youtube.model.{Video, VideoProcessingDetails, Vid
 import com.gu.contentatom.thrift.atom.media.PrivacyStatus
 import com.gu.media.logging.Logging
 import com.gu.media.util.ISO8601Duration
-import cats.syntax.either._
 import play.api.libs.json.Json
 import com.google.api.client.googleapis.json.{GoogleJsonError, GoogleJsonResponseException}
 import com.gu.media.model.VideoUpdateError
@@ -79,20 +78,20 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
                 .setOnBehalfOfContentOwner(contentOwner)
                 .execute()
 
-              Either.right(prettyMetadata)
+              Right(prettyMetadata)
             }
             catch {
               case e: GoogleJsonResponseException => {
                 val error: GoogleJsonError = e.getDetails
                 val message = error
-                Either.left(VideoUpdateError(error.toString, Some(error.getMessage)))
+                Left(VideoUpdateError(error.toString, Some(error.getMessage)))
               }
             }
           }
-          case Some(error) => Either.left(VideoUpdateError(error))
+          case Some(error) => Left(VideoUpdateError(error))
         }
       }
-      case _ => Either.left(VideoUpdateError("could not find video to publish"))
+      case _ => Left(VideoUpdateError("could not find video to publish"))
     }
 
   def setStatus(id: String, privacyStatus: PrivacyStatus): Either[VideoUpdateError, String] = {
@@ -115,7 +114,7 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
             catch {
               case e: GoogleJsonResponseException =>
                 val error: GoogleJsonError = e.getDetails
-                Either.left(VideoUpdateError(error.getMessage, Some(error.toString)))
+                Left(VideoUpdateError(error.getMessage, Some(error.toString)))
             }
           }
           case Some(error) => Left(VideoUpdateError(error))

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -100,7 +100,6 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
         findMistakesInDev(video) match {
           case None => {
 
-
             video.getStatus.setPrivacyStatus(privacyStatus.name)
 
             try {
@@ -129,7 +128,6 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
       case Some(video) => {
         findMistakesInDev(video) match {
           case None => {
-
 
             val content = new InputStreamContent(mimeType, new BufferedInputStream(thumbnailUrl.openStream()))
             val set = client.thumbnails().set(id, content).setOnBehalfOfContentOwner(contentOwner)
@@ -172,13 +170,11 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
   private def findMistakesInDev(video: Video): Option[String] = {
     val videoChannelId = video.getSnippet.getChannelId
 
-    if (disallowedVideos.contains(video.getId)) {
-      Some(s"Failed to edit as its in config.youtube.disallowedVideos")
-    }
+    if (disallowedVideos.contains(video.getId)) Some(s"Failed to edit as its in config.youtube.disallowedVideos")
 
-    if (allChannels.nonEmpty && !allChannels.contains(videoChannelId)) {
+
+    if (allChannels.nonEmpty && !allChannels.contains(videoChannelId))
       Some(s"Failed to edit as its channel ($videoChannelId) isn't in config.youtube.allowedChannels")
-    }
 
     None
   }

--- a/expirer/src/test/scala/com/gu/media/ExpirerLambdaTest.scala
+++ b/expirer/src/test/scala/com/gu/media/ExpirerLambdaTest.scala
@@ -3,6 +3,7 @@ package com.gu.media
 import com.amazonaws.util.IOUtils
 import com.gu.contentatom.thrift.atom.media.PrivacyStatus
 import com.gu.media.expirer.ExpirerLambda
+import com.gu.media.model.VideoUpdateError
 import org.scalatest.{FunSuite, MustMatchers}
 import play.api.libs.json.{JsValue, Json}
 
@@ -50,7 +51,7 @@ class ExpirerLambdaTest extends FunSuite with MustMatchers {
       Json.parse(ret)
     }
 
-    override def setStatus(id: String, privacyStatus: PrivacyStatus): Either[String, String] = {
+    override def setStatus(id: String, privacyStatus: PrivacyStatus): Either[VideoUpdateError, String] = {
       privacyStatus must be(PrivacyStatus.Private)
       madePrivate :+= id
       Right("")

--- a/expirer/src/test/scala/com/gu/media/ExpirerLambdaTest.scala
+++ b/expirer/src/test/scala/com/gu/media/ExpirerLambdaTest.scala
@@ -50,9 +50,10 @@ class ExpirerLambdaTest extends FunSuite with MustMatchers {
       Json.parse(ret)
     }
 
-    override def setStatus(id: String, privacyStatus: PrivacyStatus): Unit = {
+    override def setStatus(id: String, privacyStatus: PrivacyStatus): Either[String, String] = {
       privacyStatus must be(PrivacyStatus.Private)
       madePrivate :+= id
+      Right("")
     }
 
     override def isManagedVideo(youtubeId: String): Boolean = {

--- a/public/video-ui/src/actions/VideoActions/publishVideo.js
+++ b/public/video-ui/src/actions/VideoActions/publishVideo.js
@@ -19,8 +19,7 @@ function receiveVideoPublish(video) {
 function errorVideoPublish(error) {
   return {
     type: 'SHOW_ERROR',
-    message: 'Could not publish video',
-    error: error,
+    message: error.responseText,
     receivedAt: Date.now()
   };
 }


### PR DESCRIPTION
- Use markers to log more structures messages when we update youtube 
- Include the atom id in all the messages
- Display a more descriptive message to the user if atom publishing fails - if it is a known issue such as too many tags, they will have enough information to solve it themselves. If not, they will at least have more information to give us about a problem. 
