### PR TITLE
Workflow Form Improvement: Save priority first time

### DIFF
--- a/public/video-ui/src/actions/WorkflowActions/trackInWorkflow.js
+++ b/public/video-ui/src/actions/WorkflowActions/trackInWorkflow.js
@@ -24,10 +24,10 @@ function errorTrackInWorkflow(error) {
   };
 }
 
-export function trackInWorkflow({ video, status, section, note, prodOffice }) {
+export function trackInWorkflow({ video, status, section, note, prodOffice, priority }) {
   return dispatch => {
     dispatch(requestTrackInWorkflow());
-    return WorkflowApi.trackInWorkflow({ video, status, section, note, prodOffice })
+    return WorkflowApi.trackInWorkflow({ video, status, section, note, prodOffice, priority })
       .then(response => dispatch(receiveTrackInWorkflow(response)))
       .catch(err => dispatch(errorTrackInWorkflow(err)));
   };

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -149,7 +149,7 @@ class VideoDisplay extends React.Component {
 
     const {
       sections,
-      status: { status, section, note, isTrackedInWorkflow, prodOffice }
+      status: { status, section, note, isTrackedInWorkflow, prodOffice, priority }
     } = this.props.workflow;
 
     const {
@@ -164,7 +164,8 @@ class VideoDisplay extends React.Component {
         section: sections.find(_ => _.id === section),
         status: status,
         note: note,
-        prodOffice: prodOffice
+        prodOffice: prodOffice,
+        priority: priority
       });
 
     const updateWorkflowItem = () =>

--- a/public/video-ui/src/services/WorkflowApi.js
+++ b/public/video-ui/src/services/WorkflowApi.js
@@ -86,7 +86,8 @@ export default class WorkflowApi {
     status,
     section,
     note,
-    prodOffice
+    prodOffice,
+    priority
   }) {
 
     const { contentChangeDetails } = video;
@@ -105,11 +106,12 @@ export default class WorkflowApi {
     const [embargo, indefiniteEmbargo] =
       (embargoDate && embargoDate >= impossiblyDistantDate) ? [null, true] : [embargoDate, false];
 
+
     return {
       contentType: 'media',
       editorId: video.id,
       title: video.title,
-      priority: 0,
+      priority: priority,
       needsLegal: 'NA',
       section,
       status,
@@ -131,13 +133,14 @@ export default class WorkflowApi {
     };
   }
 
-  static trackInWorkflow({ video, status, section, note, prodOffice }) {
+  static trackInWorkflow({ video, status, section, note, prodOffice, priority }) {
     const payload = WorkflowApi._getTrackInWorkflowPayload({
       video,
       status,
       section,
       note,
-      prodOffice
+      prodOffice,
+      priority
     });
 
     return pandaReqwest({
@@ -194,7 +197,7 @@ export default class WorkflowApi {
   }
 
   static updatePriority({ id, priority }) {
-    if (!priority) return; //property is optional so may be null
+    if (priority === null) return; //property is optional so may be null, but 0 is a valid value
 
     const payload = {
       data: priority


### PR DESCRIPTION
When users save a form for the first time, the PRIORITY is not set. ie the POST request doesn't add it.

It wasn't added as a property to the functions making the create request. 

The update PUT request does work. 