### PR TITLE
live stream support

### DIFF
--- a/common/src/main/scala/com/gu/media/model/ClientAsset.scala
+++ b/common/src/main/scala/com/gu/media/model/ClientAsset.scala
@@ -111,6 +111,8 @@ object ClientAssetProcessing {
     case YouTubeProcessingStatus(_, "processing", _, _, timeLeftMs, _) =>
       s"YouTube Processing (${timeLeftMs / 1000}s left)"
 
+    case YouTubeProcessingStatus(_, "live", _, _, _, _) => "YouTube Live Stream"
+
     case _ =>
       status.failure.getOrElse(status.status)
   }

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -23,7 +23,7 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
   def getProcessingStatus(videoId: String): Option[YouTubeProcessingStatus] = {
     if(isGuardianVideo(videoId)) {
       val request = client.videos()
-        .list("status,processingDetails")
+        .list("snippet,status,processingDetails")
         .setId(videoId)
         .setOnBehalfOfContentOwner(contentOwner)
 

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.js
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.js
@@ -129,7 +129,7 @@ export function Asset({ upload, isActive, selectAsset, deleteAsset }) {
           <AssetProgress {...processing} />
         </div>
         <div className="grid__item__footer">
-          <AssetControls user={user}>
+          <AssetControls user={user} selectAsset={selectAsset} deleteAsset={deleteAsset}>
             <AssetInfo info={processing.status} />
           </AssetControls>
         </div>


### PR DESCRIPTION
Allow live streams to be added as an asset.

We use the upload status of a video to determine which actions to take for a video. The status of a live stream is `uploading`, the same as a video that you're uploading to YouTube. Unlike a new upload, the livestream will only transition to `uploaded` once it ends.

This changes that behaviour. We now check if `getLiveBroadcastContent` suggests the video is `live` and allow it to be activated in the Atom.

Easiest to see changes without whitespace - https://github.com/guardian/media-atom-maker/pull/811/files?w=1