### PR TITLE
bump yt description length

### DIFF
--- a/public/video-ui/src/components/YoutubeFurniture/index.js
+++ b/public/video-ui/src/components/YoutubeFurniture/index.js
@@ -123,8 +123,8 @@ class YoutubeFurniture extends React.Component {
         <ManagedField
           fieldLocation="youtubeDescription"
           name="Description"
-          maxCharLength={fieldLengths.description.charMax}
-          maxLength={fieldLengths.description.max}
+          maxCharLength={fieldLengths.youtubeDescription.charMax}
+          maxLength={fieldLengths.youtubeDescription.charMax}
           isRequired={false}
         >
           <TextAreaInput />

--- a/public/video-ui/src/constants/videoEditValidation.js
+++ b/public/video-ui/src/constants/videoEditValidation.js
@@ -8,5 +8,8 @@ export const fieldLengths = {
   trail: {
     max: 1000,
     charMax: 2000
+  },
+  youtubeDescription: {
+    charMax: 5000
   }
 };


### PR DESCRIPTION
now that yt description is seperate from the standfirst, we can make the char limit of the yt description match the limit on youtube - [5000 characters](https://developers.google.com/youtube/v3/docs/videos#snippet.description)