### PR TITLE
Refresh duration

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -12,6 +12,7 @@ PUT     /api2/atom/:id/publish          controllers.Api2.publishMediaAtom(id)
 POST    /api2/atoms/:id/assets          controllers.Api2.addAsset(id)
 DELETE  /api2/atoms/:id/assets          controllers.Api2.deleteAsset(id)
 PUT     /api2/atom/:id/asset-active     controllers.Api2.setActiveAsset(id)
+PUT     /api2/atom/:id/reset-duration-from-active     controllers.Api2.resetDurationFromActive(id)
 
 POST    /api2/atom/:id/pac-file         controllers.Api2.uploadPacFile(id)
 

--- a/public/video-ui/src/components/FormFields/DurationInput.js
+++ b/public/video-ui/src/components/FormFields/DurationInput.js
@@ -1,0 +1,120 @@
+import React from 'react';
+import {
+  durationToMinAndSecs,
+  secondsToDurationStr
+} from '../../util/durationHelpers';
+
+const getStateFromProps = props => {
+  const dur = props.fieldValue || 0;
+
+  const { mins, secs } = durationToMinAndSecs(dur);
+
+  return {
+    mins: `${mins}`,
+    secs: `${secs}`
+  };
+};
+
+export default class DurationInput extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = getStateFromProps(this.props);
+  }
+
+  componentWillReceiveProps(props) {
+    this.setState(getStateFromProps(props));
+  }
+
+  updateDuration() {
+    const minsInt = parseInt(this.state.mins, 10);
+    const secsInt = parseInt(this.state.secs || '0', 10);
+    this.props.onUpdateField(minsInt * 60 + secsInt);
+  }
+
+  updateMins(mins) {
+    this.setState(
+      {
+        mins
+      },
+      () => this.updateDuration()
+    );
+  }
+
+  updateSecs(secs) {
+    this.setState(
+      {
+        secs: secs ? `${Math.min(parseInt(secs, 10), 59)}` : '' // limit seconds to 59
+      },
+      () => this.updateDuration()
+    );
+  }
+
+  renderField = () => {
+    if (!this.props.editable) {
+      return (
+        <div>
+          <p className="details-list__title">{this.props.fieldName}</p>
+          <p
+            className={
+              'details-list__field ' +
+              (this.props.displayPlaceholder(
+                this.props.placeholder,
+                this.props.fieldValue
+              )
+                ? 'details-list__empty'
+                : '')
+            }
+          >
+            {' '}
+            {secondsToDurationStr(this.props.fieldValue)}
+          </p>
+        </div>
+      );
+    }
+
+    const hasError = this.props.hasError(this.props);
+
+    return (
+      <div className="form__row">
+        <label className="form__label">{this.props.fieldName}</label>
+        <span className="form__description">
+          <em>
+            Use this to edit videos where the duration is being reported
+            incorrectly (i.e. 0:00)
+          </em>
+        </span>
+        <input
+          type="text"
+          size="3"
+          className={'form__field form__field--inline ' + (hasError ? 'form__field--error' : '')}
+          value={this.state.mins}
+          onChange={e => {
+            this.updateMins(e.target.value);
+          }}
+        />
+        <span style={{ margin: '0 5px' }}>mins</span>
+        <input
+          type="text"
+          size="3"
+          className={'form__field form__field--inline ' + (hasError ? 'form__field--error' : '')}
+          value={this.state.secs}
+          onChange={e => {
+            this.updateSecs(e.target.value);
+          }}
+        />
+        <span style={{ margin: '0 5px' }}>secs</span>
+        {hasError ? (
+          <p className="form__message form__message--error">
+            {this.props.notification.message}
+          </p>
+        ) : (
+          ''
+        )}
+      </div>
+    );
+  };
+
+  render() {
+    return <div>{this.renderField()}</div>;
+  }
+}

--- a/public/video-ui/src/components/FormFields/TextInput.js
+++ b/public/video-ui/src/components/FormFields/TextInput.js
@@ -1,7 +1,5 @@
 import React from 'react';
 
-const id = val => val;
-
 export default class TextInput extends React.Component {
   renderField = () => {
     if (!this.props.editable) {
@@ -27,8 +25,6 @@ export default class TextInput extends React.Component {
 
     const hasError = this.props.hasError(this.props);
 
-    const map = this.props.map || id;
-
     return (
       <div className="form__row">
         <label className="form__label">{this.props.fieldName}</label>
@@ -39,7 +35,7 @@ export default class TextInput extends React.Component {
           type="text"
           value={this.props.fieldValue}
           onChange={e => {
-            this.props.onUpdateField(map(e.target.value));
+            this.props.onUpdateField(e.target.value);
           }}
         />
         {hasError

--- a/public/video-ui/src/components/FormFields/TextInput.js
+++ b/public/video-ui/src/components/FormFields/TextInput.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+const id = val => val;
+
 export default class TextInput extends React.Component {
   renderField = () => {
     if (!this.props.editable) {
@@ -25,6 +27,8 @@ export default class TextInput extends React.Component {
 
     const hasError = this.props.hasError(this.props);
 
+    const map = this.props.map || id;
+
     return (
       <div className="form__row">
         <label className="form__label">{this.props.fieldName}</label>
@@ -35,7 +39,7 @@ export default class TextInput extends React.Component {
           type="text"
           value={this.props.fieldValue}
           onChange={e => {
-            this.props.onUpdateField(e.target.value);
+            this.props.onUpdateField(map(e.target.value));
           }}
         />
         {hasError

--- a/public/video-ui/src/components/Icon.js
+++ b/public/video-ui/src/components/Icon.js
@@ -93,7 +93,7 @@ export default class Icon extends React.Component {
       : 'responsive';
 
     return (
-      <span className={props.className}>
+      <span className={`${props.className} ${this.props.disabled ? 'disabled' : ''}`}>
         <i className="icon responsive--primary" onClick={props.onClick}>{props.icon}</i>
         {this.renderText()}
       </span>

--- a/public/video-ui/src/components/ManagedForm/ManagedSection.js
+++ b/public/video-ui/src/components/ManagedForm/ManagedSection.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { ManagedField } from './ManagedField';
 
 export class ManagedSection extends React.Component {
+  static managedTypes = [ManagedField];
   static propTypes = {
     data: PropTypes.object,
     updateData: PropTypes.func,
@@ -19,16 +21,18 @@ export class ManagedSection extends React.Component {
 
   render() {
     const hydratedChildren = React.Children.map(this.props.children, child => {
-
       if (child) {
-        return React.cloneElement(child, {
-          data: this.props.data,
-          updateData: this.props.updateData,
-          updateFormErrors: this.props.updateFormErrors,
-          updateWarnings: this.props.updateWarnings,
-          editable: this.props.editable
-        });
-      } return null;
+        return ManagedSection.managedTypes.indexOf(child.type) > -1
+          ? React.cloneElement(child, {
+              data: this.props.data,
+              updateData: this.props.updateData,
+              updateFormErrors: this.props.updateFormErrors,
+              updateWarnings: this.props.updateWarnings,
+              editable: this.props.editable
+            })
+          : child;
+      }
+      return null;
     });
 
     return <div className="form__section">{hydratedChildren}</div>;

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ManagedForm, ManagedField, ManagedSection } from '../ManagedForm';
 import TextInput from '../FormFields/TextInput';
+import DurationInput from '../FormFields/DurationInput';
 import ScribeEditorField from '../FormFields/ScribeEditor';
 import SelectBox from '../FormFields/SelectBox';
 import CheckBox from '../FormFields/CheckBox';
@@ -221,8 +222,8 @@ class VideoData extends React.Component {
             >
               <CheckBox />
             </ManagedField>
-            <ManagedField fieldLocation="duration" name="Video Duration (seconds)">
-              <TextInput map={num => parseInt(num, 10)} />
+            <ManagedField fieldLocation="duration" name="Video Duration (mm:ss)">
+              <DurationInput />
             </ManagedField>
             {!this.props.editable && (
               <button

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -11,6 +11,7 @@ import { fieldLengths } from '../../constants/videoEditValidation';
 import { videoCategories } from '../../constants/videoCategories';
 import PrivacyStates from '../../constants/privacyStates';
 import VideoUtils from '../../util/video';
+import VideosApi from '../../services/VideosApi';
 
 class VideoData extends React.Component {
   hasCategories = () => this.props.youtube.categories.length !== 0;
@@ -140,6 +141,20 @@ class VideoData extends React.Component {
             </ManagedField>
             <ManagedField fieldLocation="source" name="Video Source">
               <TextInput />
+            </ManagedField>
+            <button
+              type="button"
+              disabled={!this.props.video.hasOwnProperty('activeVersion')}
+              onClick={() => {
+                VideosApi.resetDurationFromActive(this.props.video.id).then(video => {
+                  this.props.updateVideo(video);
+                });
+              }}
+            >
+              Update duration from active video
+            </button>
+            <ManagedField fieldLocation="duration" name="Video Duration">
+              <TextInput map={num => parseInt(num, 10)} />
             </ManagedField>
           </ManagedSection>
           <ManagedSection>

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -142,20 +142,6 @@ class VideoData extends React.Component {
             <ManagedField fieldLocation="source" name="Video Source">
               <TextInput />
             </ManagedField>
-            <button
-              type="button"
-              disabled={!this.props.video.hasOwnProperty('activeVersion')}
-              onClick={() => {
-                VideosApi.resetDurationFromActive(this.props.video.id).then(video => {
-                  this.props.updateVideo(video);
-                });
-              }}
-            >
-              Update duration from active video
-            </button>
-            <ManagedField fieldLocation="duration" name="Video Duration">
-              <TextInput map={num => parseInt(num, 10)} />
-            </ManagedField>
           </ManagedSection>
           <ManagedSection>
             <ManagedField fieldLocation="expiryDate" name="Expiry Date">
@@ -235,6 +221,28 @@ class VideoData extends React.Component {
             >
               <CheckBox />
             </ManagedField>
+            <ManagedField fieldLocation="duration" name="Video Duration (seconds)">
+              <TextInput map={num => parseInt(num, 10)} />
+            </ManagedField>
+            {!this.props.editable && (
+              <button
+                title="Refresh video duration from active YouTube video"
+                type="button"
+                disabled={!this.props.video.hasOwnProperty('activeVersion')}
+                data-tip="Refresh video duration from active YouTube video"
+                onClick={() => {
+                  VideosApi.resetDurationFromActive(this.props.video.id).then(video => {
+                    this.props.updateVideo(video);
+                  });
+                }}
+              >
+                <Icon
+                  icon="refresh"
+                  className="icon__edit"
+                  disabled={!this.props.video.hasOwnProperty('activeVersion')}
+                />
+              </button>
+            )}
           </ManagedSection>
         </ManagedForm>
       </div>
@@ -247,6 +255,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as getCategories from '../../actions/YoutubeActions/getCategories';
 import * as getChannels from '../../actions/YoutubeActions/getChannels';
+import Icon from '../Icon';
 
 function mapStateToProps(state) {
   return {

--- a/public/video-ui/src/services/VideosApi.js
+++ b/public/video-ui/src/services/VideosApi.js
@@ -113,6 +113,12 @@ export default {
     });
   },
 
+  resetDurationFromActive: videoId =>
+    pandaReqwest({
+      url: `/api2/atom/${videoId}/reset-duration-from-active`,
+      method: 'put'
+    }),
+
   getVideoUsages: videoId => {
     return Promise.all([
       getUsages({ id: videoId, stage: ContentApi.preview }),

--- a/public/video-ui/src/util/durationHelpers.js
+++ b/public/video-ui/src/util/durationHelpers.js
@@ -1,0 +1,22 @@
+function padNumber(num, minLength = 2) {
+  const str = `${num}`;
+  const leadingZeros = minLength - str.length;
+  if (leadingZeros < 1) {
+    return str;
+  }
+  return `${'0'.repeat(leadingZeros)}${str}`;
+}
+
+function durationToMinAndSecs(num) {
+  return {
+    mins: Math.floor(parseInt(num || '0', 10) / 60),
+    secs: num % 60
+  };
+}
+
+function secondsToDurationStr(dur) {
+  const { mins, secs } = durationToMinAndSecs(dur);
+  return `${mins}:${padNumber(secs, 2)}`;
+}
+
+export { secondsToDurationStr, durationToMinAndSecs };

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -140,6 +140,16 @@
   &--textarea {
     height: inherit;
   }
+
+  &--inline {
+    display: inline-block;
+    width: auto;
+  }
+}
+
+.form__description {
+  display: inline-block;
+  margin: 5px 0;
 }
 
 .form__label {


### PR DESCRIPTION
This allows custom editing of the duration in a media atom in case YT hasn't returned the accurate duration.

The input is the last input on the right side of the meta panel.

## In the overview pane
![screenshot 2019-02-01 at 15 48 11](https://user-images.githubusercontent.com/1652187/52133222-d3814800-2638-11e9-9bba-a26bd259dba4.png)

## While editing
![screenshot 2019-02-01 at 15 48 25](https://user-images.githubusercontent.com/1652187/52133231-d7ad6580-2638-11e9-82b1-aea368264e2b.png)

