### PR TITLE
Remove searchFields filter

### DIFF
--- a/app/data/AtomListStore.scala
+++ b/app/data/AtomListStore.scala
@@ -26,8 +26,7 @@ class CapiBackedAtomListStore(capi: CapiAccess) extends AtomListStore {
 
     val baseWithSearch = search match {
       case Some(q) => base ++ Map(
-        "q" -> q,
-        "searchFields" -> "data.title"
+        "q" -> q
       )
       case None => base
     }


### PR DESCRIPTION
Currently CAPI does not seem to be returning results any more for our filter. We still get results if we simply use normal `q` search.