### PR TITLE
Rb targeting

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,7 @@
   "plugins": [
     "transform-object-assign",
     "transform-class-properties",
-    "transform-es2015-modules-commonjs"
+    "transform-es2015-modules-commonjs",
+    "transform-object-rest-spread"
   ]
 }

--- a/app/controllers/VideoUIApp.scala
+++ b/app/controllers/VideoUIApp.scala
@@ -54,7 +54,8 @@ class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfi
         permissions,
         minDurationForAds = youtube.minDurationForAds,
         isTrainingMode = isTrainingMode,
-        workflowUrl = awsConfig.workflowUrl
+        workflowUrl = awsConfig.workflowUrl,
+        targetingUrl = awsConfig.targetingUrl
       )
 
       Ok(views.html.VideoUIApp.app(

--- a/app/model/ClientConfig.scala
+++ b/app/model/ClientConfig.scala
@@ -28,7 +28,8 @@ case class ClientConfig(
   permissions: Permissions,
   minDurationForAds: Long,
   isTrainingMode: Boolean,
-  workflowUrl: String
+  workflowUrl: String,
+  targetingUrl: String
 )
 
 object ClientConfig {

--- a/app/util/AWS.scala
+++ b/app/util/AWS.scala
@@ -37,6 +37,8 @@ class AWSConfig(override val config: Config, override val credentials: AwsCreden
 
   lazy val gaPropertyId: Option[String] = getString("gaPropertyId")
 
+  lazy val targetingUrl = getMandatoryString("targeting.url")
+
   lazy val expiryPollerName = "Expiry"
   lazy val expiryPollerLastName = "Poller"
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-loader": "^6.2.5",
     "babel-plugin-transform-class-properties": "^6.16.0",
     "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "chalk": "^1.1.3",

--- a/public/video-ui/src/actions/TargetingActions/createTarget.js
+++ b/public/video-ui/src/actions/TargetingActions/createTarget.js
@@ -11,7 +11,7 @@ function receiveCreateTarget(targets) {
   return {
     type: 'TARGETING_POST_RECEIVE',
     receivedAt: Date.now(),
-    targets: targets
+    targets: [targets]
   };
 }
 

--- a/public/video-ui/src/actions/TargetingActions/createTarget.js
+++ b/public/video-ui/src/actions/TargetingActions/createTarget.js
@@ -1,0 +1,34 @@
+import TargetingApi from '../../services/TargetingApi';
+
+function requestCreateTarget() {
+  return {
+    type: 'TARGETING_POST_REQUEST',
+    receivedAt: Date.now()
+  };
+}
+
+function receiveCreateTarget(targets) {
+  return {
+    type: 'TARGETING_POST_RECEIVE',
+    receivedAt: Date.now(),
+    targets: targets
+  };
+}
+
+function errorCreateTarget(error) {
+  return {
+    type: 'SHOW_ERROR',
+    receivedAt: Date.now(),
+    message: 'Failed to create Target',
+    error: error
+  };
+}
+
+export function createTarget(video) {
+  return dispatch => {
+    dispatch(requestCreateTarget());
+    return TargetingApi.createTarget(video)
+      .then(res => dispatch(receiveCreateTarget(res)))
+      .catch(err => dispatch(errorCreateTarget(err)));
+  }
+}

--- a/public/video-ui/src/actions/TargetingActions/deleteTarget.js
+++ b/public/video-ui/src/actions/TargetingActions/deleteTarget.js
@@ -1,21 +1,30 @@
 import TargetingApi from '../../services/TargetingApi';
 
-function requestDeleteTarget() {
+function requestDeleteTarget(target) {
   return {
     type: 'TARGETING_DELETE_REQUEST',
-    receivedAt: Date.now()
+    receivedAt: Date.now(),
+    target
   };
 }
 
-function receiveDeleteTarget(targets) {
+function receiveDeleteTarget(target) {
   return {
     type: 'TARGETING_DELETE_RECEIVE',
     receivedAt: Date.now(),
-    targets: targets
+    target
   };
 }
 
-function errorDeleteTarget(error) {
+function errorDeleteTarget(target) {
+  return {
+    type: 'TARGETING_DELETE_FAILURE',
+    receivedAt: Date.now(),
+    target
+  };
+}
+
+function showDeleteTargetError(error) {
   return {
     type: 'SHOW_ERROR',
     receivedAt: Date.now(),
@@ -24,11 +33,14 @@ function errorDeleteTarget(error) {
   };
 }
 
-export function deleteTarget(video, target) {
+export function deleteTarget(target) {
   return dispatch => {
-    dispatch(requestDeleteTarget());
-    return TargetingApi.deleteTarget(video, target)
-      .then(res => dispatch(receiveDeleteTarget(res)))
-      .catch(err => dispatch(errorDeleteTarget(err)));
-  }
+    dispatch(requestDeleteTarget(target));
+    return TargetingApi.deleteTarget(target)
+      .then(() => dispatch(receiveDeleteTarget(target)))
+      .catch(err => {
+        dispatch(errorDeleteTarget(target));
+        dispatch(showDeleteTargetError(err));
+      });
+  };
 }

--- a/public/video-ui/src/actions/TargetingActions/deleteTarget.js
+++ b/public/video-ui/src/actions/TargetingActions/deleteTarget.js
@@ -1,0 +1,34 @@
+import TargetingApi from '../../services/TargetingApi';
+
+function requestDeleteTarget() {
+  return {
+    type: 'TARGETING_DELETE_REQUEST',
+    receivedAt: Date.now()
+  };
+}
+
+function receiveDeleteTarget(targets) {
+  return {
+    type: 'TARGETING_DELETE_RECEIVE',
+    receivedAt: Date.now(),
+    targets: targets
+  };
+}
+
+function errorDeleteTarget(error) {
+  return {
+    type: 'SHOW_ERROR',
+    receivedAt: Date.now(),
+    message: 'Failed to delete Target',
+    error: error
+  };
+}
+
+export function deleteTarget(video, target) {
+  return dispatch => {
+    dispatch(requestDeleteTarget());
+    return TargetingApi.deleteTarget(video, target)
+      .then(res => dispatch(receiveDeleteTarget(res)))
+      .catch(err => dispatch(errorDeleteTarget(err)));
+  }
+}

--- a/public/video-ui/src/actions/TargetingActions/getTargets.js
+++ b/public/video-ui/src/actions/TargetingActions/getTargets.js
@@ -1,0 +1,34 @@
+import TargetingApi from '../../services/TargetingApi';
+
+function requestGetTargets() {
+  return {
+    type: 'TARGETING_GET_REQUEST',
+    receivedAt: Date.now()
+  };
+}
+
+function receiveGetTarget(targets) {
+  return {
+    type: 'TARGETING_GET_RECEIVE',
+    receivedAt: Date.now(),
+    targets: targets
+  };
+}
+
+function errorGetTarget(error) {
+  return {
+    type: 'SHOW_ERROR',
+    receivedAt: Date.now(),
+    message: 'Failed to get Target',
+    error: error
+  };
+}
+
+export function getTargets(video) {
+  return dispatch => {
+    dispatch(requestGetTargets());
+    return TargetingApi.getTargets(video)
+      .then(res => dispatch(receiveGetTarget(res)))
+      .catch(err => dispatch(errorGetTarget(err)));
+  }
+}

--- a/public/video-ui/src/actions/TargetingActions/updateTarget.js
+++ b/public/video-ui/src/actions/TargetingActions/updateTarget.js
@@ -1,0 +1,33 @@
+import TargetingApi from '../../services/TargetingApi';
+
+function requestUpdateTarget() {
+  return {
+    type: 'TARGETING_UPDATE_REQUEST',
+    receivedAt: Date.now()
+  };
+}
+
+function receiveUpdateTarget() {
+  return {
+    type: 'TARGETING_UPDATE_RECEIVE',
+    receivedAt: Date.now()
+  };
+}
+
+function errorUpdateTarget(error) {
+  return {
+    type: 'SHOW_ERROR',
+    receivedAt: Date.now(),
+    message: 'Failed to update Target',
+    error: error
+  };
+}
+
+export function updateTarget(target) {
+  return dispatch => {
+    dispatch(requestUpdateTarget());
+    return TargetingApi.updateTarget(target)
+      .then(() => dispatch(receiveUpdateTarget()))
+      .catch(err => dispatch(errorUpdateTarget(err)));
+  };
+}

--- a/public/video-ui/src/actions/TargetingActions/updateTarget.js
+++ b/public/video-ui/src/actions/TargetingActions/updateTarget.js
@@ -1,9 +1,11 @@
 import TargetingApi from '../../services/TargetingApi';
+import debounce from 'lodash/debounce';
 
-function requestUpdateTarget() {
+function requestUpdateTarget(target) {
   return {
     type: 'TARGETING_UPDATE_REQUEST',
-    receivedAt: Date.now()
+    receivedAt: Date.now(),
+    target
   };
 }
 
@@ -23,11 +25,17 @@ function errorUpdateTarget(error) {
   };
 }
 
+const debouncedUpdate = debounce(
+  (dispatch, target) =>
+    TargetingApi.updateTarget(target)
+      .then(() => dispatch(receiveUpdateTarget()))
+      .catch(err => dispatch(errorUpdateTarget(err))),
+  500
+);
+
 export function updateTarget(target) {
   return dispatch => {
-    dispatch(requestUpdateTarget());
-    return TargetingApi.updateTarget(target)
-      .then(() => dispatch(receiveUpdateTarget()))
-      .catch(err => dispatch(errorUpdateTarget(err)));
+    dispatch(requestUpdateTarget(target));
+    return debouncedUpdate(dispatch, target);
   };
 }

--- a/public/video-ui/src/components/FormFields/CheckBox.js
+++ b/public/video-ui/src/components/FormFields/CheckBox.js
@@ -3,7 +3,7 @@ import React from 'react';
 export default class CheckBox extends React.Component {
   renderCheckbox() {
     const checked =
-      this.props.fieldValue && this.props.fieldValue !== this.props.placeholder;
+      !!this.props.fieldValue && this.props.fieldValue !== this.props.placeholder;
 
     return (
       <div>

--- a/public/video-ui/src/components/FormFields/DatePicker.js
+++ b/public/video-ui/src/components/FormFields/DatePicker.js
@@ -71,7 +71,7 @@ function DateSelector({ date, onChange }) {
   return <Picker {...datePickerParams} />;
 }
 
-function Editor({ date, onChange, fieldName }) {
+function Editor({ date, onChange, fieldName, canCancel, dayOnly }) {
   function reset() {
     onChange(null);
   }
@@ -83,14 +83,17 @@ function Editor({ date, onChange, fieldName }) {
         <div className="expiry-date-picker__date">
           <DateSelector date={date} onChange={onChange} />
         </div>
-        <div className="expiry-date-picker__number">
-          <HourSelector date={date} onChange={onChange} />
-        </div>
-        <div className="expiry-date-picker__number">
-          <MinuteSelector date={date} onChange={onChange} />
-        </div>
-        {
-          date &&
+        {!dayOnly && (
+          <div className="expiry-date-picker__number">
+            <HourSelector date={date} onChange={onChange} />
+          </div>
+        )}
+        {!dayOnly && (
+          <div className="expiry-date-picker__number">
+            <MinuteSelector date={date} onChange={onChange} />
+          </div>
+        )}
+        {date && canCancel &&
             <Icon
             icon="cancel"
             className="icon__edit icon__cancel"
@@ -122,7 +125,9 @@ export default function DatePicker({
   onUpdateField,
   fieldValue,
   placeholder,
-  fieldName
+  fieldName,
+  dayOnly,
+  canCancel = true
 }) {
   const date = fieldValue && fieldValue !== placeholder
     ? moment(fieldValue)
@@ -134,6 +139,8 @@ export default function DatePicker({
         fieldName={fieldName}
         date={date}
         placeholder={placeholder}
+        canCancel={canCancel}
+        dayOnly={dayOnly}
         onChange={newDate => {
           if (newDate) {
             onUpdateField(newDate.valueOf());

--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -76,22 +76,28 @@ export default class TagPicker extends React.Component {
   fetchTags = searchText => {
     const tagTypes = this._getTagTypes();
 
-    ContentApi.getTagsByType(searchText, tagTypes)
-      .then(capiResponses => {
-        const tags = capiResponses.reduce((tags, capiResponse) => {
-          return tags.concat(getTagDisplayNames(capiResponse.response.results));
-        }, []);
-
-        this.setState({
-          capiTags: tags
-        });
-      })
-      .catch(() => {
-        this.setState({
-          capiTags: [],
-          capiUnavailable: true
-        });
+    if (!searchText) {
+      this.setState({
+        capiTags: []
       });
+    } else {
+      ContentApi.getTagsByType(searchText, tagTypes)
+        .then(capiResponses => {
+          const tags = capiResponses.reduce((tags, capiResponse) => {
+            return tags.concat(getTagDisplayNames(capiResponse.response.results));
+          }, []);
+
+          this.setState({
+            capiTags: tags
+          });
+        })
+        .catch(() => {
+          this.setState({
+            capiTags: [],
+            capiUnavailable: true
+          });
+        });
+    }
   }
 
   onUpdate = newValue => {

--- a/public/video-ui/src/components/Targeting/Targeting.js
+++ b/public/video-ui/src/components/Targeting/Targeting.js
@@ -1,5 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import TagPicker from '../FormFields/TagPicker';
+import TagTypes from '../../constants/TagTypes';
+import { ManagedForm, ManagedField } from '../ManagedForm';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import * as createTarget from '../../actions/TargetingActions/createTarget';
+import * as getTargets from '../../actions/TargetingActions/getTargets';
+import * as deleteTarget from '../../actions/TargetingActions/deleteTarget';
+
+const logArgs = (...args) => console.log(...args);
+const logArgsAync = (...args) => Promise.resolve(logArgs(...args));
 
 class Targeting extends React.Component {
   static propTypes = {
@@ -10,18 +21,32 @@ class Targeting extends React.Component {
     this.props.targetingActions.getTargets(this.props.video);
   }
 
-  render () {
+  render() {
     return (
-      <h1>hi</h1>
+      <ManagedForm
+        data={this.props.video}
+        updateData={logArgsAync}
+        editable={true}
+        updateErrors={(...args) => console.log(args)}
+        updateWarnings={(...args) => console.log(args)}
+        formName={this.props.formName}
+        formClass="atom__edit__form"
+      >
+        <ManagedField
+          fieldLocation="commissioningDesks"
+          name="Tracking tags"
+          formRowClass="form__row__byline"
+          tagType={TagTypes.tracking}
+          isDesired={false}
+          isRequired={false}
+          inputPlaceholder="Search commissioning info (type '*' to show all)"
+        >
+          <TagPicker />
+        </ManagedField>
+      </ManagedForm>
     );
   }
 }
-
-import {connect} from 'react-redux';
-import {bindActionCreators} from 'redux';
-import * as createTarget from '../../actions/TargetingActions/createTarget';
-import * as getTargets from '../../actions/TargetingActions/getTargets';
-import * as deleteTarget from '../../actions/TargetingActions/deleteTarget';
 
 function mapStateToProps(state) {
   return {

--- a/public/video-ui/src/components/Targeting/Targeting.js
+++ b/public/video-ui/src/components/Targeting/Targeting.js
@@ -88,11 +88,8 @@ class Targeting extends React.Component {
                 )}
               </div>
             ))}
-            <button
-              className="button__secondary--confirm"
-              onClick={this.createTarget}
-            >
-              <Icon icon="add" />
+            <button className="btn" onClick={this.createTarget}>
+              <Icon icon="add" /> Add suggestion
             </button>
           </div>
         )}

--- a/public/video-ui/src/components/Targeting/Targeting.js
+++ b/public/video-ui/src/components/Targeting/Targeting.js
@@ -1,14 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import TagPicker from '../FormFields/TagPicker';
+import TextInput from '../FormFields/TextInput';
 import TagTypes from '../../constants/TagTypes';
 import { ManagedForm, ManagedField } from '../ManagedForm';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import Icon from '../Icon';
 import * as createTarget from '../../actions/TargetingActions/createTarget';
 import * as getTargets from '../../actions/TargetingActions/getTargets';
 import * as deleteTarget from '../../actions/TargetingActions/deleteTarget';
 import * as updateTarget from '../../actions/TargetingActions/updateTarget';
+
+const isDeleting = (target, deleting) => deleting.indexOf(target.id) > -1;
 
 class Targeting extends React.Component {
   static propTypes = {
@@ -30,47 +34,73 @@ class Targeting extends React.Component {
     return Promise.resolve(target);
   };
 
+  deleteTarget = target => {
+    this.props.targetingActions.deleteTarget(target);
+  };
+
   render() {
     return (
       <div>
-        {this.props.targetsLoaded &&
-          (!this.props.target ? (
-            <button className="btn" onClick={this.createTarget}>
-              Create targeting
-            </button>
-          ) : (
-            <ManagedForm
-              data={this.props.target}
-              updateData={this.updateTarget}
-              editable={true}
-              formName="TargetingForm"
-              formClass="atom__edit__form"
+        {this.props.targetsLoaded && (
+          <div>
+            {this.props.targets.map(target => (
+              <div key={target.id} className="targeting__form">
+                <ManagedForm
+                  data={target}
+                  updateData={this.updateTarget}
+                  editable={true}
+                  formName="TargetingForm"
+                >
+                  <ManagedField
+                    fieldLocation="title"
+                    name="Title"
+                    disabled={isDeleting(target, this.props.deleting)}
+                  >
+                    <TextInput />
+                  </ManagedField>
+                    <ManagedField
+                      fieldLocation="tagPaths"
+                      name="Tracking tags"
+                      formRowClass="form__row__byline"
+                      tagType={TagTypes.tracking}
+                      isDesired={false}
+                      isRequired={false}
+                      inputPlaceholder="Search commissioning info (type '*' to show all)"
+                    >
+                      <TagPicker disableTextInput />
+                    </ManagedField>
+                </ManagedForm>
+                {!isDeleting(target, this.props.deleting) && (
+                  <button
+                    className="button__secondary--cancel"
+                    onClick={() =>this.deleteTarget(target)}
+                  >
+                    <Icon icon="delete" /> Delete
+                  </button>
+                )}
+              </div>
+            ))}
+            <button
+              className="button__secondary--confirm"
+              onClick={this.createTarget}
             >
-              <ManagedField
-                fieldLocation="tagPaths"
-                name="Tracking tags"
-                formRowClass="form__row__byline"
-                tagType={TagTypes.tracking}
-                isDesired={false}
-                isRequired={false}
-                inputPlaceholder="Search commissioning info (type '*' to show all)"
-              >
-                <TagPicker disableTextInput />
-              </ManagedField>
-            </ManagedForm>
-          ))}
+              <Icon icon="add" />
+            </button>
+          </div>
+        )}
       </div>
     );
   }
 }
 
 function mapStateToProps(state) {
-  const { targeting: { targets: currentTargets } } = state;
+  const { targeting: { targets: currentTargets, deleting } } = state;
   const targetsLoaded = !!currentTargets;
-  const target = (currentTargets || [])[0]; // use the first target only
+  const targets = currentTargets || []; // use the first target only
   return {
     targetsLoaded,
-    target
+    targets,
+    deleting
   };
 }
 

--- a/public/video-ui/src/components/Targeting/Targeting.js
+++ b/public/video-ui/src/components/Targeting/Targeting.js
@@ -104,7 +104,7 @@ class Targeting extends React.Component {
 function mapStateToProps(state) {
   const { targeting: { targets: currentTargets, deleting } } = state;
   const targetsLoaded = !!currentTargets;
-  const targets = currentTargets || []; // use the first target only
+  const targets = currentTargets || [];
   return {
     targetsLoaded,
     targets,

--- a/public/video-ui/src/components/Targeting/Targeting.js
+++ b/public/video-ui/src/components/Targeting/Targeting.js
@@ -35,7 +35,9 @@ class Targeting extends React.Component {
       <div>
         {this.props.targetsLoaded &&
           (!this.props.target ? (
-            <button onClick={this.createTarget}>Create targeting</button>
+            <button className="btn" onClick={this.createTarget}>
+              Create targeting
+            </button>
           ) : (
             <ManagedForm
               data={this.props.target} // use the first target only

--- a/public/video-ui/src/components/Targeting/Targeting.js
+++ b/public/video-ui/src/components/Targeting/Targeting.js
@@ -40,7 +40,7 @@ class Targeting extends React.Component {
             </button>
           ) : (
             <ManagedForm
-              data={this.props.target} // use the first target only
+              data={this.props.target}
               updateData={this.updateTarget}
               editable={true}
               formName="TargetingForm"
@@ -67,7 +67,7 @@ class Targeting extends React.Component {
 function mapStateToProps(state) {
   const { targeting: { targets: currentTargets } } = state;
   const targetsLoaded = !!currentTargets;
-  const target = (currentTargets || [])[0];
+  const target = (currentTargets || [])[0]; // use the first target only
   return {
     targetsLoaded,
     target

--- a/public/video-ui/src/components/Targeting/Targeting.js
+++ b/public/video-ui/src/components/Targeting/Targeting.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import TagPicker from '../FormFields/TagPicker';
 import TextInput from '../FormFields/TextInput';
+import DatePicker from '../FormFields/DatePicker';
 import TagTypes from '../../constants/TagTypes';
 import { ManagedForm, ManagedField } from '../ManagedForm';
 import { connect } from 'react-redux';
@@ -58,6 +59,7 @@ class Targeting extends React.Component {
                   >
                     <TextInput />
                   </ManagedField>
+                  {!isDeleting(target, this.props.deleting) && (
                     <ManagedField
                       fieldLocation="tagPaths"
                       name="Tracking tags"
@@ -69,6 +71,12 @@ class Targeting extends React.Component {
                     >
                       <TagPicker disableTextInput />
                     </ManagedField>
+                  )}
+                  {!isDeleting(target, this.props.deleting) && (
+                    <ManagedField fieldLocation="activeUntil" name="ActiveUntil">
+                      <DatePicker canCancel={false} dayOnly />
+                    </ManagedField>
+                  )}
                 </ManagedForm>
                 {!isDeleting(target, this.props.deleting) && (
                   <button

--- a/public/video-ui/src/components/Targeting/Targeting.js
+++ b/public/video-ui/src/components/Targeting/Targeting.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class Targeting extends React.Component {
+  static propTypes = {
+    video: PropTypes.object.isRequired
+  };
+
+  componentWillMount() {
+    this.props.targetingActions.getTargets(this.props.video);
+  }
+
+  render () {
+    return (
+      <h1>hi</h1>
+    );
+  }
+}
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+import * as createTarget from '../../actions/TargetingActions/createTarget';
+import * as getTargets from '../../actions/TargetingActions/getTargets';
+import * as deleteTarget from '../../actions/TargetingActions/deleteTarget';
+
+function mapStateToProps(state) {
+  return {
+    targeting: state.targeting
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    targetingActions: bindActionCreators(
+      Object.assign(
+        {},
+        createTarget,
+        getTargets,
+        deleteTarget
+      ),
+      dispatch
+    )
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Targeting);

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -6,6 +6,7 @@ import VideoImages from '../VideoImages/VideoImages';
 import VideoUsages from '../VideoUsages/VideoUsages';
 import VideoData from '../VideoData/VideoData';
 import Workflow from '../Workflow/Workflow';
+import Targeting from '../Targeting/Targeting';
 import Icon from '../Icon';
 import { formNames } from '../../constants/formNames';
 import FieldNotification from '../../constants/FieldNotification';
@@ -278,6 +279,17 @@ class VideoDisplay extends React.Component {
     }
   }
 
+  renderTargeting() {
+    return (
+      <div className="video__detailbox">
+        <div className="video__detailbox__header__container">
+          <header className="video__detailbox__header">Suggest this Video</header>
+        </div>
+        <Targeting video={this.props.video || {}} />
+      </div>
+    );
+  }
+
   render() {
     const video = this.props.video &&
       this.props.params.id === this.props.video.id
@@ -299,6 +311,7 @@ class VideoDisplay extends React.Component {
               {this.renderPreviewAndImages()}
             </div>
             <div className="video__row">
+              {this.renderTargeting()}
               {this.renderUsages()}
               {this.renderWorkflow()}
             </div>

--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -285,7 +285,9 @@ class VideoDisplay extends React.Component {
         <div className="video__detailbox__header__container">
           <header className="video__detailbox__header">Suggest this Video</header>
         </div>
-        <Targeting video={this.props.video || {}} />
+        <div className="form__group">
+          <Targeting video={this.props.video || {}} />
+        </div>
       </div>
     );
   }

--- a/public/video-ui/src/reducers/rootReducer.js
+++ b/public/video-ui/src/reducers/rootReducer.js
@@ -20,6 +20,7 @@ import uploads from './uploadsReducer';
 import path from './pathReducer';
 import pluto from './plutoReducer';
 import workflow from './workflowReducer';
+import targeting from './targetingReducer';
 
 export default combineReducers({
   audits,
@@ -42,5 +43,6 @@ export default combineReducers({
   path,
   routing: routerReducer,
   pluto,
-  workflow
+  workflow,
+  targeting
 });

--- a/public/video-ui/src/reducers/targetingReducer.js
+++ b/public/video-ui/src/reducers/targetingReducer.js
@@ -1,15 +1,40 @@
 // null here means targets haven't been fetched, an empty array means they have
 // been fetched but there are none
-export default function targeting(state = { targets: null }, action) {
+export default function targeting(state = { targets: null, deleting: [] }, action) {
   switch (action.type) {
+    case 'TARGETING_UPDATE_REQUEST':
+      return {
+        ...state,
+        targets: [
+          ...state.targets.filter(({ id }) => id !== action.target.id),
+          action.target
+        ]
+      };
     // when we start a new request for targets reset to our 'loading' state
+    // this gets called when we look for targets for a new video
     case 'TARGETING_GET_REQUEST':
-    case 'TARGETING_POST_REQUEST':
-      return { targets: null };
+      return { targets: null, deleting: [] };
     // if we receive any targets, for now, completely overwrite what's in here
     case 'TARGETING_POST_RECEIVE':
     case 'TARGETING_GET_RECEIVE':
-      return { targets: action.targets || [] };
+      return {
+        ...state,
+        targets: (state.targets || []).concat(action.targets)
+      };
+    case 'TARGETING_DELETE_REQUEST':
+      return {
+        ...state,
+        deleting: [...new Set([...state.deleting, action.target.id])]
+      };
+    case 'TARGETING_DELETE_RECEIVE':
+      return {
+        deleting: [...state.deleting.filter(id => id !== action.target.id)],
+        targets: [...state.targets.filter(({ id }) => id !== action.target.id)]
+      };
+    case 'TARGETING_DELETE_FAILURE':
+    return {
+      deleting: [...state.deleting.filter(id => id !== action.target.id)],
+    };
     default:
       return state;
   }

--- a/public/video-ui/src/reducers/targetingReducer.js
+++ b/public/video-ui/src/reducers/targetingReducer.js
@@ -1,6 +1,9 @@
 // null here means targets haven't been fetched, an empty array means they have
 // been fetched but there are none
-export default function targeting(state = { targets: null, deleting: [] }, action) {
+export default function targeting(
+  state = { targets: null, deleting: [] },
+  action
+) {
   switch (action.type) {
     case 'TARGETING_UPDATE_REQUEST':
       return {
@@ -16,10 +19,11 @@ export default function targeting(state = { targets: null, deleting: [] }, actio
       return { targets: null, deleting: [] };
     // if we receive any targets, for now, completely overwrite what's in here
     case 'TARGETING_POST_RECEIVE':
+    // v--- fallthrough ---v
     case 'TARGETING_GET_RECEIVE':
       return {
         ...state,
-        targets: (state.targets || []).concat(action.targets)
+        targets: [...(state.targets || []), ...action.targets]
       };
     case 'TARGETING_DELETE_REQUEST':
       return {
@@ -32,9 +36,9 @@ export default function targeting(state = { targets: null, deleting: [] }, actio
         targets: [...state.targets.filter(({ id }) => id !== action.target.id)]
       };
     case 'TARGETING_DELETE_FAILURE':
-    return {
-      deleting: [...state.deleting.filter(id => id !== action.target.id)],
-    };
+      return {
+        deleting: [...state.deleting.filter(id => id !== action.target.id)]
+      };
     default:
       return state;
   }

--- a/public/video-ui/src/reducers/targetingReducer.js
+++ b/public/video-ui/src/reducers/targetingReducer.js
@@ -1,0 +1,10 @@
+export default function targeting(state = { targets: [] }, action) {
+  switch (action.type) {
+    case 'TARGETING_GET_RECEIVE':
+      return Object.assign({}, state, {
+        targets: action.targets || []
+      });
+    default:
+      return state;
+  }
+}

--- a/public/video-ui/src/reducers/targetingReducer.js
+++ b/public/video-ui/src/reducers/targetingReducer.js
@@ -1,9 +1,11 @@
-export default function targeting(state = { targets: [] }, action) {
+// null here means targets haven't been fetched, an empty array means they have
+// been fetched but there are none
+export default function targeting(state = { targets: null }, action) {
   switch (action.type) {
+    // if we receive any targets, for now, completely overwrite what's in here
+    case 'TARGETING_POST_RECEIVE':
     case 'TARGETING_GET_RECEIVE':
-      return Object.assign({}, state, {
-        targets: action.targets || []
-      });
+      return { targets: action.targets || [] };
     default:
       return state;
   }

--- a/public/video-ui/src/reducers/targetingReducer.js
+++ b/public/video-ui/src/reducers/targetingReducer.js
@@ -2,6 +2,10 @@
 // been fetched but there are none
 export default function targeting(state = { targets: null }, action) {
   switch (action.type) {
+    // when we start a new request for targets reset to our 'loading' state
+    case 'TARGETING_GET_REQUEST':
+    case 'TARGETING_POST_REQUEST':
+      return { targets: null };
     // if we receive any targets, for now, completely overwrite what's in here
     case 'TARGETING_POST_RECEIVE':
     case 'TARGETING_GET_RECEIVE':

--- a/public/video-ui/src/services/TargetingApi.js
+++ b/public/video-ui/src/services/TargetingApi.js
@@ -1,0 +1,54 @@
+import {getStore} from '../util/storeAccessor';
+import { pandaReqwest } from './pandaReqwest';
+
+export default class TargetingApi {
+  static get targetingUrl() {
+    return getStore().getState().config.targetingUrl;
+  }
+
+  static get getEmail() {
+    return getStore().getState().config.presence.email;
+  }
+
+  static createTarget({id, title, tags, expiryDate}) {
+    const coreData = {
+      title,
+      tagPaths: tags,
+      url : `/atom/media/${id}`,
+      createdBy: TargetingApi.getEmail()
+    };
+
+    const data = Object.assign({}, coreData, expiryDate ? {activeUntil: expiryDate} : {});
+
+    const params = {
+      url: `${TargetingApi.targetingUrl}/api/suggestions`,
+      method: 'post',
+      data,
+      crossOrigin: true,
+      withCredentials: true
+    };
+
+    return pandaReqwest(params);
+  }
+
+  static deleteTarget({id}) {
+    const params = {
+      method: 'delete',
+      url: `${TargetingApi.targetingUrl}/api/suggestions/${id}`,
+      crossOrigin: true,
+      withCredentials: true
+    };
+
+    return pandaReqwest(params);
+  }
+
+  static getTargets({id}) {
+    const params = {
+      url: `${TargetingApi.targetingUrl}/api/suggestions/search?url=/atom/media/${id}`,
+      crossOrigin: true,
+      withCredentials: true
+    };
+
+    return pandaReqwest(params);
+  }
+}

--- a/public/video-ui/src/services/TargetingApi.js
+++ b/public/video-ui/src/services/TargetingApi.js
@@ -26,6 +26,18 @@ export default class TargetingApi {
     return pandaReqwest(params);
   }
 
+  static updateTarget({ id, ...data }) {
+    const params = {
+      url: `${TargetingApi.targetingUrl}/api/suggestions/${id}`,
+      method: 'put',
+      data,
+      crossOrigin: true,
+      withCredentials: true
+    };
+
+    return pandaReqwest(params);
+  }
+
   static deleteTarget({id}) {
     const params = {
       method: 'delete',

--- a/public/video-ui/src/services/TargetingApi.js
+++ b/public/video-ui/src/services/TargetingApi.js
@@ -6,16 +6,11 @@ export default class TargetingApi {
     return getStore().getState().config.targetingUrl;
   }
 
-  static get getEmail() {
-    return getStore().getState().config.presence.email;
-  }
-
-  static createTarget({id, title, tags, expiryDate}) {
+  static createTarget({id, title, expiryDate}) {
     const coreData = {
       title,
-      tagPaths: tags,
-      url : `/atom/media/${id}`,
-      createdBy: TargetingApi.getEmail()
+      tagPaths: [],
+      url : `/atom/media/${id}`
     };
 
     const data = Object.assign({}, coreData, expiryDate ? {activeUntil: expiryDate} : {});

--- a/public/video-ui/src/services/TargetingApi.js
+++ b/public/video-ui/src/services/TargetingApi.js
@@ -1,5 +1,8 @@
 import {getStore} from '../util/storeAccessor';
 import { pandaReqwest } from './pandaReqwest';
+import moment from 'moment';
+
+const getFortnight = () => moment().add('days', 14).valueOf();
 
 export default class TargetingApi {
   static get targetingUrl() {
@@ -7,13 +10,12 @@ export default class TargetingApi {
   }
 
   static createTarget({id, title, expiryDate}) {
-    const coreData = {
+    const data = {
       title,
       tagPaths: [],
-      url : `/atom/media/${id}`
+      url : `/atom/media/${id}`,
+      activeUntil: expiryDate || getFortnight()
     };
-
-    const data = Object.assign({}, coreData, expiryDate ? {activeUntil: expiryDate} : {});
 
     const params = {
       url: `${TargetingApi.targetingUrl}/api/suggestions`,

--- a/public/video-ui/styles/components/_expiry-date.scss
+++ b/public/video-ui/styles/components/_expiry-date.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  margin-bottom: 10px;
 
   /* overrides margins from form styling */
   div:not(:last-child) {

--- a/public/video-ui/styles/components/_targeting.scss
+++ b/public/video-ui/styles/components/_targeting.scss
@@ -1,0 +1,5 @@
+.targeting {
+  &__form {
+    margin-bottom: 10px;
+  }
+}

--- a/public/video-ui/styles/main.scss
+++ b/public/video-ui/styles/main.scss
@@ -47,4 +47,5 @@
   'components/advanced',
   'components/scribe',
   'components/presence',
-  'components/scheduledLaunch';
+  'components/scheduledLaunch',
+  'components/targeting';


### PR DESCRIPTION
This brings in basic support for targeting to MAM and allows multiple suggestions. It defaults to have an `activeUntil` of a fortnight away from today. The API allows this not to be set but a fortnight is what is used in atom workshop and seems like a sensible way to avoid suggestions hanging around forever!

Ideally we'd bring in data about tag reach and sample articles into the UI to make tagging less opaque but this is outside of the scope of this PR.

![suggestions 2](https://user-images.githubusercontent.com/1652187/35729827-d940f9de-0807-11e8-9371-9cce09cfec14.gif)

