### PR TITLE
Remove `data.` prefix from CAPI search

### DIFF
--- a/app/data/AtomListStore.scala
+++ b/app/data/AtomListStore.scala
@@ -27,7 +27,7 @@ class CapiBackedAtomListStore(capi: CapiAccess) extends AtomListStore {
     val baseWithSearch = search match {
       case Some(q) => base ++ Map(
         "q" -> q,
-        "searchFields" -> "data.title"
+        "searchFields" -> "title"
       )
       case None => base
     }


### PR DESCRIPTION
The prefix is not working. The issue has been raised with the CAPI team but I thought it worth raising the mitigation in the meantime