### PR TITLE
create a youtube furniture component

### DIFF
--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -10,15 +10,15 @@ import TagPicker from '../FormFields/TagPicker';
 import TagTypes from '../../constants/TagTypes';
 import { fieldLengths } from '../../constants/videoEditValidation';
 import { videoCategories } from '../../constants/videoCategories';
-import PrivacyStates from '../../constants/privacyStates';
 import VideoUtils from '../../util/video';
 import DurationReset from "../DurationReset";
 import Flags from "../Flags";
 import ContentChangeDetails from "../ContentChangeDetails";
+import YoutubeFurniture from '../YoutubeFurniture';
 import {formNames} from "../../constants/formNames";
 import FieldNotification from "../../constants/FieldNotification";
 
-class VideoData extends React.Component {
+export default class VideoData extends React.Component {
   static propTypes = {
     video: PropTypes.object.isRequired,
     updateVideo: PropTypes.func.isRequired,
@@ -26,21 +26,8 @@ class VideoData extends React.Component {
     updateErrors: PropTypes.func.isRequired,
     updateWarnings: PropTypes.func.isRequired,
     canonicalVideoPageExists: PropTypes.bool.isRequired,
-    composerKeywordsToYouTube: PropTypes.func.isRequired,
-    validateYouTubeKeywords: PropTypes.func.isRequired
+    composerKeywordsToYouTube: PropTypes.func.isRequired
   };
-
-  hasCategories = () => this.props.youtube.categories.length !== 0;
-  hasChannels = () => this.props.youtube.channels.length !== 0;
-
-  componentWillMount() {
-    if (!this.hasCategories()) {
-      this.props.youtubeActions.getCategories();
-    }
-    if (!this.hasChannels()) {
-      this.props.youtubeActions.getChannels();
-    }
-  }
 
   validateKeywords = keywords => {
     if (!Array.isArray(keywords) ||
@@ -73,18 +60,12 @@ class VideoData extends React.Component {
       updateWarnings,
       editable,
       canonicalVideoPageExists,
-      composerKeywordsToYouTube,
-      validateYouTubeKeywords
+      composerKeywordsToYouTube
     } = this.props;
 
     const isYoutubeAtom = VideoUtils.isYoutube(video);
     const isCommercialType = VideoUtils.isCommercialType(video);
     const hasAssets = VideoUtils.hasAssets(video);
-    const availableChannels = VideoUtils.getAvailableChannels(video);
-    const availablePrivacyStates = VideoUtils.getAvailablePrivacyStates(video);
-    const hasYoutubeWriteAccess = VideoUtils.hasYoutubeWriteAccess(video);
-
-    const { categories } = this.props.youtube;
 
     return (
       <div className="form__group">
@@ -187,29 +168,13 @@ class VideoData extends React.Component {
             >
               <SelectBox selectValues={videoCategories} />
             </ManagedField>
-            <ManagedField fieldLocation="channelId" name="YouTube Channel" disabled={hasAssets}>
-              <SelectBox selectValues={availableChannels} />
-            </ManagedField>
-            <ManagedField
-              fieldLocation="privacyStatus"
-              name="Privacy Status"
-              disabled={!isYoutubeAtom || !hasYoutubeWriteAccess}
-            >
-              <SelectBox selectValues={PrivacyStates.forForm(availablePrivacyStates)} />
-            </ManagedField>
-            <ManagedField fieldLocation="youtubeCategoryId" name="YouTube Category">
-              <SelectBox selectValues={categories} />
-            </ManagedField>
-            <ManagedField
-              fieldLocation="tags"
-              name="YouTube Keywords"
-              placeholder="No keywords"
-              tagType={TagTypes.youtube}
-              disabled={!isYoutubeAtom}
-              customValidation={validateYouTubeKeywords}
-            >
-              <TagPicker disableCapiTags />
-            </ManagedField>
+            <YoutubeFurniture
+              video={video}
+              editable={editable}
+              updateVideo={updateVideo}
+              updateErrors={updateErrors}
+              updateWarnings={updateWarnings}
+            />
             <Flags
               video={video}
               editable={editable}
@@ -229,27 +194,3 @@ class VideoData extends React.Component {
     );
   }
 }
-
-//REDUX CONNECTIONS
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import * as getCategories from '../../actions/YoutubeActions/getCategories';
-import * as getChannels from '../../actions/YoutubeActions/getChannels';
-
-function mapStateToProps(state) {
-  return {
-    youtube: state.youtube,
-    workflow: state.workflow
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    youtubeActions: bindActionCreators(
-      Object.assign({}, getCategories, getChannels),
-      dispatch
-    )
-  };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(VideoData);

--- a/public/video-ui/src/components/YoutubeFurniture/index.js
+++ b/public/video-ui/src/components/YoutubeFurniture/index.js
@@ -1,0 +1,131 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ManagedField, ManagedForm } from '../ManagedForm';
+import VideoUtils from '../../util/video';
+import TagTypes from '../../constants/TagTypes';
+import TagPicker from '../FormFields/TagPicker';
+import SelectBox from '../FormFields/SelectBox';
+import PrivacyStates from '../../constants/privacyStates';
+import {formNames} from "../../constants/formNames";
+import YouTubeKeywords from "../../constants/youTubeKeywords";
+import {getYouTubeTagCharCount} from "../../util/getYouTubeTagCharCount";
+import FieldNotification from "../../constants/FieldNotification";
+
+class YoutubeFurniture extends React.Component {
+  static propTypes = {
+    video: PropTypes.object.isRequired,
+    editable: PropTypes.bool.isRequired,
+    updateVideo: PropTypes.func.isRequired,
+    updateErrors: PropTypes.func.isRequired,
+    updateWarnings: PropTypes.func.isRequired
+  };
+
+  hasCategories = () => this.props.youtube.categories.length !== 0;
+  hasChannels = () => this.props.youtube.channels.length !== 0;
+
+  componentWillMount() {
+    if (!this.hasCategories()) {
+      this.props.youtubeActions.getCategories();
+    }
+    if (!this.hasChannels()) {
+      this.props.youtubeActions.getChannels();
+    }
+  }
+
+  validateYouTubeKeywords = youTubeKeywords => {
+    const charLimit = YouTubeKeywords.maxCharacters;
+    const numberOfChars = getYouTubeTagCharCount(youTubeKeywords);
+    const characterCountExceeded = numberOfChars > charLimit;
+
+    return characterCountExceeded
+      ? new FieldNotification(
+        'required',
+        `Maximum characters allowed in YouTube keywords is ${charLimit}.`,
+        FieldNotification.error
+      )
+      : null;
+  };
+
+  render() {
+    const {
+      video,
+      editable,
+      updateVideo,
+      updateErrors,
+      updateWarnings,
+    } = this.props;
+
+    if (!video || !video.id) {
+      return;
+    }
+
+    const { categories } = this.props.youtube;
+
+    const isYoutubeAtom = VideoUtils.isYoutube(video);
+    const availableChannels = VideoUtils.getAvailableChannels(video);
+    const availablePrivacyStates = VideoUtils.getAvailablePrivacyStates(video);
+    const hasYoutubeWriteAccess = VideoUtils.hasYoutubeWriteAccess(video);
+    const hasAssets = VideoUtils.hasAssets(video);
+
+    return (
+      <ManagedForm
+        data={video}
+        updateData={updateVideo}
+        editable={editable}
+        updateErrors={updateErrors}
+        updateWarnings={updateWarnings}
+        formName={formNames.youtubeFurniture}
+        formClass="atom__edit__form"
+      >
+        <ManagedField fieldLocation="channelId" name="Channel" disabled={hasAssets}>
+          <SelectBox selectValues={availableChannels} />
+        </ManagedField>
+        <ManagedField
+          fieldLocation="privacyStatus"
+          name="Privacy Status"
+          disabled={!isYoutubeAtom || !hasYoutubeWriteAccess}
+        >
+          <SelectBox
+            selectValues={PrivacyStates.forForm(availablePrivacyStates)}
+          />
+        </ManagedField>
+        <ManagedField fieldLocation="youtubeCategoryId" name="Category">
+          <SelectBox selectValues={categories} />
+        </ManagedField>
+        <ManagedField
+          fieldLocation="tags"
+          name="Keywords"
+          placeholder="No keywords"
+          tagType={TagTypes.youtube}
+          disabled={!isYoutubeAtom}
+          customValidation={this.validateYouTubeKeywords}
+        >
+          <TagPicker disableCapiTags />
+        </ManagedField>
+      </ManagedForm>
+    );
+  }
+}
+
+//REDUX CONNECTIONS
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import * as getCategories from '../../actions/YoutubeActions/getCategories';
+import * as getChannels from '../../actions/YoutubeActions/getChannels';
+
+function mapStateToProps(state) {
+  return {
+    youtube: state.youtube
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    youtubeActions: bindActionCreators(
+      Object.assign({}, getCategories, getChannels),
+      dispatch
+    )
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(YoutubeFurniture);

--- a/public/video-ui/src/constants/formNames.js
+++ b/public/video-ui/src/constants/formNames.js
@@ -1,5 +1,6 @@
 export const formNames = {
   posterImage: 'posterImage',
   videoData: 'dataForm',
-  flags: 'flags'
+  flags: 'flags',
+  youtubeFurniture: 'youtubeFurniture'
 };

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -9,12 +9,9 @@ import Workflow from '../../components/Workflow/Workflow';
 import Targeting from '../../components/Targeting/Targeting';
 import Icon from '../../components/Icon';
 import { formNames } from '../../constants/formNames';
-import FieldNotification from '../../constants/FieldNotification';
 import ReactTooltip from 'react-tooltip';
 import { blankVideoData } from '../../constants/blankVideoData';
 import KeywordsApi from '../../services/KeywordsApi';
-import YouTubeKeywords from '../../constants/youTubeKeywords';
-import { getYouTubeTagCharCount } from '../../util/getYouTubeTagCharCount';
 import { canonicalVideoPageExists } from '../../util/canonicalVideoPageExists';
 import { isVideoPublished } from '../../util/isVideoPublished';
 import VideoUtils from '../../util/video';
@@ -93,22 +90,6 @@ class VideoDisplay extends React.Component {
       const value = errors[field];
       return value !== null;
     });
-  };
-
-  validateYouTubeKeywords = youTubeKeywords => {
-    const charLimit = YouTubeKeywords.maxCharacters;
-    const numberOfChars = getYouTubeTagCharCount(youTubeKeywords);
-
-    if (numberOfChars > charLimit) {
-
-      return new FieldNotification(
-        'required',
-        `Maximum characters allowed in YouTube keywords is ${charLimit}.`,
-        FieldNotification.error
-      );
-    }
-
-    return null;
   };
 
   handleAssetClick = e => {
@@ -228,7 +209,6 @@ class VideoDisplay extends React.Component {
           formName={formNames.videoData}
           updateErrors={this.props.formErrorActions.updateFormErrors}
           updateWarnings={this.props.formErrorActions.updateFormWarnings}
-          validateYouTubeKeywords={this.validateYouTubeKeywords}
           composerKeywordsToYouTube={this.composerKeywordsToYouTube}
           canonicalVideoPageExists={canonicalVideoPageExists(this.props.usages)}
         />


### PR DESCRIPTION
Move youtube specific metadata fields into their own components for a better separation of concerns.

This is preparation for the tabbed-ui work, where youtube metadata editing will live on its own tab. (Spoiler - https://github.com/guardian/media-atom-maker/pull/848/files#diff-d099a8f2c8dcc1c7a7f2fd86c4cf6d2fR115)