### PR TITLE
splitting furniture fields across tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react-redux": "^5.0.1",
     "react-router": "^3.0.0",
     "react-router-redux": "^4.0.8",
+    "react-tabs": "^3.0.0",
     "react-tooltip": "^3.3.0",
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0",

--- a/public/video-ui/src/components/EditSaveCancel/index.js
+++ b/public/video-ui/src/components/EditSaveCancel/index.js
@@ -8,7 +8,8 @@ class EditSaveCancel extends React.Component {
     onEdit: PropTypes.func.isRequired,
     onSave: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
-    canSave: PropTypes.func.isRequired
+    canSave: PropTypes.func.isRequired,
+    canCancel: PropTypes.func
   };
 
   renderEditButton() {
@@ -36,11 +37,11 @@ class EditSaveCancel extends React.Component {
   }
 
   renderCancelButton() {
-    const { onCancel } = this.props;
+    const { canCancel, onCancel } = this.props;
 
     return (
-      <button onClick={onCancel}>
-        <Icon icon="cancel" className="icon__cancel">Cancel</Icon>
+      <button onClick={onCancel} disabled={canCancel ? !canCancel() : false}>
+        <Icon icon="cancel" className={`icon__cancel ${canCancel ? (canCancel() ? '' : 'disabled') : ''}`}>Cancel</Icon>
       </button>
     );
   }

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -14,7 +14,6 @@ import VideoUtils from '../../util/video';
 import DurationReset from "../DurationReset";
 import Flags from "../Flags";
 import ContentChangeDetails from "../ContentChangeDetails";
-import YoutubeFurniture from '../YoutubeFurniture';
 import {formNames} from "../../constants/formNames";
 import FieldNotification from "../../constants/FieldNotification";
 
@@ -168,13 +167,6 @@ export default class VideoData extends React.Component {
             >
               <SelectBox selectValues={videoCategories} />
             </ManagedField>
-            <YoutubeFurniture
-              video={video}
-              editable={editable}
-              updateVideo={updateVideo}
-              updateErrors={updateErrors}
-              updateWarnings={updateWarnings}
-            />
             <Flags
               video={video}
               editable={editable}

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -24,8 +24,7 @@ export default class VideoData extends React.Component {
     editable: PropTypes.bool.isRequired,
     updateErrors: PropTypes.func.isRequired,
     updateWarnings: PropTypes.func.isRequired,
-    canonicalVideoPageExists: PropTypes.bool.isRequired,
-    composerKeywordsToYouTube: PropTypes.func.isRequired
+    canonicalVideoPageExists: PropTypes.bool.isRequired
   };
 
   validateKeywords = keywords => {
@@ -58,8 +57,7 @@ export default class VideoData extends React.Component {
       updateErrors,
       updateWarnings,
       editable,
-      canonicalVideoPageExists,
-      composerKeywordsToYouTube
+      canonicalVideoPageExists
     } = this.props;
 
     const isYoutubeAtom = VideoUtils.isYoutube(video);
@@ -148,7 +146,6 @@ export default class VideoData extends React.Component {
               isDesired={true}
               inputPlaceholder="Search keywords (type '*' to show all)"
               customValidation={this.validateKeywords}
-              updateSideEffects={composerKeywordsToYouTube}
             >
               <TagPicker disableTextInput />
             </ManagedField>

--- a/public/video-ui/src/components/YoutubeFurniture/index.js
+++ b/public/video-ui/src/components/YoutubeFurniture/index.js
@@ -10,6 +10,7 @@ import {formNames} from "../../constants/formNames";
 import YouTubeKeywords from "../../constants/youTubeKeywords";
 import {getYouTubeTagCharCount} from "../../util/getYouTubeTagCharCount";
 import FieldNotification from "../../constants/FieldNotification";
+import KeywordsApi from '../../services/KeywordsApi';
 
 class YoutubeFurniture extends React.Component {
   static propTypes = {
@@ -44,6 +45,26 @@ class YoutubeFurniture extends React.Component {
         FieldNotification.error
       )
       : null;
+  };
+
+  composerKeywordsToYouTube = () => {
+    const { video, updateVideo } = this.props;
+
+    return Promise.all(
+      video.keywords.map(keyword => KeywordsApi.composerTagToYouTube(keyword))
+    )
+      .then(youTubeKeywords => {
+        const oldTags = video.tags;
+        const keywordsToCopy = youTubeKeywords.reduce((tagsAdded, keyword) => {
+          const allAddedTags = oldTags.concat(tagsAdded);
+          if (keyword !== '' && allAddedTags.every(oldTag => oldTag !== keyword)) {
+            tagsAdded.push(keyword);
+          }
+          return tagsAdded;
+        }, []);
+        const newVideo = Object.assign({}, video, { tags: oldTags.concat(keywordsToCopy)});
+        updateVideo(newVideo);
+      });
   };
 
   render() {
@@ -95,6 +116,7 @@ class YoutubeFurniture extends React.Component {
           tagType={TagTypes.youtube}
           disabled={!isYoutubeAtom}
           customValidation={this.validateYouTubeKeywords}
+          updateSideEffects={this.composerKeywordsToYouTube}
         >
           <TagPicker disableCapiTags />
         </ManagedField>

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -10,7 +10,6 @@ import Icon from '../../components/Icon';
 import { formNames } from '../../constants/formNames';
 import ReactTooltip from 'react-tooltip';
 import { blankVideoData } from '../../constants/blankVideoData';
-import KeywordsApi from '../../services/KeywordsApi';
 import { isVideoPublished } from '../../util/isVideoPublished';
 import { canonicalVideoPageExists } from '../../util/canonicalVideoPageExists';
 import VideoUtils from '../../util/video';
@@ -51,27 +50,6 @@ class VideoDisplay extends React.Component {
   updateVideo = video => {
     this.props.videoActions.updateVideo(video);
     return Promise.resolve();
-  };
-
-  composerKeywordsToYouTube = () => {
-
-    return Promise.all(this.props.video.keywords.map(keyword => KeywordsApi.composerTagToYouTube(keyword)))
-    .then(youTubeKeywords => {
-
-      const oldTags = this.props.video.tags;
-      const keywordsToCopy = youTubeKeywords.reduce((tagsAdded, keyword) => {
-        const allAddedTags = oldTags.concat(tagsAdded);
-        if (keyword !== '' &&
-          allAddedTags.every(oldTag => oldTag !== keyword)
-        ) {
-          tagsAdded.push(keyword);
-        }
-        return tagsAdded;
-      }, []);
-      const newVideo = Object.assign({}, this.props.video, { tags: oldTags.concat(keywordsToCopy)});
-
-      this.updateVideo(newVideo);
-    });
   };
 
   selectVideo = () => {
@@ -248,7 +226,6 @@ class VideoDisplay extends React.Component {
           updateErrors={this.props.formErrorActions.updateFormErrors}
           updateWarnings={this.props.formErrorActions.updateFormWarnings}
           canonicalVideoPageExists={canonicalVideoPageExists(usages)}
-          composerKeywordsToYouTube={this.composerKeywordsToYouTube}
         />
         <YoutubeFurnitureTabPanel
           editing={editingYoutubeFurniture}

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -22,28 +22,38 @@ import {
 
 class VideoDisplay extends React.Component {
   state = {
+    isCreateMode: false,
     editingFurniture: false,
     editingYoutubeFurniture: false
   };
 
   componentWillMount() {
-    if (this.props.route.mode === 'create') {
+    const isCreateMode = this.props.route.mode === 'create';
+    this.setState({ isCreateMode: isCreateMode });
+
+    if (isCreateMode) {
       this.props.videoActions.updateVideo(blankVideoData);
-      this.props.videoActions.updateVideoEditState(true);
+      this.updateEditingState({ key: 'editingFurniture', editing: true });
     } else {
-      this.props.videoActions.getVideo(this.props.params.id);
+      this.getVideo();
       this.props.videoActions.getUsages(this.props.params.id);
     }
   }
 
+  getVideo() {
+    this.props.videoActions.getVideo(this.props.params.id);
+  }
+
   saveAndUpdateVideo = video => {
-    if (this.props.route.mode === 'create') {
-      this.props.videoActions.createVideo(video)
-        .then(() => {
-          this.props.videoActions.getUsages(this.props.video.id);
-        });
+    const { isCreateMode } = this.state;
+
+    if (isCreateMode) {
+      this.props.videoActions.createVideo(video).then(() => {
+        this.setState({ isCreateMode: false });
+        this.props.videoActions.getUsages(this.props.video.id);
+      });
     } else {
-      this.props.videoActions.saveVideo(video)
+      this.props.videoActions.saveVideo(video);
     }
   };
 
@@ -187,6 +197,7 @@ class VideoDisplay extends React.Component {
     } = this.props;
 
     const {
+      isCreateMode,
       editingFurniture,
       editingYoutubeFurniture
     } = this.state;
@@ -208,7 +219,7 @@ class VideoDisplay extends React.Component {
             })
           }
           onCancel={() => {
-            this.updateEditingState({
+            !isCreateMode && this.updateEditingState({
               key: 'editingFurniture', editing: false
             });
             this.getVideo();
@@ -221,6 +232,7 @@ class VideoDisplay extends React.Component {
             this.saveAndUpdateVideo(video);
           }}
           canSave={() => !this.formHasErrors(formNames.videoData)}
+          canCancel={() => !isCreateMode}
           video={video}
           updateVideo={this.updateVideo}
           updateErrors={this.props.formErrorActions.updateFormErrors}

--- a/public/video-ui/src/pages/Video/tabs/Furniture.js
+++ b/public/video-ui/src/pages/Video/tabs/Furniture.js
@@ -29,8 +29,7 @@ export class FurnitureTabPanel extends React.Component {
     updateVideo: PropTypes.func.isRequired,
     updateErrors: PropTypes.func.isRequired,
     updateWarnings: PropTypes.func.isRequired,
-    canonicalVideoPageExists: PropTypes.bool.isRequired,
-    composerKeywordsToYouTube: PropTypes.func.isRequired
+    canonicalVideoPageExists: PropTypes.bool.isRequired
   };
 
   render() {
@@ -45,7 +44,6 @@ export class FurnitureTabPanel extends React.Component {
       updateErrors,
       updateWarnings,
       canonicalVideoPageExists,
-      composerKeywordsToYouTube,
       ...rest
     } = this.props;
 
@@ -66,7 +64,6 @@ export class FurnitureTabPanel extends React.Component {
           updateErrors={updateErrors}
           updateWarnings={updateWarnings}
           canonicalVideoPageExists={canonicalVideoPageExists}
-          composerKeywordsToYouTube={composerKeywordsToYouTube}
         />
       </TabPanel>
     );

--- a/public/video-ui/src/pages/Video/tabs/Furniture.js
+++ b/public/video-ui/src/pages/Video/tabs/Furniture.js
@@ -25,6 +25,7 @@ export class FurnitureTabPanel extends React.Component {
     onSave: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
     canSave: PropTypes.func.isRequired,
+    canCancel: PropTypes.func.isRequired,
     video: PropTypes.object.isRequired,
     updateVideo: PropTypes.func.isRequired,
     updateErrors: PropTypes.func.isRequired,
@@ -39,6 +40,7 @@ export class FurnitureTabPanel extends React.Component {
       onSave,
       onCancel,
       canSave,
+      canCancel,
       video,
       updateVideo,
       updateErrors,
@@ -55,6 +57,7 @@ export class FurnitureTabPanel extends React.Component {
           onSave={onSave}
           onCancel={onCancel}
           canSave={canSave}
+          canCancel={canCancel}
         />
 
         <VideoData

--- a/public/video-ui/src/pages/Video/tabs/Furniture.js
+++ b/public/video-ui/src/pages/Video/tabs/Furniture.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Tab, TabPanel } from 'react-tabs';
+import EditSaveCancel from '../../../components/EditSaveCancel';
+import VideoData from '../../../components/VideoData/VideoData';
+
+export class FurnitureTab extends React.Component {
+  static tabsRole = Tab.tabsRole;
+
+  render() {
+    return (
+      <Tab {...this.props}>
+        Furniture
+      </Tab>
+    );
+  }
+}
+
+export class FurnitureTabPanel extends React.Component {
+  static tabsRole = TabPanel.tabsRole;
+
+  static propTypes = {
+    editing: PropTypes.bool.isRequired,
+    onEdit: PropTypes.func.isRequired,
+    onSave: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    canSave: PropTypes.func.isRequired,
+    video: PropTypes.object.isRequired,
+    updateVideo: PropTypes.func.isRequired,
+    updateErrors: PropTypes.func.isRequired,
+    updateWarnings: PropTypes.func.isRequired,
+    canonicalVideoPageExists: PropTypes.bool.isRequired,
+    composerKeywordsToYouTube: PropTypes.func.isRequired
+  };
+
+  render() {
+    const {
+      editing,
+      onEdit,
+      onSave,
+      onCancel,
+      canSave,
+      video,
+      updateVideo,
+      updateErrors,
+      updateWarnings,
+      canonicalVideoPageExists,
+      composerKeywordsToYouTube,
+      ...rest
+    } = this.props;
+
+    return (
+      <TabPanel {...rest}>
+        <EditSaveCancel
+          editing={editing}
+          onEdit={onEdit}
+          onSave={onSave}
+          onCancel={onCancel}
+          canSave={canSave}
+        />
+
+        <VideoData
+          video={video}
+          updateVideo={updateVideo}
+          editable={editing}
+          updateErrors={updateErrors}
+          updateWarnings={updateWarnings}
+          canonicalVideoPageExists={canonicalVideoPageExists}
+          composerKeywordsToYouTube={composerKeywordsToYouTube}
+        />
+      </TabPanel>
+    );
+  }
+}

--- a/public/video-ui/src/pages/Video/tabs/YoutubeFurniture.js
+++ b/public/video-ui/src/pages/Video/tabs/YoutubeFurniture.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Tab, TabPanel } from 'react-tabs';
+import EditSaveCancel from '../../../components/EditSaveCancel';
+import YoutubeFurniture from '../../../components/YoutubeFurniture';
+
+export class YoutubeFurnitureTab extends React.Component {
+  static tabsRole = Tab.tabsRole;
+
+  render() {
+    return (
+      <Tab {...this.props}>
+        YouTube Furniture
+      </Tab>
+    );
+  }
+}
+
+export class YoutubeFurnitureTabPanel extends React.Component {
+  static tabsRole = TabPanel.tabsRole;
+
+  static propTypes = {
+    editing: PropTypes.bool.isRequired,
+    onEdit: PropTypes.func.isRequired,
+    onSave: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    canSave: PropTypes.func.isRequired,
+    video: PropTypes.object.isRequired,
+    updateVideo: PropTypes.func.isRequired,
+    updateErrors: PropTypes.func.isRequired,
+    updateWarnings: PropTypes.func.isRequired
+  };
+
+  render() {
+    const {
+      editing,
+      onEdit,
+      onSave,
+      onCancel,
+      canSave,
+      video,
+      updateVideo,
+      updateErrors,
+      updateWarnings,
+      ...rest
+    } = this.props;
+
+    return (
+      <TabPanel {...rest}>
+        <EditSaveCancel
+          editing={editing}
+          onEdit={onEdit}
+          onSave={onSave}
+          onCancel={onCancel}
+          canSave={canSave}
+        />
+        <YoutubeFurniture
+          video={video}
+          editable={editing}
+          updateVideo={updateVideo}
+          updateErrors={updateErrors}
+          updateWarnings={updateWarnings}
+        />
+      </TabPanel>
+    );
+  }
+}

--- a/public/video-ui/styles/layout/_tabs.scss
+++ b/public/video-ui/styles/layout/_tabs.scss
@@ -1,0 +1,46 @@
+.react-tabs__tab-list {
+  border-bottom: 1px solid #aaa;
+  margin: 0 0 10px;
+  padding: 0;
+}
+
+.react-tabs__tab {
+  display: inline-block;
+  border: 1px solid $color600Grey;
+  border-bottom: 4px solid transparent;
+  position: relative;
+  list-style: none;
+  padding: 10px 20px;
+  cursor: pointer;
+  font-size: 15px;
+  font-weight: bold;
+
+  &:nth-child(2) {
+    border-left: none;
+    border-right: none;
+  }
+
+  &:hover {
+    background-color: $color625Grey;
+    color: $brandColor;
+  }
+
+  &--selected {
+    background-color: $color600Grey;
+    border-bottom: 4px solid $brandColor;
+    color: $brandColor;
+
+    &:hover {
+      background-color: $color600Grey;
+    }
+  }
+
+  &--disabled {
+    color: $color600Grey;
+    cursor: default;
+  }
+}
+
+.react-tabs__tab-panel {
+  margin: 10px;
+}

--- a/public/video-ui/styles/main.scss
+++ b/public/video-ui/styles/main.scss
@@ -25,7 +25,8 @@
   'layout/grid',
   'layout/video',
   'layout/icons',
-  'layout/upload';
+  'layout/upload',
+  'layout/tabs';
 
 // 5. Components
 @import

--- a/yarn.lock
+++ b/yarn.lock
@@ -3235,6 +3235,10 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@^3.5.1, js-yaml@^3.7.0, js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
@@ -3493,6 +3497,12 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -4432,6 +4442,14 @@ prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6,
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
+prop-types@^15.5.0:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 proxy-addr@~1.1.3:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.4.tgz#27e545f6960a44a627d9b44467e35c1b6b4ce2f3"
@@ -4554,6 +4572,10 @@ react-hot-loader@^3.0.0-beta.5:
     redbox-react "^1.2.5"
     source-map "^0.4.4"
 
+react-is@^16.8.1:
+  version "16.8.4"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
+
 react-onclickoutside@^5.7.1:
   version "5.11.1"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-5.11.1.tgz#00314e52567cf55faba94cabbacd119619070623"
@@ -4593,6 +4615,13 @@ react-router@^3.0.0:
     loose-envify "^1.2.0"
     prop-types "^15.5.6"
     warning "^3.0.0"
+
+react-tabs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-tabs/-/react-tabs-3.0.0.tgz#60311a17c755eb6aa9b3310123e67db421605127"
+  dependencies:
+    classnames "^2.2.0"
+    prop-types "^15.5.0"
 
 react-tooltip@^3.3.0:
   version "3.3.0"


### PR DESCRIPTION
https://github.com/guardian/media-atom-maker/pull/839 take 2.

Depends on #838 and #841 (those commits have been cherry picked onto this branch).

We want to be able to edit the YouTube title and description independently of the equivalent onsite metadata. This means we're introducing two new fields to the already busy form.

Switch to a tabbed interface to provide more clarity to the UI. This has been discussed with UX and a couple of video producers.

![tabby](https://user-images.githubusercontent.com/836140/54570864-25f3a980-49d8-11e9-8f9d-081e983bff91.gif)
