### PR TITLE
create management tab

### DIFF
--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ManagedForm, ManagedField, ManagedSection } from '../ManagedForm';
+import { ManagedForm, ManagedField } from '../ManagedForm';
 import TextInput from '../FormFields/TextInput';
 import DurationInput from '../FormFields/DurationInput';
 import ScribeEditorField from '../FormFields/ScribeEditor';
@@ -11,9 +11,6 @@ import TagTypes from '../../constants/TagTypes';
 import { fieldLengths } from '../../constants/videoEditValidation';
 import { videoCategories } from '../../constants/videoCategories';
 import VideoUtils from '../../util/video';
-import DurationReset from "../DurationReset";
-import Flags from "../Flags";
-import ContentChangeDetails from "../ContentChangeDetails";
 import {formNames} from "../../constants/formNames";
 import FieldNotification from "../../constants/FieldNotification";
 
@@ -65,121 +62,104 @@ export default class VideoData extends React.Component {
     const hasAssets = VideoUtils.hasAssets(video);
 
     return (
-      <div className="form__group">
-        <ManagedForm
-          data={video}
-          updateData={updateVideo}
-          editable={editable}
-          updateErrors={updateErrors}
-          updateWarnings={updateWarnings}
-          formName={formNames.videoData}
-          formClass="atom__edit__form"
+      <ManagedForm
+        data={video}
+        updateData={updateVideo}
+        editable={editable}
+        updateErrors={updateErrors}
+        updateWarnings={updateWarnings}
+        formName={formNames.videoData}
+        formClass="atom__edit__form"
+      >
+        <ManagedField
+          fieldLocation="title"
+          name={
+            isYoutubeAtom ? 'Headline (YouTube title)' : 'Headline'
+          }
+          maxLength={fieldLengths.title}
+          isRequired={true}
         >
-          <ManagedSection>
-            <ContentChangeDetails video={video}/>
-            <ManagedField
-              fieldLocation="title"
-              name={
-                isYoutubeAtom ? 'Headline (YouTube title)' : 'Headline'
-              }
-              maxLength={fieldLengths.title}
-              isRequired={true}
-            >
-              <TextInput />
-            </ManagedField>
-            <ManagedField
-              fieldLocation="description"
-              name={
-                isYoutubeAtom
-                  ? 'Standfirst (YouTube description)'
-                  : 'Standfirst'
-              }
-              customValidation={this.props.descriptionValidator}
-              maxCharLength={fieldLengths.description.charMax}
-              maxLength={fieldLengths.description.max}
-            >
-              <ScribeEditorField
-                allowedEdits={['bold', 'italic', 'linkPrompt', 'unlink', 'insertUnorderedList']}
-              />
-            </ManagedField>
-            <ManagedField
-              fieldLocation="trailText"
-              derivedFrom={video.description}
-              name="Trail Text"
-              maxCharLength={fieldLengths.description.charMax}
-              maxLength={fieldLengths.description.max}
-              isDesired={!canonicalVideoPageExists}
-              isRequired={canonicalVideoPageExists}
-            >
-              <ScribeEditorField
-                allowedEdits={['bold', 'italic']}
-                isDesired={!canonicalVideoPageExists}
-                isRequired={canonicalVideoPageExists}
-              />
-            </ManagedField>
+          <TextInput />
+        </ManagedField>
+        <ManagedField
+          fieldLocation="description"
+          name={
+            isYoutubeAtom
+              ? 'Standfirst (YouTube description)'
+              : 'Standfirst'
+          }
+          customValidation={this.props.descriptionValidator}
+          maxCharLength={fieldLengths.description.charMax}
+          maxLength={fieldLengths.description.max}
+        >
+          <ScribeEditorField
+            allowedEdits={['bold', 'italic', 'linkPrompt', 'unlink', 'insertUnorderedList']}
+          />
+        </ManagedField>
+        <ManagedField
+          fieldLocation="trailText"
+          derivedFrom={video.description}
+          name="Trail Text"
+          maxCharLength={fieldLengths.description.charMax}
+          maxLength={fieldLengths.description.max}
+          isDesired={!canonicalVideoPageExists}
+          isRequired={canonicalVideoPageExists}
+        >
+          <ScribeEditorField
+            allowedEdits={['bold', 'italic']}
+            isDesired={!canonicalVideoPageExists}
+            isRequired={canonicalVideoPageExists}
+          />
+        </ManagedField>
 
-            <ManagedField
-              fieldLocation="byline"
-              name="Byline"
-              formRowClass="form__row__byline"
-              tagType={TagTypes.contributor}
-            >
-              <TagPicker />
-            </ManagedField>
-            <ManagedField
-              fieldLocation="commissioningDesks"
-              name="Commissioning Desks"
-              formRowClass="form__row__byline"
-              tagType={TagTypes.tracking}
-              isDesired={!canonicalVideoPageExists}
-              isRequired={canonicalVideoPageExists}
-              inputPlaceholder="Search commissioning info (type '*' to show all)"
-            >
-              <TagPicker disableTextInput />
-            </ManagedField>
+        <ManagedField
+          fieldLocation="byline"
+          name="Byline"
+          formRowClass="form__row__byline"
+          tagType={TagTypes.contributor}
+        >
+          <TagPicker />
+        </ManagedField>
+        <ManagedField
+          fieldLocation="commissioningDesks"
+          name="Commissioning Desks"
+          formRowClass="form__row__byline"
+          tagType={TagTypes.tracking}
+          isDesired={!canonicalVideoPageExists}
+          isRequired={canonicalVideoPageExists}
+          inputPlaceholder="Search commissioning info (type '*' to show all)"
+        >
+          <TagPicker disableTextInput />
+        </ManagedField>
 
-            <ManagedField
-              fieldLocation="keywords"
-              name="Composer Keywords"
-              formRowClass="form__row__byline"
-              tagType={isCommercialType ? TagTypes.commercial : TagTypes.keyword}
-              isDesired={true}
-              inputPlaceholder="Search keywords (type '*' to show all)"
-              customValidation={this.validateKeywords}
-            >
-              <TagPicker disableTextInput />
-            </ManagedField>
-            <ManagedField fieldLocation="source" name="Video Source">
-              <TextInput />
-            </ManagedField>
-          </ManagedSection>
-          <ManagedSection>
-            <ManagedField fieldLocation="expiryDate" name="Expiry Date">
-              <DatePicker />
-            </ManagedField>
-            <ManagedField
-              fieldLocation="category"
-              name="Category"
-              disabled={hasAssets}
-            >
-              <SelectBox selectValues={videoCategories} />
-            </ManagedField>
-            <Flags
-              video={video}
-              editable={editable}
-              updateVideo={updateVideo}
-              updateErrors={updateErrors}
-              updateWarnings={updateWarnings}
-            />
-            <ManagedField fieldLocation="duration" name="Video Duration (mm:ss)">
-              <DurationInput />
-            </ManagedField>
-            {!editable && (
-              <DurationReset video={video} updateVideo={updateVideo}/>
-            )}
-          </ManagedSection>
-        </ManagedForm>
-      </div>
+        <ManagedField
+          fieldLocation="keywords"
+          name="Composer Keywords"
+          formRowClass="form__row__byline"
+          tagType={isCommercialType ? TagTypes.commercial : TagTypes.keyword}
+          isDesired={true}
+          inputPlaceholder="Search keywords (type '*' to show all)"
+          customValidation={this.validateKeywords}
+        >
+          <TagPicker disableTextInput />
+        </ManagedField>
+        <ManagedField fieldLocation="source" name="Video Source">
+          <TextInput />
+        </ManagedField>
+        <ManagedField fieldLocation="expiryDate" name="Expiry Date">
+          <DatePicker />
+        </ManagedField>
+        <ManagedField
+          fieldLocation="category"
+          name="Category"
+          disabled={hasAssets}
+        >
+          <SelectBox selectValues={videoCategories} />
+        </ManagedField>
+        <ManagedField fieldLocation="duration" name="Video Duration (mm:ss)">
+          <DurationInput />
+        </ManagedField>
+      </ManagedForm>
     );
   }
 }

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -19,6 +19,7 @@ import {
 import { WorkflowTab, WorkflowTabPanel } from './tabs/Workflow';
 import { UsageTab, UsageTabPanel } from './tabs/Usage';
 import { TargetingTab, TargetingTabPanel } from './tabs/Targeting';
+import { ManagementTab, ManagementTabPanel } from './tabs/Management';
 
 class VideoDisplay extends React.Component {
   state = {
@@ -223,6 +224,7 @@ class VideoDisplay extends React.Component {
           <WorkflowTab disabled={workflowDisabled || isCreateMode} />
           <UsageTab disabled={videoEditOpen || isCreateMode} />
           <TargetingTab disabled={videoEditOpen || isCreateMode} />
+          <ManagementTab disabled={videoEditOpen || isCreateMode} />
         </TabList>
         <FurnitureTabPanel
           editing={editingFurniture}
@@ -301,6 +303,7 @@ class VideoDisplay extends React.Component {
           usages={usages || {}}
         />
         <TargetingTabPanel video={video} />
+        <ManagementTabPanel video={video} updateVideo={this.updateVideo} />
       </Tabs>
     );
   }

--- a/public/video-ui/src/pages/Video/tabs/Furniture.js
+++ b/public/video-ui/src/pages/Video/tabs/Furniture.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Tab, TabPanel } from 'react-tabs';
 import EditSaveCancel from '../../../components/EditSaveCancel';
 import VideoData from '../../../components/VideoData/VideoData';
+import Flags from '../../../components/Flags';
 
 export class FurnitureTab extends React.Component {
   static tabsRole = Tab.tabsRole;
@@ -67,6 +68,14 @@ export class FurnitureTabPanel extends React.Component {
           updateErrors={updateErrors}
           updateWarnings={updateWarnings}
           canonicalVideoPageExists={canonicalVideoPageExists}
+        />
+
+        <Flags
+          video={video}
+          editable={editing}
+          updateVideo={updateVideo}
+          updateErrors={updateErrors}
+          updateWarnings={updateWarnings}
         />
       </TabPanel>
     );

--- a/public/video-ui/src/pages/Video/tabs/Management.js
+++ b/public/video-ui/src/pages/Video/tabs/Management.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Tab, TabPanel } from 'react-tabs';
+import ContentChangeDetails from '../../../components/ContentChangeDetails';
+import DurationReset from '../../../components/DurationReset';
+
+export class ManagementTab extends React.Component {
+  static tabsRole = Tab.tabsRole;
+
+  render() {
+    return (
+      <Tab {...this.props}>
+        Management
+      </Tab>
+    );
+  }
+}
+
+export class ManagementTabPanel extends React.Component {
+  static tabsRole = TabPanel.tabsRole;
+
+  static propTypes = {
+    video: PropTypes.object.isRequired,
+    updateVideo: PropTypes.func.isRequired
+  };
+
+  render() {
+    const { video, updateVideo, ...rest } = this.props;
+
+    return (
+      <TabPanel {...rest}>
+        <div className="form__group">
+          <header className="video__detailbox__header">Content Details</header>
+          <ContentChangeDetails video={video} />
+        </div>
+
+        <div className="form__group">
+          <header className="video__detailbox__header">Duration Reset</header>
+          <DurationReset video={video} updateVideo={updateVideo} />
+        </div>
+      </TabPanel>
+    );
+  }
+}


### PR DESCRIPTION
depends on #846 

easier to review w/out whitespace changes - https://github.com/guardian/media-atom-maker/pull/847/files?w=1

management tab contains infrequently used features, such as content change details and resetting video duration from youtube

![image](https://user-images.githubusercontent.com/836140/54571367-4886c200-49da-11e9-8f75-0a357ef16b57.png)

also flattens furniture tab to a single column form

![image](https://user-images.githubusercontent.com/836140/54571387-589ea180-49da-11e9-9a2e-55fb2462b8ae.png)
