### PR TITLE
fail healthcheck if we're unable to read stage tag

### DIFF
--- a/app/controllers/Healthcheck.scala
+++ b/app/controllers/Healthcheck.scala
@@ -1,14 +1,22 @@
 package controllers
 
-import com.gu.media.aws.KinesisAccess
+import com.amazonaws.util.EC2MetadataUtils
+import com.gu.media.aws.{AwsAccess, KinesisAccess}
 import play.api.mvc.{Action, Controller}
 
-class Healthcheck(val kinesis: KinesisAccess) extends Controller {
+class Healthcheck(val kinesis: AwsAccess with KinesisAccess) extends Controller {
   def healthcheck = Action {
-    if(kinesis.testKinesisAccess(kinesis.previewKinesisStreamName) && kinesis.testKinesisAccess(kinesis.liveKinesisStreamName)) {
+    val instanceId = EC2MetadataUtils.getInstanceId
+    val isRunningInAws = instanceId != null
+    val canAccessPreviewStream = kinesis.testKinesisAccess(kinesis.previewKinesisStreamName)
+    val canAccessLiveStream = kinesis.testKinesisAccess(kinesis.liveKinesisStreamName)
+
+    val isMissingTag = isRunningInAws && kinesis.isDev
+
+    if(!isMissingTag && canAccessLiveStream && canAccessPreviewStream) {
       Ok(s"ok\ngitCommitID ${app.BuildInfo.gitCommitId}")
     } else {
-      InternalServerError("fail. cannot access CAPI kinesis streams")
+      InternalServerError("Fail. Cannot access CAPI kinesis streams or cannot read tags")
     }
   }
 }


### PR DESCRIPTION
We use the stage tag to determine what config and ultimiately what resources to use. If the stage isn't available, we're defaulting to `DEV`, which means PROD tries to access DEV resources.

That's not good!

Now we're failing to report healthy if we're running in AWS and we're reporting stage as DEV. This will have the effect of a deploy succeeding only when we're able to correctly read the stage tag.