### PR TITLE
WORKFLOW FORM: Fix 0 == false error on saving 'Normal Priority'

### DIFF
--- a/public/video-ui/src/components/Workflow/Workflow.js
+++ b/public/video-ui/src/components/Workflow/Workflow.js
@@ -46,7 +46,9 @@ class Workflow extends React.Component {
         video={video}
         workflowSections={this.props.workflow.sections || []}
         workflowStatuses={this.props.workflow.statuses || []}
-        workflowPriorities={this.props.workflow.priorities}
+        workflowPriorities={
+          this.props.workflow.priorities.map(({ name, value }) => ({ id: value, title: name })) || []
+        }
         workflowStatus={this.props.workflow.status}
         workflowProductionOffices={[
           { id: 'UK', title: 'UK' },

--- a/public/video-ui/src/components/Workflow/WorkflowForm.js
+++ b/public/video-ui/src/components/Workflow/WorkflowForm.js
@@ -60,3 +60,5 @@ export default class WorkflowForm extends React.Component {
     );
   }
 }
+
+

--- a/public/video-ui/src/components/Workflow/WorkflowForm.js
+++ b/public/video-ui/src/components/Workflow/WorkflowForm.js
@@ -53,10 +53,7 @@ export default class WorkflowForm extends React.Component {
           fieldLocation="priority"
           name="Priority"
           disabled={!this.props.editable}>
-          <SelectBox selectValues={
-            this.props.workflowPriorities.map(({ name, value }) => {
-              return { id: value, title: name };
-            })}
+          <SelectBox selectValues={this.props.workflowPriorities}
           />
         </ManagedField>
       </ManagedForm>

--- a/public/video-ui/src/services/WorkflowApi.js
+++ b/public/video-ui/src/services/WorkflowApi.js
@@ -73,12 +73,18 @@ export default class WorkflowApi {
     });
   }
 
+  //clean up the workflow data so that the priority field number, which can be 0, is converted to a string
+  static cleanUpWorkflowData(workflowData) {
+    return { ...workflowData, priority: workflowData.priority.toString() };
+  }
+
   static getAtomInWorkflow({ id }) {
     return pandaReqwest({
       url: `${WorkflowApi.workflowUrl}/api/atom/${id}`,
       crossOrigin: true,
       withCredentials: true
-    }).then(response => WorkflowApi._getResponseAsJson(response).data);
+    }).then(response => WorkflowApi._getResponseAsJson(response).data)
+      .then(jsonRes => this.cleanUpWorkflowData(jsonRes));
   }
 
   static _getTrackInWorkflowPayload({

--- a/public/video-ui/src/services/WorkflowApi.js
+++ b/public/video-ui/src/services/WorkflowApi.js
@@ -20,6 +20,11 @@ export default class WorkflowApi {
     return response;
   }
 
+  //clean up the workflow data so that the priority field number, which can be 0, is converted to a string
+  static _cleanUpWorkflowData(workflowData) {
+    return { ...workflowData, priority: workflowData.priority.toString() };
+  }
+
   static getSections() {
     // timeout in case the user is not logged into Workflow
     const params = {
@@ -73,18 +78,13 @@ export default class WorkflowApi {
     });
   }
 
-  //clean up the workflow data so that the priority field number, which can be 0, is converted to a string
-  static cleanUpWorkflowData(workflowData) {
-    return { ...workflowData, priority: workflowData.priority.toString() };
-  }
-
   static getAtomInWorkflow({ id }) {
     return pandaReqwest({
       url: `${WorkflowApi.workflowUrl}/api/atom/${id}`,
       crossOrigin: true,
       withCredentials: true
     }).then(response => WorkflowApi._getResponseAsJson(response).data)
-      .then(jsonRes => this.cleanUpWorkflowData(jsonRes));
+      .then(jsonRes => WorkflowApi._cleanUpWorkflowData(jsonRes));
   }
 
   static _getTrackInWorkflowPayload({


### PR DESCRIPTION
An annoying bug came up when saving the "Priority" section on the Workflow form. 

# User problem
From a user perspective, all priorities can be saved except for "Normal". See video below. 

![ezgif com-optimize](https://user-images.githubusercontent.com/10324129/64263715-06b9eb80-cf28-11e9-8e90-27b7c82ebfed.gif)

# The reason
The priorities come in from the Workflow API with a value property that gets read as a number. The problem is that if 'Normal' is selected, the value of the field is assigned `0`. Because `0` evaluates as false in js - this means it fails a bunch of checks throughout the code - along the lines of `fieldValue && xxxxx`. 

The priority object.
```
[
  { "name": "Very-Low", "value": -2 },
  { "name": "Low", "value": -1},
  { "name": "Normal", "value": 0},
  {"name": "Urgent","value": 1},
  {"name": "Very-Urgent","value": 2}
]
```

# Solution
I opted to run an extra cleaning step on atom data loaded in from workflow - this means that `priority: 0` gets converted to a string `priority: "0"` which means it doesn't evaluate to false.

