### PR TITLE
show newlines for text area display

### DIFF
--- a/public/video-ui/src/components/FormFields/TextAreaInput.js
+++ b/public/video-ui/src/components/FormFields/TextAreaInput.js
@@ -14,10 +14,10 @@ export default class TextAreaInput extends React.Component {
                   this.props.fieldValue
                 )
                   ? 'details-list__empty'
-                  : '')
+                  : 'details-list__field--text-area')
             }
           >
-            {' '}{this.props.fieldValue}
+            {this.props.fieldValue}
           </p>
         </div>
       );

--- a/public/video-ui/styles/components/_details-list.scss
+++ b/public/video-ui/styles/components/_details-list.scss
@@ -12,6 +12,10 @@
   text-overflow: ellipsis;
   margin: 0 0 10px;
   padding: 0px;
+
+  &--text-area {
+    white-space: pre-line;
+  }
 }
 
 .details-list__field--scribe > p,ul {


### PR DESCRIPTION
correctly show newlines for a text area form field in display mode

# Before
![before](https://user-images.githubusercontent.com/836140/54806709-c2d17380-4c72-11e9-9551-2b6bafff192e.gif)

# After
![after](https://user-images.githubusercontent.com/836140/54806714-c7962780-4c72-11e9-962e-538e0bec93a9.gif)
