### PR TITLE
limit youtube keywords to 430 characters

### DIFF
--- a/public/video-ui/src/constants/youTubeKeywords.js
+++ b/public/video-ui/src/constants/youTubeKeywords.js
@@ -1,5 +1,5 @@
 export default class YouTubeKeywords {
   static get maxCharacters() {
-    return 450;
+    return 430;
   }
 }


### PR DESCRIPTION
Having a 450 character limit on youtube keywords was still causing errors on youtube. Looking at the logs and failed youtube requests, lowering the limit to 430 characters should fix the problem. 