### PR TITLE
Project-assigned fields

### DIFF
--- a/common/src/main/scala/com/gu/media/model/PlutoIntegrationData.scala
+++ b/common/src/main/scala/com/gu/media/model/PlutoIntegrationData.scala
@@ -16,7 +16,9 @@ case class AtomAssignedProjectMessage(
   `type`: String,
   atomId: String,
   commissionId: String,
-  projectId: String
+  projectId: String,
+  title: String,
+  user: String
 ) extends PlutoIntegrationMessage {
   override def partitionKey: String = atomId
 }
@@ -26,7 +28,12 @@ object AtomAssignedProjectMessage {
 
   def build(atom: MediaAtom): AtomAssignedProjectMessage = {
     val plutoData = atom.plutoData.get
-    AtomAssignedProjectMessage("project-assigned", atom.id, plutoData.commissionId.get, plutoData.projectId.get)
+    val email = atom.contentChangeDetails.created match {
+      case Some(changeRecord)=>changeRecord.user.getOrElse("unknown_user").toString
+      case None=>"unknown_user"
+    }
+
+    AtomAssignedProjectMessage("project-assigned", atom.id, plutoData.commissionId.get, plutoData.projectId.get, atom.title, email)
   }
 }
 

--- a/common/src/main/scala/com/gu/media/model/PlutoIntegrationData.scala
+++ b/common/src/main/scala/com/gu/media/model/PlutoIntegrationData.scala
@@ -32,8 +32,7 @@ object AtomAssignedProjectMessage {
     val email = for {
       created <- atom.contentChangeDetails.created
       user <- created.user
-      user_email <- user.email
-    } yield user_email
+    } yield user.email
 
     AtomAssignedProjectMessage("project-assigned", atom.id, plutoData.commissionId.get, plutoData.projectId.get, atom.title, email)
   }

--- a/common/src/main/scala/com/gu/media/model/PlutoIntegrationData.scala
+++ b/common/src/main/scala/com/gu/media/model/PlutoIntegrationData.scala
@@ -18,7 +18,7 @@ case class AtomAssignedProjectMessage(
   commissionId: String,
   projectId: String,
   title: String,
-  user: String
+  user: Option[String]
 ) extends PlutoIntegrationMessage {
   override def partitionKey: String = atomId
 }
@@ -28,10 +28,12 @@ object AtomAssignedProjectMessage {
 
   def build(atom: MediaAtom): AtomAssignedProjectMessage = {
     val plutoData = atom.plutoData.get
-    val email = atom.contentChangeDetails.created match {
-      case Some(changeRecord)=>changeRecord.user.getOrElse("unknown_user").toString
-      case None=>"unknown_user"
-    }
+
+    val email = for {
+      created <- atom.contentChangeDetails.created
+      user <- created.user
+      user_email <- user.email
+    } yield user_email
 
     AtomAssignedProjectMessage("project-assigned", atom.id, plutoData.commissionId.get, plutoData.projectId.get, atom.title, email)
   }


### PR DESCRIPTION
adding "title" and "user" fields to the "project assigned" message; we have been receiving a lot of these at the pluto end which have not yet been ingested, and cannot start an ingest without these fields