### PR TITLE
accept more youtube url formats

### DIFF
--- a/app/model/commands/AddAssetCommand.scala
+++ b/app/model/commands/AddAssetCommand.scala
@@ -8,6 +8,7 @@ import com.gu.media.util.{MAMLogger, MediaAtomImplicits, ThriftUtil}
 import com.gu.pandomainauth.model.{User => PandaUser}
 import data.DataStores
 import com.gu.media.model.MediaAtom.fromThrift
+import com.gu.media.youtube.YoutubeUrl
 import model.commands.CommandExceptions._
 import util.{AWSConfig, YouTube}
 
@@ -116,7 +117,7 @@ case class AddAssetCommand(atomId: String, videoUri: String, override val stores
       val platform = ThriftUtil.parsePlatform(videoUri)
 
       (platform, videoUri) match {
-        case (Right(Platform.Youtube), ThriftUtil.youtube(videoId)) =>
+        case (Right(Platform.Youtube), YoutubeUrl(videoId)) =>
           Some(videoId)
 
         case _ =>

--- a/common/src/main/scala/com/gu/media/util/ThriftUtil.scala
+++ b/common/src/main/scala/com/gu/media/util/ThriftUtil.scala
@@ -9,27 +9,27 @@ import play.api.libs.json._
 import play.api.mvc.{BodyParser, BodyParsers}
 import com.gu.media.util.MediaAtomImplicits._
 import com.gu.media.util.JsonConversions._
+import com.gu.media.youtube.YoutubeUrl
+
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 
 object ThriftUtil {
   type ThriftResult[A] = Either[String, A]
 
-  val youtube = "https?://www.youtube.com/watch\\?v=([^&]+)".r
-
   def getSingleParam(params: Map[String, Seq[String]], name: String): Option[String] =
     params.get(name).flatMap(_.headOption)
 
   def parsePlatform(uri: String): ThriftResult[Platform] =
     uri match {
-      case youtube(_) => Right(Platform.Youtube)
+      case YoutubeUrl(_) => Right(Platform.Youtube)
       case Url(_) => Right(Platform.Url)
       case _ => Left(s"Unrecognised platform in uri ($uri)")
     }
 
   def parseId(uri: String): ThriftResult[String] =
     uri match {
-      case youtube(id) => Right(id)
+      case YoutubeUrl(id) => Right(id)
       case Url(url) => Right(url)
       case _ => Left(s"couldn't extract id from uri ($uri)")
     }

--- a/common/src/main/scala/com/gu/media/youtube/YoutubeUrl.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YoutubeUrl.scala
@@ -1,0 +1,14 @@
+package com.gu.media.youtube
+
+object YoutubeUrl {
+  private val re = "^https://(?:www.youtube.com/(?:watch\\?v=|embed/)|youtu.be/)([a-zA-Z0-9_-]{11}).*$".r
+
+  def unapply(url: String): Option[String] = parse(url)
+
+  def parse(url: String): Option[String] = {
+    url match {
+      case re(videoId) => Some(videoId)
+      case _ => None
+    }
+  }
+}

--- a/common/src/test/scala/com/gu/media/youtube/YoutubeUrlTest.scala
+++ b/common/src/test/scala/com/gu/media/youtube/YoutubeUrlTest.scala
@@ -1,0 +1,41 @@
+package com.gu.media.youtube
+
+import org.scalatest.{FunSuite, MustMatchers}
+
+class YoutubeUrlTest extends FunSuite with MustMatchers {
+  test("Extract video id from standard YouTube URL") {
+    YoutubeUrl.parse("https://www.youtube.com/watch?v=CqUDO-livlc") must be(Some("CqUDO-livlc"))
+  }
+
+  test("Extract video id from standard YouTube URL with extra param") {
+    YoutubeUrl.parse("https://www.youtube.com/watch?v=CqUDO-livlc&feature=youtu.be") must be(Some("CqUDO-livlc"))
+  }
+
+  test("Extract video id from standard YouTube URL with multiple extra param") {
+    YoutubeUrl.parse("https://www.youtube.com/watch?v=CqUDO-livlc&feature=youtu.be&rel=0") must be(Some("CqUDO-livlc"))
+  }
+
+  test("Extract video id from YouTube short URL") {
+    YoutubeUrl.parse("https://youtu.be/CqUDO-livlc") must be(Some("CqUDO-livlc"))
+  }
+
+  test("Extract video id from YouTube embed URL") {
+    YoutubeUrl.parse("https://www.youtube.com/embed/CqUDO-livlc") must be(Some("CqUDO-livlc"))
+  }
+
+  test("Extract video id from YouTube embed URL with extra params") {
+    YoutubeUrl.parse("https://www.youtube.com/embed/CqUDO-livlc?rel=0") must be(Some("CqUDO-livlc"))
+  }
+
+  test("Extract video id from YouTube embed URL with multiple extra params") {
+    YoutubeUrl.parse("https://www.youtube.com/embed/CqUDO-livlc?rel=0&autoplay=1") must be(Some("CqUDO-livlc"))
+  }
+
+  test("Fail to extract video id from invalid URL") {
+    YoutubeUrl.parse("https://www.foo.com/watch?v=CqUDO-livlc") must be(None)
+  }
+
+  test("Fail to extract video id from YouTube URL as video id is too short") {
+    YoutubeUrl.parse("https://www.youtube.com/watch?v=CqUDO-livl") must be(None)
+  }
+}


### PR DESCRIPTION
YouTube URLs can come in many different shapes. Provide a kinder experience to user by accepting more formats other than the standard one.

This current limitation in the app has been reported a few times in the past and the error messaging we provide is pretty obscure [`Could not create asset. Asset is not a youtube video`](https://github.com/guardian/media-atom-maker/blob/11fcc50e721c6c4d76bb7fe01725342b90a5d42f/app/model/commands/AddAssetCommand.scala#L41).