### PR TITLE
Fix link keyboard shortcut

### DIFF
--- a/public/video-ui/src/constants/keyCodes.js
+++ b/public/video-ui/src/constants/keyCodes.js
@@ -4,5 +4,6 @@ export const keyCodes = {
   down: 40,
   up: 38,
   b: 66,
-  i: 73
+  i: 73,
+  k: 75
 };


### PR DESCRIPTION
The constant was missing from keyCodes. We should probably be using [KeyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) anyway but this is a nice quick fix.