### PR TITLE
change atom channel on add asset

### DIFF
--- a/app/model/commands/AddAssetCommand.scala
+++ b/app/model/commands/AddAssetCommand.scala
@@ -74,9 +74,14 @@ case class AddAssetCommand(atomId: String, videoUri: String, override val stores
         }
       }
       case (Some(channel), Some(video)) => {
-        // new asset must match the atom's channel
         val videoChannel = video.getSnippet.getChannelId
-        if (channel == videoChannel) videoChannel else IncorrectYouTubeChannel
+
+        if (channel != videoChannel) {
+          log.info(s"Atom channel updating. New asset ${asset.id} on channel $videoChannel, atom on channel $channel")
+        }
+
+        // new asset must be on a Guardian channel
+        if (!youTube.channels.exists(_.id == videoChannel)) IncorrectYouTubeChannel else videoChannel
       }
     }
   }


### PR DESCRIPTION
There have been a couple of times where Adam has wanted to change the channel of an Atom because of incorrect selection but was unable to. In these scenarios, we either curl the update endpint, editing the channel, or create a new atom. Both aren't great.

This PR changes the behaviour of the add asset endpoint allowing you to paste in the URL of any video and if the channel is recognised, the Atom's channel gets updated to match.