### PR TITLE
Remove embargo dates

### DIFF
--- a/public/video-ui/src/components/ScheduledLaunch/ScheduledLaunch.js
+++ b/public/video-ui/src/components/ScheduledLaunch/ScheduledLaunch.js
@@ -148,6 +148,7 @@ export default class ScheduledLaunch extends React.Component {
 
   renderScheduleOptions = (video, videoEditOpen, scheduledLaunch, embargo) => {
     const hasPreventedPublication = embargo && embargo >= impossiblyDistantDate;
+    // We don't currently allow setting of embargo dates
     return (
       <ul className="scheduleOptions">
         {!hasPreventedPublication && (
@@ -161,14 +162,14 @@ export default class ScheduledLaunch extends React.Component {
             </button>
           </li>
         )}
-        {!hasPreventedPublication && (
+        {!hasPreventedPublication && embargo && (
           <li>
             <button
               className="btn btn--list-item"
               onClick={() => this.onSelectOption(datesProperties.selectedEmbargoDate)}
               disabled={!video || videoEditOpen}
             >
-              {embargo ? 'Edit embargo' : 'Embargo until...'}
+              Edit embargo
             </button>
           </li>
         )}


### PR DESCRIPTION
Because the scheduled lambda doesn't remove embargo dates once they've expired, we've decided to temporarily remove the embargo dates from the ui. That means users will only be able to prevent publication indefinitely.