### PR TITLE
send an email when a new YouTube video is uploaded with WC tags

### DIFF
--- a/common/src/main/scala/com/gu/media/aws/SESSettings.scala
+++ b/common/src/main/scala/com/gu/media/aws/SESSettings.scala
@@ -10,7 +10,11 @@ trait SESSettings { this: Settings with AwsAccess =>
 
   val fromEmailAddress = getMandatoryString("aws.ses.fromEmailAddress")
 
-  val replyToAddresses = getMandatoryString("aws.ses.replyToAddresses").split(",")
+  val replyToAddresses: Seq[String] = getMandatoryString("aws.ses.replyToAddresses").split(",").toSeq
 
   val integrationTestUser: String = getMandatoryString("integration.test.user")
+
+  val host: String = getMandatoryString("host")
+
+  val worldCupEmailRecipients = getMandatoryString("aws.ses.worldCupRecipients").split(",").toSeq
 }

--- a/common/src/main/scala/com/gu/media/ses/Mailer.scala
+++ b/common/src/main/scala/com/gu/media/ses/Mailer.scala
@@ -1,31 +1,59 @@
 package com.gu.media.ses
 
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient
 import com.amazonaws.services.simpleemail.model._
+import com.gu.media.aws.SESSettings
+import com.gu.media.model.MediaAtom
+import com.gu.media.Settings
 
 import scala.collection.JavaConversions._
 
-class Mailer(sesClient: AmazonSimpleEmailServiceClient, host: String) {
-  def sendPlutoIdMissingEmail(atomId: String, atomTitle: String, sendTo: String, fromAddress: String, replyToAddresses: Array[String]): Unit = {
+class Mailer(config: Settings with SESSettings) {
+  def sendPlutoIdMissingEmail(atomId: String, atomTitle: String, sendTo: String): SendEmailResult = {
 
     val emailBody =
       s"""
         |<div>The video “$atomTitle” that you uploaded via Media Atom Maker recently, does not have a Pluto project associated with it.</div>
-        |<div>Please visit <a href="https://$host/videos/$atomId/upload" target="_blank" rel="noopener noreferrer">this address</a> to set its Pluto project.
+        |<div>Please visit ${getLinkTag(s"${getAtomUrl(atomId)}/upload", "this address")} to set its Pluto project.
         |<div>Without a project, the video won’t be archived and won't maintain a link to its original Adobe Premiere project and assets.</div>
         |
-        |<div>For a complete list of incomplete Atoms, <a href="https://$host/videos/pluto-list" target="_blank" rel="noopener noreferrer">click here</a>.
+        |<div>For a complete list of incomplete Atoms, ${getLinkTag(s"https://${config.host}/videos/pluto-list", "click here")}.
       """.stripMargin
 
-    sesClient.sendEmail(new SendEmailRequest()
-      .withDestination(new Destination().withToAddresses(sendTo))
-      .withMessage(new Message()
-        .withSubject(new Content("[Media Atom Maker] Failed Pluto Video Ingest - Action Required"))
-        .withBody(new Body().withHtml(new Content(emailBody)))
-      )
-      .withSource(fromAddress)
-      .withReplyToAddresses(replyToAddresses.toSeq)
+    sendEmail(List(sendTo), "Failed Pluto Video Ingest - Action Required", emailBody)
+  }
 
+  def sendWorldCupEmail(atom: MediaAtom): Option[SendEmailResult] = {
+    atom.getActiveYouTubeAsset() match {
+      case Some(asset) => {
+        val emailBody =
+          s"""
+             | <div>A Video Atom has been published with a YouTube video with either a tag <code>2018 world cup</code> or <code>world cup 2018</code>.</div>
+             | <div>Click ${getLinkTag(getAtomUrl(atom.id), "here")} to view the Atom.</div>
+             | <div>Click ${getLinkTag(getActiveYoutubeAssetLink(asset.id), "here")} to view the YouTube video</div>
+           """.stripMargin
+
+        Some(sendEmail(config.worldCupEmailRecipients, "Atom published with World Cup 2018 tags", emailBody))
+      }
+      case _ => None
+    }
+  }
+
+  private def getAtomUrl(atomId: String) = s"https://${config.host}/videos/$atomId"
+
+  private def getActiveYoutubeAssetLink(youtubeVideoId: String) = s"https://www.youtube.com/watch?v=$youtubeVideoId"
+
+  private def getLinkTag(url: String, text: String) = s"""<a href="$url" target="_blank" rel="noopener noreferrer">$text</a>"""
+
+  private def sendEmail(recipients: Seq[String], subject: String, body: String): SendEmailResult = {
+    config.sesClient.sendEmail(new SendEmailRequest()
+      .withDestination(new Destination().withToAddresses(recipients))
+      .withMessage(new Message()
+        .withSubject(new Content(s"[Media Atom Maker] $subject"))
+        .withBody(new Body().withHtml(new Content(body)))
+      )
+      .withSource(config.fromEmailAddress)
+      .withReplyToAddresses(config.replyToAddresses)
     )
   }
+
 }

--- a/common/src/main/scala/com/gu/media/upload/PlutoUploadActions.scala
+++ b/common/src/main/scala/com/gu/media/upload/PlutoUploadActions.scala
@@ -7,7 +7,7 @@ import com.gu.media.ses.Mailer
 import com.gu.media.{PlutoDataStore, Settings}
 
 class PlutoUploadActions(config: Settings with DynamoAccess with KinesisAccess with SESSettings) extends Logging {
-  private val mailer = new Mailer(config.sesClient, config.getMandatoryString("host"))
+  private val mailer = new Mailer(config)
   private val plutoStore = new PlutoDataStore(config.dynamoDB, config.manualPlutoDynamo)
 
   def sendToPluto(plutoIntegrationMessage: PlutoIntegrationMessage): Unit = {
@@ -26,9 +26,7 @@ class PlutoUploadActions(config: Settings with DynamoAccess with KinesisAccess w
               mailer.sendPlutoIdMissingEmail(
                 plutoData.atomId,
                 plutoData.title,
-                plutoData.user,
-                config.fromEmailAddress,
-                config.replyToAddresses
+                plutoData.user
               )
             }
           }


### PR DESCRIPTION
We've got an ad campaign for the WC which will get served when a video has the tag `world cup 2018` or `2018 world cup`.

There have been a couple of instances where the YouTube video didn't make it to DfP for targeting. We're not sure why this is as the video appears to be tagged correctly on youtube.com.

Tom suggested sending him an email when a new video is uploaded to YouTube with these tags so he can then check DfP immediately rather than finding DfP is missing items when its too late.

Note: the email gets sent when an atom is published with a new YouTube asset, or the tags have been added to the existing asset.