### PR TITLE
only change privacy status iff you have permission to do so

### DIFF
--- a/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
@@ -15,9 +15,9 @@ trait YouTubeAccess extends Settings {
   def contentOwner: String = getMandatoryString("youtube.contentOwner")
 
   val allowedChannels: Set[String] = getStringSet("youtube.channels.allowed")
-  val unlistedWithoutPermissionChannels: Set[String] = getStringSet("youtube.channels.unlisted")
+  val channelsRequiringPermission: Set[String] = getStringSet("youtube.channels.unlisted")
   val commercialChannels: Set[String] = getStringSet("youtube.channels.commercial")
-  val allChannels: Set[String] = allowedChannels ++ unlistedWithoutPermissionChannels ++ commercialChannels
+  val allChannels: Set[String] = allowedChannels ++ channelsRequiringPermission ++ commercialChannels
 
   val trainingChannels: Set[String] = getStringSet("youtube.channels.training")
 

--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -73,7 +73,7 @@ package object youtube {
     implicit val writes: Writes[YouTubeChannelWithData] = Json.writes[YouTubeChannelWithData]
 
     private def getPrivacyStates(id: String, hasMakePublicPermission: Boolean, youtubeAccess: YouTubeAccess): Set[PrivacyStatus] = {
-      if (!youtubeAccess.unlistedWithoutPermissionChannels.contains(id)) {
+      if (!youtubeAccess.channelsRequiringPermission.contains(id)) {
         PrivacyStatus.all
       } else {
         if (hasMakePublicPermission) PrivacyStatus.all else Set(PrivacyStatus.Unlisted, PrivacyStatus.Private)


### PR DESCRIPTION
Adam has raised the idea that once a video is public, it should remain public. Else he ends up playing a cat and mouse game when someone w/out permission edits the title, thumbnail etc as the video becomes unlisted.

This change enforces that on publish by:
- checking if you have permission on that channel
- if you do, then take the preview status
- if you don't then take the publish status

NB this should be in the `UpdateAtomCommand` rather than the `PublishAtomCommand` so that it takes effect on save rather than on publish. I'll raise this as a separate PR.