### PR TITLE
Fix NaN in UI

### DIFF
--- a/public/video-ui/src/components/FormFields/DurationInput.js
+++ b/public/video-ui/src/components/FormFields/DurationInput.js
@@ -5,7 +5,7 @@ import {
 } from '../../util/durationHelpers';
 
 const getStateFromProps = props => {
-  const dur = props.fieldValue || 0;
+  const dur = props.rawFieldValue || 0;
 
   const { mins, secs } = durationToMinAndSecs(dur);
 
@@ -66,7 +66,7 @@ export default class DurationInput extends React.Component {
             }
           >
             {' '}
-            {secondsToDurationStr(this.props.fieldValue)}
+            {secondsToDurationStr(this.props.rawFieldValue)}
           </p>
         </div>
       );

--- a/public/video-ui/src/components/ManagedForm/ManagedField.js
+++ b/public/video-ui/src/components/ManagedForm/ManagedField.js
@@ -147,6 +147,7 @@ export class ManagedField extends React.Component {
         fieldValue: this.getFieldValue(
           _get(this.props.fieldLocation, this.props.data)
         ),
+        rawFieldValue: _get(this.props.fieldLocation, this.props.data),
         onUpdateField: this.updateFn,
         editable,
         maxLength: this.props.maxLength,


### PR DESCRIPTION
This was leaving _NaN:NaN_ in the UI as `fieldData` was being set as "No [field name]" if it wasn't there 🙄 