### PR TITLE
move validation function closer to home

### DIFF
--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -16,6 +16,7 @@ import DurationReset from "../DurationReset";
 import Flags from "../Flags";
 import ContentChangeDetails from "../ContentChangeDetails";
 import {formNames} from "../../constants/formNames";
+import FieldNotification from "../../constants/FieldNotification";
 
 class VideoData extends React.Component {
   static propTypes = {
@@ -25,7 +26,6 @@ class VideoData extends React.Component {
     updateErrors: PropTypes.func.isRequired,
     updateWarnings: PropTypes.func.isRequired,
     canonicalVideoPageExists: PropTypes.bool.isRequired,
-    validateKeywords: PropTypes.func.isRequired,
     composerKeywordsToYouTube: PropTypes.func.isRequired,
     validateYouTubeKeywords: PropTypes.func.isRequired
   };
@@ -42,6 +42,29 @@ class VideoData extends React.Component {
     }
   }
 
+  validateKeywords = keywords => {
+    if (!Array.isArray(keywords) ||
+      keywords.length === 0 ||
+      keywords.every(keyword => {
+        return keyword.match(/^tone/);
+      })
+    ) {
+      if (this.props.canonicalVideoPageExists) {
+        return new FieldNotification(
+          'error',
+          'A series or a keyword tag is required for updating composer pages',
+          FieldNotification.error
+        );
+      }
+      return new FieldNotification(
+        'desired',
+        'A series or a keyword tag is required for creating composer pages',
+        FieldNotification.warning
+      );
+    }
+    return null;
+  };
+
   render() {
     const {
       video,
@@ -50,7 +73,6 @@ class VideoData extends React.Component {
       updateWarnings,
       editable,
       canonicalVideoPageExists,
-      validateKeywords,
       composerKeywordsToYouTube,
       validateYouTubeKeywords
     } = this.props;
@@ -145,7 +167,7 @@ class VideoData extends React.Component {
               tagType={isCommercialType ? TagTypes.commercial : TagTypes.keyword}
               isDesired={true}
               inputPlaceholder="Search keywords (type '*' to show all)"
-              customValidation={validateKeywords}
+              customValidation={this.validateKeywords}
               updateSideEffects={composerKeywordsToYouTube}
             >
               <TagPicker disableTextInput />

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -1,10 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { ManagedForm, ManagedField, ManagedSection } from '../ManagedForm';
 import TextInput from '../FormFields/TextInput';
 import DurationInput from '../FormFields/DurationInput';
 import ScribeEditorField from '../FormFields/ScribeEditor';
 import SelectBox from '../FormFields/SelectBox';
-import CheckBox from '../FormFields/CheckBox';
 import DatePicker from '../FormFields/DatePicker';
 import TagPicker from '../FormFields/TagPicker';
 import TagTypes from '../../constants/TagTypes';
@@ -12,10 +12,24 @@ import { fieldLengths } from '../../constants/videoEditValidation';
 import { videoCategories } from '../../constants/videoCategories';
 import PrivacyStates from '../../constants/privacyStates';
 import VideoUtils from '../../util/video';
-import VideosApi from '../../services/VideosApi';
 import DurationReset from "../DurationReset";
+import Flags from "../Flags";
+import ContentChangeDetails from "../ContentChangeDetails";
+import {formNames} from "../../constants/formNames";
 
 class VideoData extends React.Component {
+  static propTypes = {
+    video: PropTypes.object.isRequired,
+    updateVideo: PropTypes.func.isRequired,
+    editable: PropTypes.bool.isRequired,
+    updateErrors: PropTypes.func.isRequired,
+    updateWarnings: PropTypes.func.isRequired,
+    canonicalVideoPageExists: PropTypes.bool.isRequired,
+    validateKeywords: PropTypes.func.isRequired,
+    composerKeywordsToYouTube: PropTypes.func.isRequired,
+    validateYouTubeKeywords: PropTypes.func.isRequired
+  };
+
   hasCategories = () => this.props.youtube.categories.length !== 0;
   hasChannels = () => this.props.youtube.channels.length !== 0;
 
@@ -29,28 +43,40 @@ class VideoData extends React.Component {
   }
 
   render() {
-    const isYoutubeAtom = VideoUtils.isYoutube(this.props.video);
-    const isCommercialType = VideoUtils.isCommercialType(this.props.video);
-    const hasAssets = VideoUtils.hasAssets(this.props.video);
-    const availableChannels = VideoUtils.getAvailableChannels(this.props.video);
-    const availablePrivacyStates = VideoUtils.getAvailablePrivacyStates(this.props.video);
-    const hasYoutubeWriteAccess = VideoUtils.hasYoutubeWriteAccess(this.props.video);
+    const {
+      video,
+      updateVideo,
+      updateErrors,
+      updateWarnings,
+      editable,
+      canonicalVideoPageExists,
+      validateKeywords,
+      composerKeywordsToYouTube,
+      validateYouTubeKeywords
+    } = this.props;
 
-    const { categories }= this.props.youtube;
+    const isYoutubeAtom = VideoUtils.isYoutube(video);
+    const isCommercialType = VideoUtils.isCommercialType(video);
+    const hasAssets = VideoUtils.hasAssets(video);
+    const availableChannels = VideoUtils.getAvailableChannels(video);
+    const availablePrivacyStates = VideoUtils.getAvailablePrivacyStates(video);
+    const hasYoutubeWriteAccess = VideoUtils.hasYoutubeWriteAccess(video);
+
+    const { categories } = this.props.youtube;
 
     return (
       <div className="form__group">
         <ManagedForm
-          data={this.props.video}
-          updateData={this.props.updateVideo}
-          editable={this.props.editable}
-          updateErrors={this.props.updateErrors}
-          updateWarnings={this.props.updateWarnings}
-          formName={this.props.formName}
+          data={video}
+          updateData={updateVideo}
+          editable={editable}
+          updateErrors={updateErrors}
+          updateWarnings={updateWarnings}
+          formName={formNames.videoData}
           formClass="atom__edit__form"
         >
           <ManagedSection>
-            <ContentChangeDetails video={this.props.video}/>
+            <ContentChangeDetails video={video}/>
             <ManagedField
               fieldLocation="title"
               name={
@@ -78,17 +104,17 @@ class VideoData extends React.Component {
             </ManagedField>
             <ManagedField
               fieldLocation="trailText"
-              derivedFrom={this.props.video.description}
+              derivedFrom={video.description}
               name="Trail Text"
               maxCharLength={fieldLengths.description.charMax}
               maxLength={fieldLengths.description.max}
-              isDesired={!this.props.canonicalVideoPageExists}
-              isRequired={this.props.canonicalVideoPageExists}
+              isDesired={!canonicalVideoPageExists}
+              isRequired={canonicalVideoPageExists}
             >
               <ScribeEditorField
                 allowedEdits={['bold', 'italic']}
-                isDesired={!this.props.canonicalVideoPageExists}
-                isRequired={this.props.canonicalVideoPageExists}
+                isDesired={!canonicalVideoPageExists}
+                isRequired={canonicalVideoPageExists}
               />
             </ManagedField>
 
@@ -105,8 +131,8 @@ class VideoData extends React.Component {
               name="Commissioning Desks"
               formRowClass="form__row__byline"
               tagType={TagTypes.tracking}
-              isDesired={!this.props.canonicalVideoPageExists}
-              isRequired={this.props.canonicalVideoPageExists}
+              isDesired={!canonicalVideoPageExists}
+              isRequired={canonicalVideoPageExists}
               inputPlaceholder="Search commissioning info (type '*' to show all)"
             >
               <TagPicker disableTextInput />
@@ -119,8 +145,8 @@ class VideoData extends React.Component {
               tagType={isCommercialType ? TagTypes.commercial : TagTypes.keyword}
               isDesired={true}
               inputPlaceholder="Search keywords (type '*' to show all)"
-              customValidation={this.props.validateKeywords}
-              updateSideEffects={this.props.composerKeywordsToYouTube}
+              customValidation={validateKeywords}
+              updateSideEffects={composerKeywordsToYouTube}
             >
               <TagPicker disableTextInput />
             </ManagedField>
@@ -158,22 +184,22 @@ class VideoData extends React.Component {
               placeholder="No keywords"
               tagType={TagTypes.youtube}
               disabled={!isYoutubeAtom}
-              customValidation={this.props.validateYouTubeKeywords}
+              customValidation={validateYouTubeKeywords}
             >
               <TagPicker disableCapiTags />
             </ManagedField>
             <Flags
-              video={this.props.video}
-              editable={this.props.editable}
-              updateVideo={this.props.updateVideo}
-              updateErrors={this.props.updateErrors}
-              updateWarnings={this.props.updateWarnings}
+              video={video}
+              editable={editable}
+              updateVideo={updateVideo}
+              updateErrors={updateErrors}
+              updateWarnings={updateWarnings}
             />
             <ManagedField fieldLocation="duration" name="Video Duration (mm:ss)">
               <DurationInput />
             </ManagedField>
-            {!this.props.editable && (
-              <DurationReset video={this.props.video} updateVideo={this.props.updateVideo}/>
+            {!editable && (
+              <DurationReset video={video} updateVideo={updateVideo}/>
             )}
           </ManagedSection>
         </ManagedForm>
@@ -187,9 +213,6 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as getCategories from '../../actions/YoutubeActions/getCategories';
 import * as getChannels from '../../actions/YoutubeActions/getChannels';
-import Icon from '../Icon';
-import Flags from "../Flags";
-import ContentChangeDetails from "../ContentChangeDetails";
 
 function mapStateToProps(state) {
   return {

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -95,29 +95,6 @@ class VideoDisplay extends React.Component {
     });
   };
 
-  validateKeywords = keywords => {
-    if (!Array.isArray(keywords) ||
-        keywords.length === 0 ||
-        keywords.every(keyword => {
-          return keyword.match(/^tone/);
-        })
-       ) {
-        if (canonicalVideoPageExists(this.props.usages)) {
-          return new FieldNotification(
-            'error',
-            'A series or a keyword tag is required for updating composer pages',
-            FieldNotification.error
-          );
-        }
-        return new FieldNotification(
-          'desired',
-          'A series or a keyword tag is required for creating composer pages',
-          FieldNotification.warning
-        );
-    }
-    return null;
-  };
-
   validateYouTubeKeywords = youTubeKeywords => {
     const charLimit = YouTubeKeywords.maxCharacters;
     const numberOfChars = getYouTubeTagCharCount(youTubeKeywords);
@@ -251,7 +228,6 @@ class VideoDisplay extends React.Component {
           formName={formNames.videoData}
           updateErrors={this.props.formErrorActions.updateFormErrors}
           updateWarnings={this.props.formErrorActions.updateFormWarnings}
-          validateKeywords={this.validateKeywords}
           validateYouTubeKeywords={this.validateYouTubeKeywords}
           composerKeywordsToYouTube={this.composerKeywordsToYouTube}
           canonicalVideoPageExists={canonicalVideoPageExists(this.props.usages)}


### PR DESCRIPTION
`validateKeywords` is only relevant to `VideoData` so there's no need to pass it as a prop, we should just define it in the `VideoData` component itself.

This is also part of the work to break #839 up into smaller PRs.