### PR TITLE
Send CAPI notifications as well as updates

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -29,7 +29,6 @@ class Api(
   capi: Capi,
   thumbnailGenerator: ThumbnailGenerator)
   extends MediaAtomImplicits
-    with AtomAPIActions
     with AtomController
     with JsonRequestParsing
     with Logging {

--- a/app/model/commands/DeleteCommand.scala
+++ b/app/model/commands/DeleteCommand.scala
@@ -13,7 +13,7 @@ import model.YouTubeMessage
 import util.YouTube
 
 case class DeleteCommand(id: String, override val stores: DataStores, youTube: YouTube)
-  extends Command with AtomAPIActions with Logging {
+  extends Command with Logging {
 
   type T = Unit
 

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -30,7 +30,7 @@ case class PublishAtomCommand(
   permissions: MediaAtomMakerPermissionsProvider,
   awsConfig: AWSConfig,
   thumbnailGenerator: ThumbnailGenerator)
-  extends Command with AtomAPIActions with Logging {
+  extends Command with Logging {
 
   type T = Future[MediaAtom]
 

--- a/app/util/AWS.scala
+++ b/app/util/AWS.scala
@@ -21,6 +21,7 @@ class AWSConfig(override val config: Config, override val credentials: AwsCreden
     with ElasticTranscodeAccess
     with KinesisLogging
     with SQSAccess
+    with SNSAccess
     with SESSettings {
 
   lazy val ec2Client = AmazonEC2ClientBuilder

--- a/app/util/NotifyingAtomPublisher.scala
+++ b/app/util/NotifyingAtomPublisher.scala
@@ -1,0 +1,48 @@
+package util
+
+import com.amazonaws.services.sns.AmazonSNS
+import com.amazonaws.services.sns.model.PublishRequest
+import com.gu.atom.publish.AtomPublisher
+import com.gu.contentatom.thrift.{ContentAtomEvent, EventType}
+import org.joda.time.{DateTime, DateTimeZone}
+import play.api.libs.json.{Json, Writes}
+
+import scala.util.Try
+
+class NotifyingAtomPublisher(isLive: Boolean, topicArn: String, underlying: AtomPublisher, sns: AmazonSNS) extends AtomPublisher {
+  override def publishAtomEvent(event: ContentAtomEvent): Try[Unit] = {
+    underlying.publishAtomEvent(event).map { _ =>
+      val notification = SimpleContentUpdate.fromEvent(event, isLive)
+      val json = Json.stringify(Json.toJson(notification))
+
+      // TODO MRB: should we have a new message-type called atom update?
+      val request = new PublishRequest(topicArn, json, "composer-update")
+      Try(sns.publish(request))
+    }
+  }
+}
+
+case class SimpleContentUpdate( composerId: String,
+                                whatChanged: String,
+                                eventTime: DateTime,
+                                revision: Option[Long],
+                                isLive: Boolean,
+                                isMigration: Boolean = false,
+                                isProdmon: Boolean,
+                                isExpired: Boolean
+                              )
+
+object SimpleContentUpdate {
+  implicit val writes: Writes[SimpleContentUpdate] = Json.writes[SimpleContentUpdate]
+
+  def fromEvent(event: ContentAtomEvent, isLive: Boolean): SimpleContentUpdate = SimpleContentUpdate(
+    composerId = s"${event.atom.atomType.toString}-${event.atom.id}",
+    whatChanged = if(event.eventType == EventType.Takedown) { "takeDown" } else { "update" },
+    eventTime = new DateTime(event.eventCreationTime, DateTimeZone.UTC),
+    revision = Some(event.atom.contentChangeDetails.revision),
+    isLive,
+    isMigration = false,
+    isProdmon = false,
+    isExpired = false
+  )
+}

--- a/app/util/NotifyingAtomPublisher.scala
+++ b/app/util/NotifyingAtomPublisher.scala
@@ -21,7 +21,7 @@ class NotifyingAtomPublisher(isLive: Boolean, topicArn: String, underlying: Atom
   }
 }
 
-case class SimpleContentUpdate( composerId: String,
+case class SimpleContentUpdate( id: String,
                                 whatChanged: String,
                                 eventTime: DateTime,
                                 revision: Option[Long],
@@ -35,7 +35,7 @@ object SimpleContentUpdate {
   implicit val writes: Writes[SimpleContentUpdate] = Json.writes[SimpleContentUpdate]
 
   def fromEvent(event: ContentAtomEvent, isLive: Boolean): SimpleContentUpdate = SimpleContentUpdate(
-    composerId = s"${event.atom.atomType.toString}/${event.atom.id}",
+    id = s"${event.atom.atomType.toString}/${event.atom.id}",
     whatChanged = if(event.eventType == EventType.Takedown) { "takeDown" } else { "update" },
     eventTime = new DateTime(event.eventCreationTime, DateTimeZone.UTC),
     revision = Some(event.atom.contentChangeDetails.revision),

--- a/common/src/main/scala/com/gu/media/aws/SNSAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/SNSAccess.scala
@@ -1,0 +1,16 @@
+package com.gu.media.aws
+
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.sns.AmazonSNSClientBuilder
+import com.gu.media.Settings
+
+trait SNSAccess { this: Settings with AwsAccess =>
+
+  lazy val capiContentEventsTopicName = getMandatoryString("aws.sns.content.capi.topicname")
+
+  lazy val snsClient =
+    AmazonSNSClientBuilder.standard()
+      .withRegion(Regions.fromName(region.getName))
+      .withCredentials(credentials.instance)
+      .build()
+}


### PR DESCRIPTION
This will allow us to run pubflow against video atoms (https://github.com/guardian/pubflow/pull/193)