### PR TITLE
log revision number when logging successful publish

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -177,7 +177,7 @@ case class PublishAtomCommand(
       case Success(_) =>
         publishedDataStore.updateAtom(atom) match {
           case Right(_) => {
-            log.info(s"Successfully published atom: ${id}")
+            log.info(s"Successfully published atom: ${id} (revision ${atom.contentChangeDetails.revision})")
             MediaAtom.fromThrift(atom)
           }
           case Left(err) =>


### PR DESCRIPTION
We've found some atoms where updates seemingly fail to reach capi. Log the revision number to make make debugging a bit easier.