### PR TITLE
remove html tags before using atom description as yt description

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,8 @@ lazy val common = (project in file("common"))
       "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ses" % awsVersion,
       "com.gu" %% "content-api-client-aws" % capiAwsVersion,
-      "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
+      "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
+      "org.jsoup" % "jsoup" % jsoupVersion
     )
   )
 
@@ -127,8 +128,7 @@ lazy val app = (project in file("."))
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
       "org.scalatestplus.play" %% "scalatestplus-play" % scalaTestPlusPlayVersion % "test",
       "org.mockito" %  "mockito-core" % mockitoVersion % "test",
-      "org.scala-lang.modules" %% "scala-xml" % scalaXmlVersion   % "test",
-      "org.jsoup" % "jsoup" % jsoupVersion
+      "org.scala-lang.modules" %% "scala-xml" % scalaXmlVersion   % "test"
     ),
 
     aggregate in run := false,


### PR DESCRIPTION
the atom's description is html, remove any html markup before using it as the youtube description as youtube displays as plain text

This was removed [here](https://github.com/guardian/media-atom-maker/pull/848/files#diff-7f574d10ef01ba109a3d2e022bea685cL239) and I clearly hadn't tested that branch with rich text! Moving it into `common` (and thus jsoup is a common dependency) so that it can be part of the model, rather calculated at publish time.

an example of the wrong behaviour:
![image](https://user-images.githubusercontent.com/836140/54984270-68078700-4fa6-11e9-8315-a155c164c2e0.png)
