### PR TITLE
BUG: Workflow form does not correctly set default 

### DIFF
--- a/public/video-ui/src/actions/WorkflowActions/getStatus.js
+++ b/public/video-ui/src/actions/WorkflowActions/getStatus.js
@@ -1,5 +1,5 @@
 import WorkflowApi from '../../services/WorkflowApi';
-import { blankWorkflowStatusData } from '../../constants/blankWorkflowStatusData';
+import { defaultWorkflowStatusData } from '../../constants/defaultWorkflowStatusData';
 
 function requestStatus() {
   return {
@@ -20,7 +20,7 @@ function receiveStatus404() {
   return {
     type: 'WORKFLOW_STATUS_NOT_FOUND',
     receivedAt: Date.now(),
-    status: blankWorkflowStatusData
+    status: defaultWorkflowStatusData()
   };
 }
 

--- a/public/video-ui/src/components/FormFields/SelectBox.js
+++ b/public/video-ui/src/components/FormFields/SelectBox.js
@@ -10,19 +10,11 @@ export default class SelectBox extends React.Component {
 
   renderDefaultOption = () => {
     if (this.props.displayDefault || !this.props.fieldValue) {
-      if (this.props.defaultOption) {
-        return (
-          <option value={this.props.defaultOption.id || null}>
-            {this.props.defaultOption.title || 'Please select...'}
-          </option>
-        );
-      } else {
-        return (
-          <option value={null}>
-            {'Please select...'}
-          </option>
-        );
-      }
+      return (
+        <option value={null}>
+          {this.props.defaultOption || 'Please select...'}
+        </option>
+      );
     }
   };
 

--- a/public/video-ui/src/components/Workflow/WorkflowForm.js
+++ b/public/video-ui/src/components/Workflow/WorkflowForm.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { ManagedForm, ManagedField } from '../ManagedForm';
 import SelectBox from '../FormFields/SelectBox';
 import TextAreaInput from '../FormFields/TextAreaInput';
-import getProductionOffice from '../../util/getProductionOffice';
 
 export default class WorkflowForm extends React.Component {
   static propTypes = {
@@ -18,9 +17,6 @@ export default class WorkflowForm extends React.Component {
   };
 
   render() {
-    const assumedProdOffice = getProductionOffice(); // guess default by user's timezone
-    const defaultProdOffice = { title: assumedProdOffice, id: assumedProdOffice };
-    const otherProdOffices = this.props.workflowProductionOffices.filter(office => office.id !== defaultProdOffice.id);
     return (
       <ManagedForm
         data={this.props.workflowStatus}
@@ -33,11 +29,7 @@ export default class WorkflowForm extends React.Component {
           name="Production Office"
           disabled={!this.props.editable}
         >
-          <SelectBox
-            defaultOption={defaultProdOffice}
-            selectValues={otherProdOffices}
-            displayDefault={true}
-          />
+          <SelectBox selectValues={this.props.workflowProductionOffices} />
         </ManagedField>
         <ManagedField
           fieldLocation="section"

--- a/public/video-ui/src/constants/blankWorkflowStatusData.js
+++ b/public/video-ui/src/constants/blankWorkflowStatusData.js
@@ -1,1 +1,0 @@
-export const blankWorkflowStatusData = { };

--- a/public/video-ui/src/constants/defaultWorkflowStatusData.js
+++ b/public/video-ui/src/constants/defaultWorkflowStatusData.js
@@ -1,0 +1,7 @@
+import getProductionOffice from '../util/getProductionOffice';
+
+const assumedProdOffice = getProductionOffice(); // guess default by user's timezone
+
+export const defaultWorkflowStatusData = () => {
+  return { prodOffice: assumedProdOffice };
+};


### PR DESCRIPTION
The default on the form for the `Production Office` field was not being saved to the state, unless the user specifically interacted with it. 

This caused a lot of form saves to fail as the prodOffice value was not present

1. I have moved the default prodOffice value from where the form fields get created to a defaultState object
