### PR TITLE
Fix big red scary error message when YT Data API is down

### DIFF
--- a/public/video-ui/src/actions/UploadActions/getUploads.js
+++ b/public/video-ui/src/actions/UploadActions/getUploads.js
@@ -12,7 +12,7 @@ function runningUploads(uploads) {
 function errorGettingUploads(error) {
   return {
     type: 'SHOW_ERROR',
-    message: `Could not get uploads: ${error}`,
+    message: "Could not get uploads",
     error: error,
     receivedAt: Date.now()
   };

--- a/public/video-ui/src/reducers/youtubeReducer.js
+++ b/public/video-ui/src/reducers/youtubeReducer.js
@@ -9,7 +9,7 @@ export default function youtube(
       });
     case 'YT_CHANNELS_GET_RECEIVE':
       return Object.assign({}, state, {
-        channels: action.channels
+        channels: action.channels || []
       });
     default:
       return state;


### PR DESCRIPTION
We were not gracefully handling a failure to retreive the list of YouTube channels. There were two problems:

- the list of channels was `undefined` in the state so the edit panel failed to render
- the HTML error Play error page was being inserted directly into the page (!) pushing down the real UI