### PR TITLE
Private block ads

### DIFF
--- a/app/model/commands/DeleteCommand.scala
+++ b/app/model/commands/DeleteCommand.scala
@@ -7,12 +7,12 @@ import com.gu.contentatom.thrift.atom.media.PrivacyStatus
 import com.gu.contentatom.thrift.{ContentAtomEvent, EventType}
 import com.gu.media.logging.Logging
 import com.gu.media.model.{VideoUpdateError, Asset, MediaAtom}
-import com.gu.media.youtube.YouTubeVideos
 import data.DataStores
 import com.gu.media.model.Platform.Youtube
 import model.YouTubeMessage
+import util.YouTube
 
-case class DeleteCommand(id: String, override val stores: DataStores, youTube: YouTubeVideos)
+case class DeleteCommand(id: String, override val stores: DataStores, youTube: YouTube)
   extends Command with AtomAPIActions with Logging {
 
   type T = Unit
@@ -40,6 +40,11 @@ case class DeleteCommand(id: String, override val stores: DataStores, youTube: Y
 
         case Left(error: VideoUpdateError) => YouTubeMessage(id, videoId, "Atom Deletion", error.errorToLog, isError = true).logMessage
 
+      }
+
+      youTube.createOrUpdateClaim(id, videoId, blockAds=true) match {
+        case Right(message: String) => YouTubeMessage(id, videoId, "Asset marked as private due to atom deletion", message).logMessage
+        case Left(error: VideoUpdateError) => YouTubeMessage(id, videoId, "Asset private due to atom Deletion", error.errorToLog, isError = true).logMessage
       }
   }
 }

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -202,8 +202,12 @@ case class PublishAtomCommand(
             handleYouTubeMessages(claimUpdate, "YouTube Claim Update: Block ads on Glabs atom", previewAtom, asset.id)
           }
           case _ => {
-            val claimUpdate = youtube.createOrUpdateClaim(previewAtom.id, asset.id, previewAtom.blockAds)
-            handleYouTubeMessages(claimUpdate, "YouTube Claim Update: block ads updated", previewAtom, asset.id)
+            val activeAssetClaimUpdate = youtube.createOrUpdateClaim(previewAtom.id, asset.id, previewAtom.blockAds)
+            handleYouTubeMessages(activeAssetClaimUpdate, "YouTube Claim Update: block ads updated", previewAtom, asset.id)
+            val oldActiveAsset = getActiveAsset(publishedAtom).get
+            val oldActiveAssetClaimUpdate = youtube.createOrUpdateClaim(previewAtom.id, oldActiveAsset.id, blockAds = true)
+            handleYouTubeMessages(oldActiveAssetClaimUpdate, "YouTube Claim Update: ads blocked on previous active asset",
+              previewAtom, oldActiveAsset.id)
           }
         }
       }

--- a/expirer/src/test/resources/one-atom-per-page-page-1.json
+++ b/expirer/src/test/resources/one-atom-per-page-page-1.json
@@ -4,6 +4,7 @@
     "pages": 2,
     "results": [
       {
+        "id": "oneAtomPerPage1",
         "data": {
           "media": {
             "metadata": {

--- a/expirer/src/test/resources/one-atom-per-page-page-2.json
+++ b/expirer/src/test/resources/one-atom-per-page-page-2.json
@@ -4,6 +4,7 @@
     "pages": 2,
     "results": [
       {
+        "id": "oneAtomPerPage2",
         "data": {
           "media": {
             "metadata": {

--- a/expirer/src/test/resources/one-expired-atom-one-yt-asset-one-nonyt-asset.json
+++ b/expirer/src/test/resources/one-expired-atom-one-yt-asset-one-nonyt-asset.json
@@ -4,6 +4,7 @@
     "pages": 1,
     "results": [
       {
+        "id": "oneExpiredAtomOneYtAsset",
         "data": {
           "media": {
             "metadata": {

--- a/expirer/src/test/resources/one-expired-atom-two-yt-assets.json
+++ b/expirer/src/test/resources/one-expired-atom-two-yt-assets.json
@@ -4,6 +4,7 @@
     "pages": 1,
     "results": [
       {
+        "id": "oneExpiredTwoAssets",
         "data": {
           "media": {
             "metadata": {

--- a/expirer/src/test/scala/com/gu/media/ExpirerLambdaTest.scala
+++ b/expirer/src/test/scala/com/gu/media/ExpirerLambdaTest.scala
@@ -14,6 +14,7 @@ class ExpirerLambdaTest extends FunSuite with MustMatchers {
 
     lambda.handleRequest((), null)
     lambda.madePrivate must be(List("one", "two"))
+    lambda.claimUpdated must be(List("one", "two"))
   }
 
   test("Not touch other assets") {
@@ -22,6 +23,7 @@ class ExpirerLambdaTest extends FunSuite with MustMatchers {
 
     lambda.handleRequest((), null)
     lambda.madePrivate must be(List("one"))
+    lambda.claimUpdated must be(List("one"))
   }
 
   test("Not touch third party videos") {
@@ -30,6 +32,7 @@ class ExpirerLambdaTest extends FunSuite with MustMatchers {
 
     lambda.handleRequest((), null)
     lambda.madePrivate mustBe empty
+    lambda.claimUpdated mustBe empty
   }
 
   test("Iterate through CAPI pages") {
@@ -39,10 +42,12 @@ class ExpirerLambdaTest extends FunSuite with MustMatchers {
 
     lambda.handleRequest((), null)
     lambda.madePrivate must be(List("one", "two"))
+    lambda.claimUpdated must be(List("one", "two"))
   }
 
   class TestExpirerLambda(var capiResults: List[String], isMyVideo: Boolean = true) extends ExpirerLambda with TestSettings {
     var madePrivate = List.empty[String]
+    var claimUpdated = List.empty[String]
 
     override def capiQuery(path: String, qs: Map[String, String], queryLive: Boolean = false): JsValue = {
       val ret = capiResults.head
@@ -54,6 +59,11 @@ class ExpirerLambdaTest extends FunSuite with MustMatchers {
     override def setStatus(id: String, privacyStatus: PrivacyStatus): Either[VideoUpdateError, String] = {
       privacyStatus must be(PrivacyStatus.Private)
       madePrivate :+= id
+      Right("")
+    }
+
+    override def createOrUpdateClaim(atomId: String, assetId: String, blockAds: Boolean) = {
+      claimUpdated :+= assetId
       Right("")
     }
 


### PR DESCRIPTION
When videos are made private (on atom delete, publish or expiry), we should also block adds on these videos. 

https://trello.com/c/iP52mrB0/268-marking-video-as-private-should-also-block-ads

