### PR TITLE
Rewrite Youtube embed URLs to use the cookie-less domain

### DIFF
--- a/common/src/main/scala/com/gu/media/util/MediaAtomImplicits.scala
+++ b/common/src/main/scala/com/gu/media/util/MediaAtomImplicits.scala
@@ -28,7 +28,7 @@ trait MediaAtomImplicits extends AtomImplicits[MediaAtom] {
         s"""<img src="$poster"/>"""
       }
       case (Some(YouTubeAsset(id)), _) => {
-        s"""<iframe frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/$id?showinfo=0&rel=0"></iframe>"""
+        s"""<iframe frameborder="0" allowfullscreen="true" src="https://www.youtube-nocookie.com/embed/$id?showinfo=0&rel=0"></iframe>"""
       }
       case (Some(SelfHostedAsset(sources)), poster) => {
         s"""

--- a/common/src/main/scala/com/gu/media/youtube/YoutubeUrl.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YoutubeUrl.scala
@@ -1,7 +1,7 @@
 package com.gu.media.youtube
 
 object YoutubeUrl {
-  private val re = "^https://(?:www.youtube(?:\\-nocookie).com/(?:watch\\?v=|embed/)|youtu.be/)([a-zA-Z0-9_-]{11}).*$".r
+  private val re = "^https://(?:www.youtube(?:\\-nocookie)?.com/(?:watch\\?v=|embed/)|youtu.be/)([a-zA-Z0-9_-]{11}).*$".r
 
   def unapply(url: String): Option[String] = parse(url)
 

--- a/common/src/main/scala/com/gu/media/youtube/YoutubeUrl.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YoutubeUrl.scala
@@ -1,7 +1,7 @@
 package com.gu.media.youtube
 
 object YoutubeUrl {
-  private val re = "^https://(?:www.youtube.com/(?:watch\\?v=|embed/)|youtu.be/)([a-zA-Z0-9_-]{11}).*$".r
+  private val re = "^https://(?:www.youtube(?:\\-nocookie).com/(?:watch\\?v=|embed/)|youtu.be/)([a-zA-Z0-9_-]{11}).*$".r
 
   def unapply(url: String): Option[String] = parse(url)
 

--- a/test/ThriftUtilSpec.scala
+++ b/test/ThriftUtilSpec.scala
@@ -20,7 +20,7 @@ class ThriftUtilSpec extends FunSpec
       params.map { case (k, v) => (k, List(v)) }.toMap
 
     val youtubeId  =  "7H9Z4sn8csA"
-    val youtubeUrl = s"https://www.youtube.com/watch?v=${youtubeId}"
+    val youtubeUrl = s"https://www.youtube-nocookie.com/watch?v=${youtubeId}"
 
     it("should result in error if uri param is invalid") {
       assert(parseRequest(makeParams("uri" -> "gobbldeygook")).isLeft)
@@ -61,7 +61,7 @@ class ThriftUtilSpec extends FunSpec
               }
 
               val iframe = Jsoup.parse(defaultHtml).getElementsByTag("iframe")
-              iframe.attr("src") should be(s"https://www.youtube.com/embed/$youtubeId?showinfo=0&rel=0")
+              iframe.attr("src") should be(s"https://www.youtube-nocookie.com/embed/$youtubeId?showinfo=0&rel=0")
           }
       }
     }


### PR DESCRIPTION
This is going to supersede [this PR](https://github.com/guardian/content-api/pull/2285) in CAPI as MAM is the source of truth.