### PR TITLE
correct rules for ad eligibility

### DIFF
--- a/public/video-ui/src/util/video.js
+++ b/public/video-ui/src/util/video.js
@@ -87,7 +87,7 @@ export default class VideoUtils {
     }
 
     const minDurationForAds = getStore().getState().config.minDurationForAds;
-    return atom.duration > 0 && atom.duration > minDurationForAds;
+    return atom.duration > 0 && atom.duration >= minDurationForAds;
   }
 
   static isRecentlyModified({ contentChangeDetails }) {


### PR DESCRIPTION
We should automatically block ads (and disable editing) when the video is GLabs content or the video is less than 30 seconds (`minDurationForAds`).

Correct the condition, videos greater than or equal to `minDurationForAds` are ok. (Previously only greater than).

![img](https://media.giphy.com/media/m7sn0naRjpfkA/giphy.gif)