### PR TITLE
Use internalName as the display name for tags

### DIFF
--- a/public/video-ui/src/components/Tags/TagFieldValue.js
+++ b/public/video-ui/src/components/Tags/TagFieldValue.js
@@ -3,10 +3,10 @@ import React from 'react';
 export default class TagFieldValue extends React.Component {
 
   renderFieldValue(value, index) {
-    if (value.webTitle) {
+    if (value.detailedTitle) {
       return (
         <span key={`${value.id}-${index}`}>
-          <span className="form__field__tag__display">{value.webTitle}</span>
+          <span className="form__field__tag__display">{value.detailedTitle}</span>
           {' '}
         </span>
       );

--- a/public/video-ui/src/util/getTagDisplayNames.js
+++ b/public/video-ui/src/util/getTagDisplayNames.js
@@ -1,32 +1,38 @@
 import TagTypes from '../constants/TagTypes';
 
+// Logic from before CAPI returned internal names for tags
+function getLegacyDetailedTitle(tag) {
+  const tagType = tag.type;
+
+  if (tagType === TagTypes.keyword) {
+    //Some webtitles on keyword tags are too unspecific and we need to add
+    //the section name to them to know what tags they are referring to
+    return tag.webTitle !== tag.sectionName
+      ? `${tag.webTitle} (${tag.sectionName})`
+      : tag.webTitle;
+  } else {
+    const appendTagTypes = [
+      TagTypes.series,
+      TagTypes.tone,
+      TagTypes.commercial
+    ];
+
+    return appendTagTypes.includes(tagType)
+      ? `${tag.webTitle} (${tagType})`
+      : tag.webTitle;
+  }
+}
+
 export default function getTagDisplayNames(tags) {
   return tags.map(tag => {
     if (typeof tag === 'string') {
       return tag;
     }
 
-    const tagType = tag.type;
-    const tagForDisplay = { id: tag.id, webTitle: tag.webTitle };
-
-    if (tagType === TagTypes.keyword) {
-      //Some webtitles on keyword tags are too unspecific and we need to add
-      //the section name to them to know what tags they are referring to
-      tagForDisplay.detailedTitle = tag.webTitle !== tag.sectionName
-        ? `${tag.webTitle} (${tag.sectionName})`
-        : tag.webTitle;
-    } else {
-      const appendTagTypes = [
-        TagTypes.series,
-        TagTypes.tone,
-        TagTypes.commercial
-      ];
-
-      tagForDisplay.detailedTitle = appendTagTypes.includes(tagType)
-        ? `${tag.webTitle} (${tagType})`
-        : tag.webTitle;
-    }
-
-    return tagForDisplay;
+    return {
+      id: tag.id,
+      webTitle: tag.webTitle,
+      detailedTitle: tag.internalName ? tag.internalName : getLegacyDetailedTitle(tag)
+    };
   });
 }

--- a/public/video-ui/src/util/tagParsers.js
+++ b/public/video-ui/src/util/tagParsers.js
@@ -12,15 +12,8 @@ export function tagsFromStringList(savedTags, tagType) {
         (tagType !== TagTypes.contributor && tagType !== TagTypes.youtube) ||
         element.match('^profile/')
       ) {
-        return ContentApi.getLivePage(element).then(capiResponse => {
-          const tag = capiResponse.response.tag;
-          return {
-            id: tag.id,
-            webTitle: tag.webTitle,
-            type: tag.type,
-            sectionName: tag.sectionName
-          };
-        });
+        return ContentApi.getLivePage(element)
+          .then(({ response }) => response.tag);
       }
 
       if (tagType === TagTypes.youtube) {


### PR DESCRIPTION
As requested by every video producer ever :) This means that the tag names that appear in the results are the same as those in Composer which makes it much easier to avoid picking the wrong one. This is possible due to the `internalName` now being available in CAPI (https://github.com/guardian/content-api/pull/2262)

![04ff963c94fd12b110b673d2e144f9af](https://user-images.githubusercontent.com/395805/58716072-2806bb00-83c0-11e9-8dab-eb6a26cff9c2.gif)

The original logic did some appending of the tag type but from having a look at the tags in PROD, I think it was just trying to emulate the internal name as best as possible so I've bypassed it entirely. @akash1810 @Reettaphant is that a reasonable assumption.

That said, I've retained it in the event `internalName` is not present so we are not tightly coupled to CAPI retaining the field. I can't imagine it's going to disappear but this at least means we don't break if it does.