### PR TITLE
comma separate tags

### DIFF
--- a/public/video-ui/src/components/Tags/TagFieldValue.js
+++ b/public/video-ui/src/components/Tags/TagFieldValue.js
@@ -2,12 +2,14 @@ import React from 'react';
 
 export default class TagFieldValue extends React.Component {
 
-  renderFieldValue(value, index) {
+  renderFieldValue(value, index, arr) {
     if (value.webTitle) {
+      const isLastItem = index === arr.length - 1;
+
       return (
         <span key={`${value.id}-${index}`}>
           <span className="form__field__tag__display">{value.webTitle}</span>
-          {' '}
+          {isLastItem ? '' : ', '}
         </span>
       );
 

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -299,7 +299,6 @@
 
 
 .form__field__tag__display {
-  text-decoration: underline $textColor;
   padding-left: 3px;
 }
 


### PR DESCRIPTION
Its sometimes desired to copy and paste tags (in particular youtube tags) across atoms. We already accept a comma seperated string as input for youtube tags, this changes the rendering to include commas between tags to make copy pasting easier. Previously, we were copying the tags, pasting into a text editor, adding the commas, pasting into atom... long!

Also removes the underlining style as it was quite distracting.

# Before
![image](https://user-images.githubusercontent.com/836140/55019102-1f72bc80-4fec-11e9-9160-85dd985712f9.png)


# After
![image](https://user-images.githubusercontent.com/836140/55019038-066a0b80-4fec-11e9-98ea-fb8207ca489f.png)
