### PR TITLE
Targeting UX - first pass

### DIFF
--- a/public/video-ui/src/components/FormFields/DatePicker.js
+++ b/public/video-ui/src/components/FormFields/DatePicker.js
@@ -62,6 +62,7 @@ function DateSelector({ date, onChange }) {
     selected: date,
     minDate: moment(),
     dateFormat: DATE_FORMAT,
+    readOnly: true,
     onChange: newDate => {
       const base = date ? date : moment().hours(0).minutes(0);
       onChange(newDate.hours(base.hours()).minutes(base.minutes()));

--- a/public/video-ui/src/components/ManagedForm/ManagedForm.js
+++ b/public/video-ui/src/components/ManagedForm/ManagedForm.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { ManagedField } from './ManagedField';
+import { ManagedSection } from './ManagedSection';
 
 export class ManagedForm extends React.Component {
   static propTypes = {
@@ -15,6 +17,8 @@ export class ManagedForm extends React.Component {
     updateErrors: PropTypes.func,
     updateWarnings: PropTypes.func
   };
+
+  static managedTypes = [ManagedField, ManagedSection];
 
   updateFormErrors = (fieldError, fieldName) => {
     if (this.props.updateErrors) {
@@ -44,15 +48,20 @@ export class ManagedForm extends React.Component {
   };
 
   render() {
-    const hydratedChildren = React.Children.map(this.props.children, child => {
-      return React.cloneElement(child, {
-        data: this.props.data,
-        updateData: this.props.updateData,
-        updateFormErrors: this.updateFormErrors,
-        updateWarnings: this.updateWarnings,
-        editable: this.props.editable
-      });
-    });
+    const hydratedChildren = React.Children.map(
+      this.props.children,
+      child =>
+        // pass down the props to managed children only
+        ManagedForm.managedTypes.indexOf(child.type) > -1
+          ? React.cloneElement(child, {
+              data: this.props.data,
+              updateData: this.props.updateData,
+              updateFormErrors: this.updateFormErrors,
+              updateWarnings: this.updateWarnings,
+              editable: this.props.editable
+            })
+          : child
+    );
 
     return <div className={this.getFormClass()}>{hydratedChildren}</div>;
   }

--- a/public/video-ui/src/components/Targeting/Targeting.js
+++ b/public/video-ui/src/components/Targeting/Targeting.js
@@ -43,7 +43,7 @@ class Targeting extends React.Component {
       <div>
         {this.props.targetsLoaded && (
           <div>
-            <h3>Targeting rules</h3>
+            <p>A targeting rule will allow this video to be suggested for certain articles.</p>
             {this.props.targets.map((target, index) => (
               <div key={target.id} className="targeting__form">
                 {!isDeleting(target, this.props.deleting) && (
@@ -55,12 +55,17 @@ class Targeting extends React.Component {
                   >
                     <p>
                       {index === 0 ? (
-                        <span>An</span>
+                        <span>
+                          {this.props.targets.length > index + 1
+                            ? 'Either an '
+                            : 'An '}
+                        </span>
                       ) : (
-                        <span>... <strong className="highlight">or</strong> an</span>
-                      )} article must match
+                        <span>... <strong className="highlight">or</strong> an </span>
+                      )}
+                      article must match
                       <strong className="highlight"> all </strong>
-                      of the tags in this group to suggest this atom
+                      of the tags in this rule to suggest this atom
                       {this.props.targets.length > index + 1 ? ' ...' : '.'}
                     </p>
                     <ManagedField

--- a/public/video-ui/src/components/Targeting/Targeting.js
+++ b/public/video-ui/src/components/Targeting/Targeting.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import TagPicker from '../FormFields/TagPicker';
-import TextInput from '../FormFields/TextInput';
 import DatePicker from '../FormFields/DatePicker';
 import TagTypes from '../../constants/TagTypes';
 import { ManagedForm, ManagedField } from '../ManagedForm';
@@ -44,25 +43,29 @@ class Targeting extends React.Component {
       <div>
         {this.props.targetsLoaded && (
           <div>
-            {this.props.targets.map(target => (
+            <h3>Targeting rules</h3>
+            {this.props.targets.map((target, index) => (
               <div key={target.id} className="targeting__form">
-                <ManagedForm
-                  data={target}
-                  updateData={this.updateTarget}
-                  editable={true}
-                  formName="TargetingForm"
-                >
-                  <ManagedField
-                    fieldLocation="title"
-                    name="Title"
-                    disabled={isDeleting(target, this.props.deleting)}
+                {!isDeleting(target, this.props.deleting) && (
+                  <ManagedForm
+                    data={target}
+                    updateData={this.updateTarget}
+                    editable={true}
+                    formName="TargetingForm"
                   >
-                    <TextInput />
-                  </ManagedField>
-                  {!isDeleting(target, this.props.deleting) && (
+                    <p>
+                      {index === 0 ? (
+                        <span>An</span>
+                      ) : (
+                        <span>... <strong className="highlight">or</strong> an</span>
+                      )} article must match
+                      <strong className="highlight"> all </strong>
+                      of the tags in this group to suggest this atom
+                      {this.props.targets.length > index + 1 ? ' ...' : '.'}
+                    </p>
                     <ManagedField
                       fieldLocation="tagPaths"
-                      name="Tracking tags"
+                      name="Targeting tags"
                       formRowClass="form__row__byline"
                       tagType={TagTypes.tracking}
                       isDesired={false}
@@ -71,13 +74,11 @@ class Targeting extends React.Component {
                     >
                       <TagPicker disableTextInput />
                     </ManagedField>
-                  )}
-                  {!isDeleting(target, this.props.deleting) && (
                     <ManagedField fieldLocation="activeUntil" name="ActiveUntil">
                       <DatePicker canCancel={false} dayOnly />
                     </ManagedField>
-                  )}
-                </ManagedForm>
+                  </ManagedForm>
+                )}
                 {!isDeleting(target, this.props.deleting) && (
                   <button
                     className="button__secondary--cancel"
@@ -89,7 +90,7 @@ class Targeting extends React.Component {
               </div>
             ))}
             <button className="btn" onClick={this.createTarget}>
-              <Icon icon="add" /> Add suggestion
+              <Icon icon="add" /> Add targeting rule
             </button>
           </div>
         )}

--- a/public/video-ui/src/components/Targeting/Targeting.js
+++ b/public/video-ui/src/components/Targeting/Targeting.js
@@ -14,6 +14,28 @@ import * as updateTarget from '../../actions/TargetingActions/updateTarget';
 
 const isDeleting = (target, deleting) => deleting.indexOf(target.id) > -1;
 
+const TargetPrefix = ({ targetIndex, targetCount }) =>
+  targetIndex === 0 ? (
+    <span>{targetCount > targetIndex + 1 ? 'Either an ' : 'An '}</span>
+  ) : (
+    <span>
+      ... <strong className="highlight">or</strong> an
+    </span>
+  );
+
+const TargetSuffix = ({ targetIndex, targetCount }) => (
+  <span>{targetCount > targetIndex + 1 ? ' ...' : '.'}</span>
+);
+
+const TargetDescription = props => (
+  <p>
+    <TargetPrefix {...props} /> article must match
+    <strong className="highlight"> all </strong>
+    of the tags in this rule to suggest this video
+    <TargetSuffix {...props} />
+  </p>
+);
+
 class Targeting extends React.Component {
   static propTypes = {
     video: PropTypes.object.isRequired
@@ -53,21 +75,10 @@ class Targeting extends React.Component {
                     editable={true}
                     formName="TargetingForm"
                   >
-                    <p>
-                      {index === 0 ? (
-                        <span>
-                          {this.props.targets.length > index + 1
-                            ? 'Either an '
-                            : 'An '}
-                        </span>
-                      ) : (
-                        <span>... <strong className="highlight">or</strong> an </span>
-                      )}
-                      article must match
-                      <strong className="highlight"> all </strong>
-                      of the tags in this rule to suggest this atom
-                      {this.props.targets.length > index + 1 ? ' ...' : '.'}
-                    </p>
+                    <TargetDescription
+                      targetIndex={index}
+                      targetCount={this.props.targets.length}
+                    />
                     <ManagedField
                       fieldLocation="tagPaths"
                       name="Targeting tags"
@@ -75,11 +86,14 @@ class Targeting extends React.Component {
                       tagType={TagTypes.tracking}
                       isDesired={false}
                       isRequired={false}
-                      inputPlaceholder="Search commissioning info (type '*' to show all)"
+                      inputPlaceholder="Target these tags (type '*' to show all)"
                     >
                       <TagPicker disableTextInput />
                     </ManagedField>
-                    <ManagedField fieldLocation="activeUntil" name="ActiveUntil">
+                    <ManagedField
+                      fieldLocation="activeUntil"
+                      name="Active until"
+                    >
                       <DatePicker canCancel={false} dayOnly />
                     </ManagedField>
                   </ManagedForm>

--- a/public/video-ui/styles/base/_typography.scss
+++ b/public/video-ui/styles/base/_typography.scss
@@ -50,3 +50,7 @@ a {
 .success {
   color: $cGreen33;
 }
+
+.highlight {
+  color: $cYellow;
+}

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -150,12 +150,6 @@
   border-top: 1px solid $color625Grey;
 }
 
-.form__label__layout {
-  display: flex;
-  justify-content: space-between;
-  align-items: center
-}
-
 .form__label__button {
   font-size: 10px;
   padding: 5px;

--- a/public/video-ui/styles/components/_targeting.scss
+++ b/public/video-ui/styles/components/_targeting.scss
@@ -1,5 +1,7 @@
 .targeting {
   &__form {
+    background: rgba(255, 255, 255, 0.04);
     margin-bottom: 10px;
+    padding: 10px;
   }
 }


### PR DESCRIPTION
This removes the editable title for targeting (which appears to not be used and is confusing) and also add some UI descriptions around what targets are and how they work. Specifically with an aim to be more clear about where the tags are `AND` and where they are `OR` for showing in proposer. Thoughts?!

![targeting](https://user-images.githubusercontent.com/1652187/35805233-f31f53a6-0a72-11e8-9def-44a23f6caa99.gif)

