### PR TITLE
Workflow update requests: check data is not null before PUT request

### DIFF
--- a/public/video-ui/src/services/WorkflowApi.js
+++ b/public/video-ui/src/services/WorkflowApi.js
@@ -178,6 +178,8 @@ export default class WorkflowApi {
   }
 
   static updateNote({ id, note }) {
+    if (!note) return; //property is optional so may be null
+
     const payload = {
       data: note
     };
@@ -192,6 +194,8 @@ export default class WorkflowApi {
   }
 
   static updatePriority({ id, priority }) {
+    if (!priority) return; //property is optional so may be null
+
     const payload = {
       data: priority
     };


### PR DESCRIPTION
Previously an update request tried to update all properties even if they were null. This resulted in failed requests which shows users an error. 

This checks for null on the two optional properties so should prevent the requests if there is no data to send