### PR TITLE
add a link to Pluto

### DIFF
--- a/public/video-ui/src/components/Pluto/PlutoProjectLink.js
+++ b/public/video-ui/src/components/Pluto/PlutoProjectLink.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Icon from '../Icon';
+import { getPlutoProjectLink } from '../../services/PlutoApi';
+
+export default class PlutoProjectLink extends React.Component {
+  static propTypes = {
+    projectId: PropTypes.string.isRequired
+  };
+
+  render() {
+    return (
+      <a
+        className="button inline-block"
+        target="_blank"
+        rel="noopener noreferrer"
+        href={getPlutoProjectLink(this.props.projectId)}
+      >
+        <Icon icon="open_in_new" className="icon__edit">Open Pluto Project</Icon>
+      </a>
+    );
+  }
+}

--- a/public/video-ui/src/pages/Upload/index.js
+++ b/public/video-ui/src/pages/Upload/index.js
@@ -6,6 +6,7 @@ import PlutoProjectPicker from '../../components/Pluto/PlutoProjectPicker';
 import AddSelfHostedAsset from '../../components/VideoUpload/AddSelfHostedAsset';
 import YoutubeUpload from '../../components/VideoUpload/YoutubeUpload';
 import PACUpload from '../../components/PACUpload/PACUpload';
+import PlutoProjectLink from '../../components/Pluto/PlutoProjectLink';
 
 class VideoUpload extends React.Component {
   hasCategories = () =>
@@ -29,6 +30,8 @@ class VideoUpload extends React.Component {
     const uploading = this.props.s3Upload.total > 0;
     const activeVersion = this.props.video ? this.props.video.activeVersion : 0;
 
+    const projectId = this.props.video.plutoData && this.props.video.plutoData.projectId;
+
     return (
       <div>
         <div className="video__main">
@@ -41,6 +44,7 @@ class VideoUpload extends React.Component {
                   </header>
                 </div>
                 <div className="form__group">
+                  { projectId && <PlutoProjectLink projectId={projectId}/> }
                   <PlutoProjectPicker
                     video={this.props.video || {}}
                     saveVideo={this.props.videoActions.saveVideo}

--- a/public/video-ui/src/services/PlutoApi.js
+++ b/public/video-ui/src/services/PlutoApi.js
@@ -11,3 +11,20 @@ export function getPlutoProjects({commissionId}) {
     url: `/api/pluto/commissions/${commissionId}/projects`
   });
 }
+
+export function getPlutoProjectLink(projectId) {
+  // `plutoSources` lifted from flexible-content
+  // https://github.com/guardian/flexible-content/blob/master/composer/src/js/controllers/content/video/body-block.js
+  const plutoDev = { prefix: 'VX-', domain: 'pluto-dev' };
+
+  const plutoSources = [
+    { prefix: 'KP-', domain: 'pluto' },
+    { prefix: 'BK-', domain: 'pluto-dr' },
+    plutoDev
+  ];
+
+  const plutoSource = plutoSources.find(source => projectId.startsWith(source)) || plutoDev;
+
+  // pluto isn't accessible over https
+  return `http://${plutoSource.domain}/project/${projectId}`;
+}


### PR DESCRIPTION
Requested by video producers on the news desk to make hand over easier as they are currently sharing atom urls and then searching within Pluto for the project to then find the Premiere files.

A link to open the linked Pluto project in a new tab is just so much easier!

![image](https://user-images.githubusercontent.com/836140/55024684-497dac00-4ff7-11e9-8d84-894c33dbc144.png)
