### PR TITLE
Disable composer video page create if usage errors

### DIFF
--- a/public/video-ui/src/actions/VideoActions/videoUsages.js
+++ b/public/video-ui/src/actions/VideoActions/videoUsages.js
@@ -1,5 +1,6 @@
 import VideosApi from '../../services/VideosApi';
 import { blankUsageData } from '../../constants/blankUsageData';
+import ErrorMessages from '../../constants/ErrorMessages';
 
 function requestVideoUsages() {
   return {
@@ -19,7 +20,7 @@ function receiveVideoUsages(usages) {
 function errorReceivingVideoUsages(error) {
   return {
     type: 'SHOW_ERROR',
-    message: 'Could not get video usages',
+    message: ErrorMessages.usages,
     error: error,
     receivedAt: Date.now()
   };

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -217,6 +217,7 @@ export default class Header extends React.Component {
             createVideoPage={this.props.createVideoPage}
             requiredComposerFieldsMissing={this.requiredComposerFieldsMissing}
             usages={this.props.usages}
+            error={this.props.error}
           />
           {this.renderComposerMissingWarning()}
           <div className="flex-container">

--- a/public/video-ui/src/components/ReactApp.js
+++ b/public/video-ui/src/components/ReactApp.js
@@ -77,6 +77,7 @@ class ReactApp extends React.Component {
           updateVideo={this.props.appActions.updateVideo}
           saveVideo={this.props.appActions.saveVideo}
           query={this.props.location.query}
+          error={this.props.error}
         />
         {this.props.error
           ? <div

--- a/public/video-ui/src/components/Videos/ComposerPageCreate.js
+++ b/public/video-ui/src/components/Videos/ComposerPageCreate.js
@@ -3,6 +3,7 @@ import { getVideoBlock } from '../../util/getVideoBlock';
 import Icon from '../Icon';
 import { getStore } from '../../util/storeAccessor';
 import { canonicalVideoPageExists } from '../../util/canonicalVideoPageExists';
+import ErrorMessages from '../../constants/ErrorMessages';
 
 export default class ComposerPageCreate extends React.Component {
   state = {
@@ -26,6 +27,10 @@ export default class ComposerPageCreate extends React.Component {
 
   isHosted = () => {
     return this.props.video.category === 'Hosted';
+  };
+
+  usageErrorsExist = () => {
+    return this.props.error === ErrorMessages.usages;
   };
 
   getComposerLink = () => `${this.getComposerUrl()}/content/${this.getComposerId()}`;
@@ -62,14 +67,18 @@ export default class ComposerPageCreate extends React.Component {
     }
 
     else {
+      const helpMsg = this.usageErrorsExist() ? 'Cannot create a video page because of errors in fetching video usages' : '';
+
       return (
-        <button
-          className="button__secondary"
-          onClick={this.pageCreate}
-          disabled={videoEditOpen || this.state.composerUpdateInProgress || requiredComposerFieldsMissing()}
-        >
+        <span data-tip={helpMsg}>
+          <button
+            className="button__secondary"
+            onClick={this.pageCreate}
+            disabled={videoEditOpen || this.state.composerUpdateInProgress || requiredComposerFieldsMissing() || this.usageErrorsExist()}
+          >
           <Icon icon="add_to_queue">Create Video Page</Icon>
         </button>
+      </span>
       );
     }
   }

--- a/public/video-ui/src/constants/ErrorMessages.js
+++ b/public/video-ui/src/constants/ErrorMessages.js
@@ -1,0 +1,6 @@
+export default class ErrorMessages {
+  static get usages() {
+    return 'Could not get video usages'
+  }
+
+}


### PR DESCRIPTION
This PR disables video page creation if we get errors when fetching usages. For it to work perfectly, we'd need to refactor the code to be able to store multiple errors messages but that would be a separate piece of work. 