### PR TITLE
404 if resync requested when no media is available

### DIFF
--- a/app/controllers/PlutoController.scala
+++ b/app/controllers/PlutoController.scala
@@ -51,16 +51,16 @@ class PlutoController(
   }
 
   def resendAtomMessage(id: String) = APIHMACAuthAction {
-
     try {
       val atomContent = getPreviewAtom(id)
       val atom = MediaAtom.fromThrift(atomContent)
-      val versionWithId = MediaAtomHelpers.getCurrentAssetVersion(atom) match {
-        case Some(versionNumber)=>id + s"-$versionNumber"
-        case None=>
-          log.error("Requested re-index on an atom with no currentAssetVersion, this could indicate a problem.")
-          id
+
+      if(MediaAtomHelpers.getCurrentAssetVersion(atom).isEmpty){
+        log.warn("Requested re-index on an atom with no currentAssetVersion, returning 404")
+        NotFound(Json.toJson(Map("status"->"notfound", "detail"->"atom had no current version, resync was probably sent too early")))
       }
+
+      val versionWithId = id + s"-${MediaAtomHelpers.getCurrentAssetVersion(atom).get}"
 
       atom.plutoData match {
         case Some(data)=>


### PR DESCRIPTION
if a resync request is sent without a version being present, return a 404 with a descriptive error message