### PR TITLE
FIX: make prodoffice field editable in Workflow form 

### DIFF
--- a/public/video-ui/src/actions/WorkflowActions/trackInWorkflow.js
+++ b/public/video-ui/src/actions/WorkflowActions/trackInWorkflow.js
@@ -24,10 +24,10 @@ function errorTrackInWorkflow(error) {
   };
 }
 
-export function trackInWorkflow({ video, status, section, note }) {
+export function trackInWorkflow({ video, status, section, note, prodOffice }) {
   return dispatch => {
     dispatch(requestTrackInWorkflow());
-    return WorkflowApi.trackInWorkflow({ video, status, section, note })
+    return WorkflowApi.trackInWorkflow({ video, status, section, note, prodOffice })
       .then(response => dispatch(receiveTrackInWorkflow(response)))
       .catch(err => dispatch(errorTrackInWorkflow(err)));
   };

--- a/public/video-ui/src/actions/WorkflowActions/updateWorkflowData.js
+++ b/public/video-ui/src/actions/WorkflowActions/updateWorkflowData.js
@@ -30,7 +30,8 @@ export function updateWorkflowData({ workflowItem }) {
     return Promise.all([
       WorkflowApi.updateStatus(workflowItem),
       WorkflowApi.updateNote(workflowItem),
-      WorkflowApi.updatePriority(workflowItem)
+      WorkflowApi.updatePriority(workflowItem),
+      WorkflowApi.updateProdOffice(workflowItem)
     ])
       .then(response => dispatch(receiveDataUpdate(response)))
       .catch(err => dispatch(errorUpdatingData(err)));

--- a/public/video-ui/src/components/FormFields/SelectBox.js
+++ b/public/video-ui/src/components/FormFields/SelectBox.js
@@ -10,11 +10,19 @@ export default class SelectBox extends React.Component {
 
   renderDefaultOption = () => {
     if (this.props.displayDefault || !this.props.fieldValue) {
-      return (
-        <option value={null}>
-          {this.props.defaultOption || 'Please select...'}
-        </option>
-      );
+      if (this.props.defaultOption) {
+        return (
+          <option value={this.props.defaultOption.id || null}>
+            {this.props.defaultOption.title || 'Please select...'}
+          </option>
+        );
+      } else {
+        return (
+          <option value={null}>
+            {'Please select...'}
+          </option>
+        );
+      }
     }
   };
 
@@ -58,7 +66,7 @@ export default class SelectBox extends React.Component {
           {...this.props.input}
           className={
             'form__field form__field--select ' +
-              (hasError ? 'form__field--error' : '')
+            (hasError ? 'form__field--error' : '')
           }
           value={this.props.fieldValue}
           onChange={e => {
@@ -67,7 +75,7 @@ export default class SelectBox extends React.Component {
         >
 
           {this.renderDefaultOption()}
-          {this.props.selectValues.map(function(value) {
+          {this.props.selectValues.map(function (value) {
             return (
               <option value={value.id} key={value.id}>{value.title}</option>
             );
@@ -75,8 +83,8 @@ export default class SelectBox extends React.Component {
         </select>
         {hasError
           ? <p className="form__message form__message--error">
-              {this.props.notification.message}
-            </p>
+            {this.props.notification.message}
+          </p>
           : ''}
       </div>
     );

--- a/public/video-ui/src/components/Workflow/Workflow.js
+++ b/public/video-ui/src/components/Workflow/Workflow.js
@@ -48,6 +48,11 @@ class Workflow extends React.Component {
         workflowStatuses={this.props.workflow.statuses || []}
         workflowPriorities={this.props.workflow.priorities}
         workflowStatus={this.props.workflow.status}
+        workflowProductionOffices={[
+          { id: 'UK', title: 'UK' },
+          { id: 'US', title: 'US' },
+          { id: 'AU', title: 'AU' }
+        ]}
         updateData={this.updateLocalData}
       />
     );

--- a/public/video-ui/src/components/Workflow/WorkflowForm.js
+++ b/public/video-ui/src/components/Workflow/WorkflowForm.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ManagedForm, ManagedField } from '../ManagedForm';
 import SelectBox from '../FormFields/SelectBox';
-import TextInput from '../FormFields/TextInput';
 import TextAreaInput from '../FormFields/TextAreaInput';
 
 export default class WorkflowForm extends React.Component {
@@ -13,6 +12,7 @@ export default class WorkflowForm extends React.Component {
     workflowStatuses: PropTypes.array.isRequired,
     workflowPriorities: PropTypes.array.isRequired,
     workflowStatus: PropTypes.object.isRequired,
+    workflowProductionOffices: PropTypes.array.isRequired,
     updateData: PropTypes.func.isRequired
   };
 
@@ -27,9 +27,9 @@ export default class WorkflowForm extends React.Component {
         <ManagedField
           fieldLocation="prodOffice"
           name="Production Office"
-          disabled={true}
+          disabled={!this.props.editable}
         >
-          <TextInput />
+          <SelectBox selectValues={this.props.workflowProductionOffices} />
         </ManagedField>
         <ManagedField
           fieldLocation="section"

--- a/public/video-ui/src/components/Workflow/WorkflowForm.js
+++ b/public/video-ui/src/components/Workflow/WorkflowForm.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { ManagedForm, ManagedField } from '../ManagedForm';
 import SelectBox from '../FormFields/SelectBox';
 import TextAreaInput from '../FormFields/TextAreaInput';
+import getProductionOffice from '../../util/getProductionOffice';
 
 export default class WorkflowForm extends React.Component {
   static propTypes = {
@@ -17,6 +18,9 @@ export default class WorkflowForm extends React.Component {
   };
 
   render() {
+    const assumedProdOffice = getProductionOffice(); // guess default by user's timezone
+    const defaultProdOffice = { title: assumedProdOffice, id: assumedProdOffice };
+    const otherProdOffices = this.props.workflowProductionOffices.filter(office => office.id !== defaultProdOffice.id);
     return (
       <ManagedForm
         data={this.props.workflowStatus}
@@ -29,7 +33,11 @@ export default class WorkflowForm extends React.Component {
           name="Production Office"
           disabled={!this.props.editable}
         >
-          <SelectBox selectValues={this.props.workflowProductionOffices} />
+          <SelectBox
+            defaultOption={defaultProdOffice}
+            selectValues={otherProdOffices}
+            displayDefault={true}
+          />
         </ManagedField>
         <ManagedField
           fieldLocation="section"

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -293,7 +293,7 @@ class VideoDisplay extends React.Component {
             this.updateEditingState({ key: 'editingWorkflow', editing: false });
             this.saveInWorkflow();
           }}
-          canSave={() => workflow.status.section && workflow.status.status && workflow.status.prodOffice}
+          canSave={() => workflow.status.section && workflow.status.status}
           video={video}
           isTrackedInWorkflow={workflow.status.isTrackedInWorkflow || false}
         />

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -149,7 +149,7 @@ class VideoDisplay extends React.Component {
 
     const {
       sections,
-      status: { status, section, note, isTrackedInWorkflow }
+      status: { status, section, note, isTrackedInWorkflow, prodOffice }
     } = this.props.workflow;
 
     const {
@@ -163,7 +163,8 @@ class VideoDisplay extends React.Component {
         video: video,
         section: sections.find(_ => _.id === section),
         status: status,
-        note: note
+        note: note,
+        prodOffice: prodOffice
       });
 
     const updateWorkflowItem = () =>
@@ -292,7 +293,7 @@ class VideoDisplay extends React.Component {
             this.updateEditingState({ key: 'editingWorkflow', editing: false });
             this.saveInWorkflow();
           }}
-          canSave={() => workflow.status.section && workflow.status.status}
+          canSave={() => workflow.status.section && workflow.status.status && workflow.status.prodOffice}
           video={video}
           isTrackedInWorkflow={workflow.status.isTrackedInWorkflow || false}
         />

--- a/public/video-ui/src/services/WorkflowApi.js
+++ b/public/video-ui/src/services/WorkflowApi.js
@@ -1,9 +1,8 @@
 import { pandaReqwest } from './pandaReqwest';
 import { getStore } from '../util/storeAccessor';
-import getProductionOffice from '../util/getProductionOffice';
 import VideoUtils from '../util/video';
 import moment from 'moment';
-import { impossiblyDistantDate }  from '../constants/dates';
+import { impossiblyDistantDate } from '../constants/dates';
 
 export default class WorkflowApi {
   static get workflowUrl() {
@@ -57,7 +56,7 @@ export default class WorkflowApi {
       return WorkflowApi._getResponseAsJson(response).data
         .filter(status => status.toLowerCase() !== 'stub')
         .map(status =>
-          Object.assign({}, {id: status, title: status})
+          Object.assign({}, { id: status, title: status })
         );
     });
   }
@@ -86,9 +85,9 @@ export default class WorkflowApi {
     video,
     status,
     section,
-    note
+    note,
+    prodOffice
   }) {
-    const prodOffice = getProductionOffice();
 
     const { contentChangeDetails } = video;
 
@@ -132,12 +131,13 @@ export default class WorkflowApi {
     };
   }
 
-  static trackInWorkflow({ video, status, section, note }) {
+  static trackInWorkflow({ video, status, section, note, prodOffice }) {
     const payload = WorkflowApi._getTrackInWorkflowPayload({
       video,
       status,
       section,
-      note
+      note,
+      prodOffice
     });
 
     return pandaReqwest({
@@ -149,7 +149,21 @@ export default class WorkflowApi {
     });
   }
 
-  static updateStatus({id, status}) {
+  static updateProdOffice({ id, prodOffice }) {
+    const payload = {
+      data: prodOffice
+    };
+
+    return pandaReqwest({
+      method: 'PUT',
+      url: `${WorkflowApi.workflowUrl}/api/stubs/${id}/prodOffice`,
+      data: payload,
+      crossOrigin: true,
+      withCredentials: true
+    });
+  }
+
+  static updateStatus({ id, status }) {
     const payload = {
       data: status
     };


### PR DESCRIPTION
The field `Production Office` should be editable in Media Atom Maker, just like it is in Composer. This  adds a select form with 3 hardcoded values - US, UK, AU.

These values are hardcoded - like they are in Composer - because it is unlikely a new production office will be setup. 

1) The first part of this code hardcodes the above values and passes them down to `WorkflowForm` to be displayed on a select menu. The select menu uses the existing function called `getProductionOffice to guess the user's production office from their timezone and set it as the default in the select menu. 
It is  required to  add: 'productionOffice' before you can save the workflow form.  

2) The second part makes sure that the POST request sent when a workflow form is saved (for the first time) includes the prodOffice property taken from the form.

3) Thirdly, adds a PUT request that just updates the ProdOffice property on the Workflowform, if that's the only bit that's been updated. 


Deployed on CODE here: https://video.code.dev-gutools.co.uk 

