### PR TITLE
Make CAPI events optional in config

### DIFF
--- a/common/src/main/scala/com/gu/media/aws/SNSAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/SNSAccess.scala
@@ -6,7 +6,7 @@ import com.gu.media.Settings
 
 trait SNSAccess { this: Settings with AwsAccess =>
 
-  lazy val capiContentEventsTopicName = getMandatoryString("aws.sns.content.capi.topicname")
+  lazy val capiContentEventsTopicName = getString("aws.sns.content.capi.topicname")
 
   lazy val snsClient =
     AmazonSNSClientBuilder.standard()


### PR DESCRIPTION
Without this we were unable to run in DEV without configuring the notifications stream.