### PR TITLE
Handle YouTube failure when adding asset to atom that already has a channel

### DIFF
--- a/common/src/main/scala/com/gu/media/util/MAMLogger.scala
+++ b/common/src/main/scala/com/gu/media/util/MAMLogger.scala
@@ -10,9 +10,11 @@ object MAMLogger {
   private def atomIdMarker(atomId: String) = Map("atomId" -> atomId)
   private def videoIdMarker(videoId: String) = Map("videoId" -> videoId)
 
-  def info(message: String, markers: Map[String, Any] = Map()): Unit = logger.info(Markers.appendEntries(markers.asJava), message)
-  def error(message: String, markers: Map[String, Any] = Map()): Unit = logger.error(Markers.appendEntries(markers.asJava), message)
+  def info(message: String, markers: Map[String, Any]): Unit = logger.info(Markers.appendEntries(markers.asJava), message)
+  def error(message: String, markers: Map[String, Any]): Unit = logger.error(Markers.appendEntries(markers.asJava), message)
+  def error(message: String, markers: Map[String, Any], throwable: Throwable): Unit = logger.error(Markers.appendEntries(markers.asJava), message, throwable)
 
   def info(message: String, atomId: String, videoId: String): Unit = info(message, atomIdMarker(atomId) ++ videoIdMarker(videoId))
-  def error(message: String, atomId: String, videoId: String): Unit = info(message, atomIdMarker(atomId) ++ videoIdMarker(videoId))
+  def error(message: String, atomId: String, videoId: String): Unit = error(message, atomIdMarker(atomId) ++ videoIdMarker(videoId))
+  def error(message: String, atomId: String, videoId: String, throwable: Throwable): Unit = error(message, atomIdMarker(atomId) ++ videoIdMarker(videoId), throwable)
 }


### PR DESCRIPTION
Making the workaround introduced in #817 work with existing atoms that already have channels (because they were set when the YouTube API was available).