### PR TITLE
use correct property to determine if atom is currently tracked in workflow

### DIFF
--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -148,9 +148,8 @@ class VideoDisplay extends React.Component {
     const { video } = this.props;
 
     const {
-      trackedInWorkflow,
       sections,
-      status: { status, section, note }
+      status: { status, section, note, isTrackedInWorkflow }
     } = this.props.workflow;
 
     const {
@@ -172,7 +171,7 @@ class VideoDisplay extends React.Component {
         workflowItem: this.props.workflow.status
       });
 
-    const wfPromise = trackedInWorkflow
+    const wfPromise = isTrackedInWorkflow
       ? updateWorkflowItem()
       : createWorkflowItem();
 


### PR DESCRIPTION
This was a regression introduced in the tabbed ui update.

It manifested itself by `wfPromise` always being assigned `createWorkflowItem`, so even if the atom is in already in Workflow, we were `POST`ing again to create a new entry 🤦‍♂️ .