### PR TITLE
Print the youtube video id on the page

### DIFF
--- a/public/video-ui/src/components/Video/Display.js
+++ b/public/video-ui/src/components/Video/Display.js
@@ -17,6 +17,7 @@ import YouTubeKeywords from '../../constants/youTubeKeywords';
 import { getYouTubeTagCharCount } from '../../util/getYouTubeTagCharCount';
 import { canonicalVideoPageExists } from '../../util/canonicalVideoPageExists';
 import { isVideoPublished } from '../../util/isVideoPublished';
+import VideoUtils from '../../util/video';
 
 class VideoDisplay extends React.Component {
   componentWillMount() {
@@ -192,10 +193,17 @@ class VideoDisplay extends React.Component {
   }
 
   renderPreviewAndImages() {
+    const isYoutube = VideoUtils.isYoutube(this.props.video);
+    const activeAsset = VideoUtils.getActiveAsset(this.props.video);
+    const youtubeAsset = isYoutube && activeAsset;
+
     return (
       <div className="video__detailbox">
         <div className="video__detailbox__header__container">
-          <header className="video__detailbox__header">Video Preview</header>
+          <header className="video__detailbox__header">
+            Video Preview
+            {youtubeAsset ? ` (${youtubeAsset.id})` : ``}
+          </header>
           <Link
             className={'button ' + (this.props.videoEditOpen ? 'disabled' : '')}
             to={`/videos/${this.props.video.id}/upload`}


### PR DESCRIPTION
Currently, its really hard for adops to find the youtube id:
- open MAM
- find video
- play video
- click link to open video on youtube
- copy video id from url

We know the id, lets just tell them!

This is a very basic implementation, but should be enough to get moving.

![image](https://user-images.githubusercontent.com/836140/43316828-7cafec4c-9192-11e8-8fc6-5eec9f6d2d27.png)
