### PR TITLE
introduce Livestream video category

### DIFF
--- a/common/src/main/scala/com/gu/media/model/Category.scala
+++ b/common/src/main/scala/com/gu/media/model/Category.scala
@@ -16,6 +16,7 @@ object Category {
   case object Hosted extends Category { val name = "Hosted" }
   case object News extends Category { val name = "News" }
   case object Paid extends Category { val name = "Paid" }
+  case object Livestream extends Category { val name = "Livestream" }
 
   val categoryReads = Reads[Category](json => {
     json.as[String] match {
@@ -25,6 +26,7 @@ object Category {
       case "Hosted" => JsSuccess(Hosted)
       case "News" => JsSuccess(News)
       case "Paid" => JsSuccess(Paid)
+      case "Livestream" => JsSuccess(Livestream)
     }
   })
 
@@ -34,7 +36,7 @@ object Category {
 
   implicit val categoryFormat = Format(categoryReads, categoryWrites)
 
-  private val types = List(Documentary, Explainer, Feature, Hosted, News, Paid)
+  private val types = List(Documentary, Explainer, Feature, Hosted, News, Paid, Livestream)
 
   def fromThrift(cat: ThriftCategory) = types.find(_.name == cat.name).get
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val awsVersion = "1.11.125"
   val pandaVersion = "0.5.1"
   val mockitoVersion = "2.0.97-beta"
-  val atomMakerVersion = "1.1.15"
+  val atomMakerVersion = "1.1.21"
   val slf4jVersion = "1.7.21"
   val typesafeConfigVersion = "1.3.0" // to match what we get from Play transitively
   val scanamoVersion = "0.9.1" // to match what we get from atom-publisher-lib transitively

--- a/public/video-ui/src/constants/videoCategories.js
+++ b/public/video-ui/src/constants/videoCategories.js
@@ -2,7 +2,8 @@ const editorialCategories = [
   'News',
   'Documentary',
   'Explainer',
-  'Feature'
+  'Feature',
+  'Livestream'
 ].map(cat => ({ id: cat, title: cat }));
 
 // id matches the thrift enum


### PR DESCRIPTION
this is to provide a hint to rendering clients that the atom is different from a normal video, so they can, for example, add a flashing red light next to the video