### PR TITLE
Metadata error messages

### DIFF
--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -84,7 +84,7 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
               case e: GoogleJsonResponseException => {
                 val error: GoogleJsonError = e.getDetails
                 val message = error
-                Left(VideoUpdateError(error.toString + "metadata: " + prettyMetadata, Some(error.getMessage)))
+                Left(VideoUpdateError(error.toString + "\n metadata: " + prettyMetadata, Some(error.getMessage)))
               }
             }
           }

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -84,7 +84,7 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
               case e: GoogleJsonResponseException => {
                 val error: GoogleJsonError = e.getDetails
                 val message = error
-                Left(VideoUpdateError(error.toString, Some(error.getMessage)))
+                Left(VideoUpdateError(error.toString + "metadata: " + prettyMetadata, Some(error.getMessage)))
               }
             }
           }

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -221,7 +221,7 @@ package object youtube {
       Map(
         "title" -> metadata.title,
         "description" -> metadata.description,
-        "tags" -> metadata.tags,
+        "tags" -> Some(metadata.tags),
         "categoryId" -> metadata.categoryId,
         "license" -> metadata.license,
         "privacyStatus" -> metadata.privacyStatus.map(_.toString)


### PR DESCRIPTION
- Add details of video metadata to youtube update error message to allow for understanding why youtube tag updates keep failing. 