### PR TITLE
change wording for consistency

### DIFF
--- a/public/video-ui/src/components/VideoPublishState/VideoPublishState.js
+++ b/public/video-ui/src/components/VideoPublishState/VideoPublishState.js
@@ -13,7 +13,7 @@ export default class VideoPublishState extends React.Component {
     }
 
     if (isVideoPublished(this.props.video)) {
-      return <div className="publish__label label__live">Live</div>;
+      return <div className="publish__label label__live">Published</div>;
     }
 
     return <div className="publish__label label__draft">Draft</div>;

--- a/public/video-ui/styles/components/_header.scss
+++ b/public/video-ui/styles/components/_header.scss
@@ -1,5 +1,5 @@
 .publish__label {
-  width: 60px;
+  min-width: 60px;
   height: 30px;
   color: $color800Grey;
   border-radius: 25px;


### PR DESCRIPTION
A "live" atom is published. We say "published" on the search page. "Published" is established naming in other Tools. Why be different?