### PR TITLE
clean youtube description at atom creation time

### DIFF
--- a/common/src/main/scala/com/gu/media/model/MediaAtom.scala
+++ b/common/src/main/scala/com/gu/media/model/MediaAtom.scala
@@ -4,8 +4,8 @@ import com.gu.contentatom.thrift.atom.media.{MediaAtom => ThriftMediaAtom, Metad
 import play.api.libs.json.Format
 import com.gu.contentatom.thrift.{AtomData, Atom => ThriftAtom, AtomType => ThriftAtomType, Flags => ThriftFlags}
 import com.gu.media.util.MediaAtomImplicits
+import com.gu.media.youtube.YoutubeDescription
 import org.cvogt.play.json.Jsonx
-import org.jsoup.Jsoup
 
 abstract class MediaAtomBase {
   //generic metadata
@@ -123,7 +123,7 @@ case class MediaAtomBeforeCreation(
 
   // when creating an atom, use the `title` (headline) and `description` (standfirst) as the initial `youtubeTitle` and `youtubeDescription`
   override val youtubeTitle: String = title
-  override val youtubeDescription: Option[String] = description
+  override val youtubeDescription: Option[String] = YoutubeDescription.clean(description)
 }
 
 object MediaAtomBeforeCreation {
@@ -228,26 +228,12 @@ case class MediaAtom(
 object MediaAtom extends MediaAtomImplicits {
   implicit val mediaAtomFormat = Jsonx.formatCaseClass[MediaAtom]
 
-  private def removeHtmlTagsForYouTube(description: String): String = {
-    val html = Jsoup.parse(description)
-
-    //Extracting the text removes line breaks
-    //We add them back in before each paragraph except
-    //for the first and before each list element
-    html.select("p:gt(0), li")
-        .prepend("\\n")
-        .select("a")
-        .unwrap()
-
-    html.text().replace("\\n", "\n")
-  }
-
   def fromThrift(atom: ThriftAtom) = {
     val data = atom.tdata
 
     val youtubeDescription: Option[String] = data.metadata.flatMap(_.youtube) match {
       case Some(youtubeData) if youtubeData.description.isDefined => youtubeData.description
-      case _ => data.description.map(removeHtmlTagsForYouTube)
+      case _ => YoutubeDescription.clean(data.description)
     }
 
     MediaAtom(

--- a/common/src/main/scala/com/gu/media/youtube/YoutubeDescription.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YoutubeDescription.scala
@@ -1,0 +1,21 @@
+package com.gu.media.youtube
+
+import org.jsoup.Jsoup
+
+object YoutubeDescription {
+  def clean(maybeDirtyDescription: Option[String]): Option[String] = {
+    maybeDirtyDescription.map(dirtyDescription => {
+      val html = Jsoup.parse(dirtyDescription)
+
+      //Extracting the text removes line breaks
+      //We add them back in before each paragraph except
+      //for the first and before each list element
+      html.select("p:gt(0), li")
+        .prepend("\\n")
+        .select("a")
+        .unwrap()
+
+      html.text().replace("\\n", "\n")
+    })
+  }
+}

--- a/common/src/test/scala/com/gu/media/model/MediaAtomTest.scala
+++ b/common/src/test/scala/com/gu/media/model/MediaAtomTest.scala
@@ -5,6 +5,66 @@ import com.gu.contentatom.thrift.{AtomData, Atom => ThriftAtom, AtomType => Thri
 import com.gu.contentatom.thrift.atom.media.{Category => ThriftMediaCategory, MediaAtom => ThriftMediaAtom, Metadata => ThriftMetaData, YoutubeData => ThriftYoutubeData}
 
 class MediaAtomTest extends FunSuite with MustMatchers {
+  private val htmlDescription =
+    """
+      |<p>
+      |  The three-year construction of Tottenham Hotspur's new stadium is revealed in a time-lapse video released by the club.
+      |  The £1bn stadium will be officially unveiled on Sunday, before Spurs play their first match at their new home on 3 April against Crystal Palace.
+      |</p>
+      |<ul>
+      |  <li>
+      |    <a href="https://www.theguardian.com/football/2019/mar/08/tottenham-new-stadium-first-match-brighton-crystal-palace-champions-league">
+      |      Tottenham announce first match for new 62,000 capacity stadium
+      |    </a>
+      |  </li>
+      |</ul>
+    """.stripMargin
+
+  private val youtubeDescription = "The three-year construction of Tottenham Hotspur's new stadium is revealed in a time-lapse video released by the club. The £1bn stadium will be officially unveiled on Sunday, before Spurs play their first match at their new home on 3 April against Crystal Palace. \n Tottenham announce first match for new 62,000 capacity stadium"
+
+  private def getAtomBeforeCreation(title: String) = MediaAtomBeforeCreation(
+    title = title,
+    description = None,
+    posterImage = None,
+    category = Category.News,
+    source = None,
+    contentChangeDetails = ContentChangeDetails(None, None, None, 1L, None, None, None),
+    channelId = None,
+    privacyStatus = None,
+    youtubeCategoryId = None,
+    keywords = List.empty,
+    license = None,
+    blockAds = false,
+    expiryDate = None,
+    trailImage = None,
+    trailText = None,
+    tags = List.empty,
+    byline = List.empty,
+    commissioningDesks = List.empty,
+    legallySensitive = None,
+    sensitive = None,
+    optimisedForWeb = None,
+    composerCommentsEnabled = None,
+    suppressRelatedContent = None
+  )
+
+  test("test youtube description of MediaAtomBeforeCreation with empty description") {
+    val atomBeforeCreation = getAtomBeforeCreation("harry potter and the philosopher's stone")
+    atomBeforeCreation.youtubeDescription must be(None)
+  }
+
+  test("test youtube description of MediaAtomBeforeCreation with plain description") {
+    val plainDescription = Some("oh hello there")
+    val atomBeforeCreation = getAtomBeforeCreation("harry potter and the chamber of secrets").copy(description = plainDescription)
+    atomBeforeCreation.youtubeDescription must be(plainDescription)
+  }
+
+  test("test youtube description of MediaAtomBeforeCreation with html description") {
+    val atomBeforeCreation = getAtomBeforeCreation("harry potter and the prisoner of azkaban").copy(description = Some(htmlDescription))
+    val expected = Some(youtubeDescription)
+    atomBeforeCreation.youtubeDescription must be(expected)
+  }
+
   test("test generation of youtube title from atom title") {
     val thriftAtomData = ThriftMediaAtom(
       title = "a title",
@@ -31,21 +91,7 @@ class MediaAtomTest extends FunSuite with MustMatchers {
     val thriftAtomData = ThriftMediaAtom(
       title = "a title",
       category = ThriftMediaCategory.News,
-      description = Some(
-        """
-          |<p>
-          |  The three-year construction of Tottenham Hotspur's new stadium is revealed in a time-lapse video released by the club.
-          |  The £1bn stadium will be officially unveiled on Sunday, before Spurs play their first match at their new home on 3 April against Crystal Palace.
-          |</p>
-          |<ul>
-          |  <li>
-          |    <a href=\"https://www.theguardian.com/football/2019/mar/08/tottenham-new-stadium-first-match-brighton-crystal-palace-champions-league\">
-          |      Tottenham announce first match for new 62,000 capacity stadium
-          |    </a>
-          |  </li>
-          |</ul>
-        """.stripMargin
-      )
+      description = Some(htmlDescription)
     )
 
     val thriftAtom = ThriftAtom(
@@ -59,7 +105,7 @@ class MediaAtomTest extends FunSuite with MustMatchers {
 
     val mediaAtom = MediaAtom.fromThrift(thriftAtom)
 
-    val expected = Some("The three-year construction of Tottenham Hotspur's new stadium is revealed in a time-lapse video released by the club. The £1bn stadium will be officially unveiled on Sunday, before Spurs play their first match at their new home on 3 April against Crystal Palace. \n Tottenham announce first match for new 62,000 capacity stadium")
+    val expected = Some(youtubeDescription)
 
     mediaAtom.youtubeDescription must be(expected)
   }
@@ -68,21 +114,7 @@ class MediaAtomTest extends FunSuite with MustMatchers {
     val thriftAtomData = ThriftMediaAtom(
       title = "a title",
       category = ThriftMediaCategory.News,
-      description = Some(
-        """
-          |<p>
-          |  The three-year construction of Tottenham Hotspur's new stadium is revealed in a time-lapse video released by the club.
-          |  The £1bn stadium will be officially unveiled on Sunday, before Spurs play their first match at their new home on 3 April against Crystal Palace.
-          |</p>
-          |<ul>
-          |  <li>
-          |    <a href=\"https://www.theguardian.com/football/2019/mar/08/tottenham-new-stadium-first-match-brighton-crystal-palace-champions-league\">
-          |      Tottenham announce first match for new 62,000 capacity stadium
-          |    </a>
-          |  </li>
-          |</ul>
-        """.stripMargin
-      ),
+      description = Some(htmlDescription),
       metadata = Some(ThriftMetaData(
         youtube = Some(ThriftYoutubeData(title = "a title", description = Some("a custom description for youtube")))
       ))

--- a/common/src/test/scala/com/gu/media/youtube/YoutubeDescriptionTest.scala
+++ b/common/src/test/scala/com/gu/media/youtube/YoutubeDescriptionTest.scala
@@ -1,0 +1,35 @@
+package com.gu.media.youtube
+
+import org.scalatest.{FunSuite, MustMatchers}
+
+class YoutubeDescriptionTest extends FunSuite with MustMatchers {
+  test("cleaning nothing") {
+    YoutubeDescription.clean(None) must be(None)
+  }
+
+  test("cleaning a plain string") {
+    val testString = Some("hello there, how are you?")
+    YoutubeDescription.clean(testString) must be(testString)
+  }
+
+  test("cleaning a blob of html") {
+    val testHtml = Some(
+      """
+        |<p>
+        |  The three-year construction of Tottenham Hotspur's new stadium is revealed in a time-lapse video released by the club.
+        |  The £1bn stadium will be officially unveiled on Sunday, before Spurs play their first match at their new home on 3 April against Crystal Palace.
+        |</p>
+        |<ul>
+        |  <li>
+        |    <a href="https://www.theguardian.com/football/2019/mar/08/tottenham-new-stadium-first-match-brighton-crystal-palace-champions-league">
+        |      Tottenham announce first match for new 62,000 capacity stadium
+        |    </a>
+        |  </li>
+        |</ul>
+      """.stripMargin
+    )
+    val expected = Some("The three-year construction of Tottenham Hotspur's new stadium is revealed in a time-lapse video released by the club. The £1bn stadium will be officially unveiled on Sunday, before Spurs play their first match at their new home on 3 April against Crystal Palace. \n Tottenham announce first match for new 62,000 capacity stadium")
+
+    YoutubeDescription.clean(testHtml) must be(expected)
+  }
+}


### PR DESCRIPTION
On creation, we set the YouTube description using the standfirst. The standfirst can be HTML, however the YouTube description cannot be and so we need to clean it first.

Extract out the HTML cleaning so it can be used at create and update time and also include more tests.