### PR TITLE
create a generic component to manage form state

### DIFF
--- a/public/video-ui/src/components/EditSaveCancel/index.js
+++ b/public/video-ui/src/components/EditSaveCancel/index.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Icon from '../Icon';
+
+class EditSaveCancel extends React.Component {
+  static propTypes = {
+    onEdit: PropTypes.func.isRequired,
+    onSave: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    canSave: PropTypes.func.isRequired,
+  };
+
+  state = {
+    editing: false
+  };
+
+  updateEditingState({ editing, save }) {
+    this.setState({editing: editing});
+    this.props.onEdit(editing);
+
+    if (!editing) {
+      if (save) {
+        this.props.onSave();
+      } else {
+        this.props.onCancel();
+      }
+    }
+  }
+
+  renderEditButton() {
+    return (
+      <button onClick={() => this.updateEditingState({ editing: true })}>
+        <Icon icon="edit" className="icon__edit">
+          Edit
+        </Icon>
+      </button>
+    );
+  }
+
+  renderSaveButton() {
+    return (
+      <button
+        onClick={() => this.updateEditingState({editing: false, save: true})}
+        disabled={!this.props.canSave()}>
+        <Icon icon="save" className={`icon__done ${this.props.canSave() ? '' : 'disabled'}`}>
+          Save changes
+        </Icon>
+      </button>
+    );
+  }
+
+  renderCancelButton() {
+    return (
+      <button onClick={() => this.updateEditingState({editing: false, save: false})}>
+        <Icon icon="cancel" className="icon__cancel">Cancel</Icon>
+      </button>
+    );
+  }
+
+  render() {
+    const { editing } = this.state;
+
+    if (editing) {
+      return (
+        <div>
+          {this.renderSaveButton()}
+          {this.renderCancelButton()}
+        </div>
+      );
+    }
+
+    return this.renderEditButton();
+  }
+}
+
+export default EditSaveCancel;

--- a/public/video-ui/src/components/Workflow/Workflow.js
+++ b/public/video-ui/src/components/Workflow/Workflow.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import WorkflowForm from './WorkflowForm';
 import Icon from '../Icon';
+import EditSaveCancel from '../EditSaveCancel';
 
 class Workflow extends React.Component {
   static propTypes = {
@@ -73,7 +74,7 @@ class Workflow extends React.Component {
   }
 
   renderViewInWorkflowLink() {
-    if (this.props.workflow.status.isTrackedInWorkflow) {
+    if (this.props.workflow.status.isTrackedInWorkflow && !this.state.editing) {
       return (
         <a className="button inline-block"
            target="_blank"
@@ -85,43 +86,21 @@ class Workflow extends React.Component {
     }
   }
 
-  renderFormButtons() {
-    if (!this.state.editing) {
-      return (
-        <span>
-          {this.renderViewInWorkflowLink()}
-          <button onClick={() => this.manageEditingState({editing: true})}>
-            <Icon icon="edit" className="icon__edit"/>
-          </button>
-        </span>
-      );
-    } else {
-      const canSave = this.props.workflow.status.section && this.props.workflow.status.status;
-
-      return (
-        <span>
-          <button
-            onClick={() => this.manageEditingState({editing: false, save: true})}
-            disabled={!canSave}
-          >
-            <Icon icon="save" className={`icon__done ${canSave ? '' : 'disabled'}`}>
-              Save changes
-            </Icon>
-          </button>
-          <button onClick={() => this.manageEditingState({editing: false})}>
-            <Icon icon="cancel" className="icon__cancel">Cancel</Icon>
-          </button>
-        </span>
-      );
-    }
-  }
-
   render() {
+    const canSave = this.props.workflow.status.section && this.props.workflow.status.status;
     return (
       <div className="video__detailbox">
         <div className="video__detailbox__header__container">
           <header className="video__detailbox__header">Workflow</header>
-          {this.renderFormButtons()}
+          <div>
+            {this.renderViewInWorkflowLink()}
+            <EditSaveCancel
+              onEdit={() => this.manageEditingState({editing: true})}
+              onSave={() => this.manageEditingState({editing: false, save: true})}
+              onCancel={() => this.manageEditingState({editing: false})}
+              canSave={() => canSave}
+            />
+          </div>
         </div>
         <div className="form__group">
           <WorkflowForm

--- a/public/video-ui/styles/layout/_icons.scss
+++ b/public/video-ui/styles/layout/_icons.scss
@@ -74,6 +74,8 @@
   margin-right: 5px;
 }
 
+.icon__edit,
+.icon__save,
 .icon__cancel {
   padding: 0 10px;
 }


### PR DESCRIPTION
This is part of the tabbed UI work.

A generic component with three buttons: Edit, Save and Cancel.

Also update the Workflow component as an example usage.

The behaviour is exactly the same as before 😄 

![esc](https://user-images.githubusercontent.com/836140/54417915-5945e800-46fb-11e9-95d1-ea723ec57f86.gif)
