### PR TITLE
remove the link back to theguardian.com

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -238,28 +238,10 @@ case class PublishAtomCommand(
       html.text().replace("\\n", "\n")
   }
 
-  private def getComposerLinkText(atomId: String): String = {
-    val path = s"/atom/media/$atomId/usage"
-    val emptyQs: Map[String, String] = Map()
-
-    val usages: JsValue = (capi.capiQuery(path, emptyQs, queryLive = true) \ "response" \ "results").get
-    val usagesList = usages.as[List[String]]
-
-    val composerPage = usagesList.find(usage => {
-      val contentType = (capi.capiQuery(usage, emptyQs, queryLive = true) \ "response" \ "content" \ "type").get.as[String]
-      contentType == "video"
-    })
-
-    composerPage match {
-      case Some(page) => "\nView the video at https://www.theguardian.com/" + page
-      case None => ""
-    }
-  }
-
   private def updateYoutubeMetadata(previewAtom: MediaAtom, asset: Asset): MediaAtom = {
 
     val description = previewAtom.description.map(description => {
-      removeHtmlTagsForYouTube(description) + getComposerLinkText(previewAtom.id)
+      removeHtmlTagsForYouTube(description)
     })
 
     val metadata = YouTubeMetadataUpdate(


### PR DESCRIPTION
Adam has asked for this to be removed as it doesn't add value to the video description; you're already watching the video on youtube, why would you click to watch it again on theguardian.com?