### PR TITLE
remove created date from pluto projects

### DIFF
--- a/common/src/main/scala/com/gu/media/pluto/PlutoProject.scala
+++ b/common/src/main/scala/com/gu/media/pluto/PlutoProject.scala
@@ -27,8 +27,7 @@ case class PlutoProject (
   status: String,
   commissionId: String,
   commissionTitle: String, //TODO remove this once migrated
-  productionOffice: String,
-  created: DateTime
+  productionOffice: String
 )
 
 object PlutoProject {
@@ -41,8 +40,7 @@ object PlutoProject {
       status = plutoUpsertRequest.status,
       commissionId = plutoUpsertRequest.commissionId,
       commissionTitle = plutoUpsertRequest.commissionTitle,
-      productionOffice = plutoUpsertRequest.productionOffice,
-      created = plutoUpsertRequest.created
+      productionOffice = plutoUpsertRequest.productionOffice
     )
   }
 }
@@ -54,7 +52,6 @@ case class PlutoUpsertRequest (
   title: String,
   status: String,
   productionOffice: String,
-  created: DateTime,
   commissionId: String,
   commissionTitle: String
 )


### PR DESCRIPTION
We have had multiple reports of commissions and projects not appearing in MAM. Looking at the logs, they are littered with:

```
Caused by: java.lang.IllegalArgumentException: Invalid format: "2018-09-11T10:54:14.582880" is too short
	at org.joda.time.format.DateTimeFormatter.parseDateTime(DateTimeFormatter.java:945)
```

I've not been able to fix the issue upstream in Pluto. Dates are hard and we're not using this field so lets remove it and get things working again.