### PR TITLE
push `editing` state downwards

### DIFF
--- a/public/video-ui/src/components/EditSaveCancel/index.js
+++ b/public/video-ui/src/components/EditSaveCancel/index.js
@@ -4,32 +4,18 @@ import Icon from '../Icon';
 
 class EditSaveCancel extends React.Component {
   static propTypes = {
+    editing: PropTypes.bool.isRequired,
     onEdit: PropTypes.func.isRequired,
     onSave: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
-    canSave: PropTypes.func.isRequired,
+    canSave: PropTypes.func.isRequired
   };
-
-  state = {
-    editing: false
-  };
-
-  updateEditingState({ editing, save }) {
-    this.setState({editing: editing});
-    this.props.onEdit(editing);
-
-    if (!editing) {
-      if (save) {
-        this.props.onSave();
-      } else {
-        this.props.onCancel();
-      }
-    }
-  }
 
   renderEditButton() {
+    const { onEdit } = this.props;
+
     return (
-      <button onClick={() => this.updateEditingState({ editing: true })}>
+      <button onClick={onEdit}>
         <Icon icon="edit" className="icon__edit">
           Edit
         </Icon>
@@ -38,11 +24,11 @@ class EditSaveCancel extends React.Component {
   }
 
   renderSaveButton() {
+    const { canSave, onSave } = this.props;
+
     return (
-      <button
-        onClick={() => this.updateEditingState({editing: false, save: true})}
-        disabled={!this.props.canSave()}>
-        <Icon icon="save" className={`icon__done ${this.props.canSave() ? '' : 'disabled'}`}>
+      <button onClick={onSave} disabled={!canSave()}>
+        <Icon icon="save" className={`icon__done ${canSave() ? '' : 'disabled'}`}>
           Save changes
         </Icon>
       </button>
@@ -50,15 +36,17 @@ class EditSaveCancel extends React.Component {
   }
 
   renderCancelButton() {
+    const { onCancel } = this.props;
+
     return (
-      <button onClick={() => this.updateEditingState({editing: false, save: false})}>
+      <button onClick={onCancel}>
         <Icon icon="cancel" className="icon__cancel">Cancel</Icon>
       </button>
     );
   }
 
   render() {
-    const { editing } = this.state;
+    const { editing } = this.props;
 
     if (editing) {
       return (

--- a/public/video-ui/src/components/Workflow/Workflow.js
+++ b/public/video-ui/src/components/Workflow/Workflow.js
@@ -95,6 +95,7 @@ class Workflow extends React.Component {
           <div>
             {this.renderViewInWorkflowLink()}
             <EditSaveCancel
+              editing={this.state.editing}
               onEdit={() => this.manageEditingState({editing: true})}
               onSave={() => this.manageEditingState({editing: false, save: true})}
               onCancel={() => this.manageEditingState({editing: false})}


### PR DESCRIPTION
It doesn't make much sense for the `EditSaveCancel` component to maintain its own editing state alongside the components that use it. Push this state into the ESC component instead.

This is also part of the work to break #839 up into smaller PRs.