### PR TITLE
SNS: Encrypt sns topics 

### DIFF
--- a/cloudformation/media-atom-maker-dev.yml
+++ b/cloudformation/media-atom-maker-dev.yml
@@ -412,6 +412,7 @@ Resources:
     Type: "AWS::SNS::Topic"
     Properties:
       TopicName: !Sub "${PlutoTopicName}-${Stage}"
+      KmsMasterKeyId: 'alias/aws/sns'
       Subscription:
         - Endpoint: !GetAtt PlutoQueue.Arn
           Protocol: sqs

--- a/cloudformation/media-atom-maker-dev.yml
+++ b/cloudformation/media-atom-maker-dev.yml
@@ -1,5 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: "Media atom maker development"
+
 Parameters:
   Domain:
     Description: "The domain name where the app is running"
@@ -239,9 +240,13 @@ Resources:
       PolicyName: "LambdaCloudWatchLoggingPolicy"
       PolicyDocument:
         Statement:
-          Effect: "Allow"
-          Action: ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
-          Resource: "*"
+          -
+            Effect: "Allow"
+            Action:
+              - "logs:CreateLogGroup"
+              - "logs:CreateLogStream"
+              - "logs:PutLogEvents"
+            Resource: "*"
       Roles:
         - !Ref ExpirerRole
         - !Ref SchedulerRole
@@ -251,24 +256,26 @@ Resources:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
-        - Effect: "Allow"
-          Action: "sts:AssumeRole"
-          Principal:
-            Service:
-            - ["lambda.amazonaws.com"]
-      Path: /
+          -
+            Effect: "Allow"
+            Action: "sts:AssumeRole"
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+      Path: "/"
       Policies:
-      - PolicyName: "SchedulerPolicy"
-        PolicyDocument:
-          Statement:
-          - Effect: "Allow"
-            Action:
-            - ["s3:GetObject"]
-            Resource:
-            - !Sub ['arn:aws:s3:::${Bucket}/${Key}', {Bucket: !Ref 'BuildBucket',
-                Key: !FindInMap [LambdaBuilds, Scheduler, DEV]}]
-            - !Sub ['arn:aws:s3:::${Bucket}/${Key}', {Bucket: !Ref 'ConfigBucket',
-                Key: !FindInMap [LambdaConfig, Scheduler, DEV]}]
+        -
+          PolicyName: "SchedulerPolicy"
+          PolicyDocument:
+            Statement:
+              -
+                Effect: "Allow"
+                Action: "s3:GetObject"
+                Resource:
+                  - !Sub ['arn:aws:s3:::${Bucket}/${Key}', {Bucket: !Ref 'BuildBucket',
+                      Key: !FindInMap [LambdaBuilds, Scheduler, DEV]}]
+                  - !Sub ['arn:aws:s3:::${Bucket}/${Key}', {Bucket: !Ref 'ConfigBucket',
+                      Key: !FindInMap [LambdaConfig, Scheduler, DEV]}]
 
   ExpirerRole:
     Type: "AWS::IAM::Role"

--- a/uploader/README.md
+++ b/uploader/README.md
@@ -13,10 +13,10 @@ during packaging.
 
 You will need the AWS CLI and `jq` installed.
 
-Run:
+Run in root:
 
 ```
-uploader/packageBin
+sbt uploader/packageBin
 ```
 
 This will compile both the cloud-formation template and the lambda code.
@@ -49,7 +49,7 @@ statelint uploader/src/main/resources/state-machine.json
 ```
 
 We do not specify the lambda ARN directly in the JSON so you will always see the following error:
- 
+
 ```
 State Machine.States.GetChunkFromS3.Resource is "${GetChunkFromS3.Arn}" but should be A URI
 ```
@@ -118,7 +118,7 @@ case class LambdaConfig(description: String, timeout: Int = 60, memorySize: Int 
 
 - Further edit [StateMachines.scala](https://github.com/guardian/media-atom-maker/blob/mbarton/step-functions/project/StateMachines.scala)
  adding the variable to the `compileTemplate` task:
- 
+
 ```scala
 val instance = lambdaTemplate
   .replace("{{name}}", name)

--- a/uploader/src/main/resources/cfn-template.yaml
+++ b/uploader/src/main/resources/cfn-template.yaml
@@ -232,6 +232,7 @@ Resources:
     Condition: CreateProdResources
     Properties:
       DisplayName: !Join ['-', [!Ref 'Stage', Alerts]]
+      KmsMasterKeyId: 'alias/aws/sns'
       Subscription:
       - Endpoint: !Ref 'AlertWebhook'
         Protocol: https


### PR DESCRIPTION
Adding a [KMS key to all SNS topics ](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html#cfn-sns-topic-kmsmasterkeyid) to enable server-side encryption.

Using AWS [default encryption key](https://docs.aws.amazon.com/kms/latest/APIReference/API_DescribeKey.html#API_DescribeKey_RequestParameters), aliased to `alias/aws/sns`.

These are the two remaining SNS topics in the media-services account:

1. media-atom-maker-ingested-videos (CODE/ DEV/ PROD)
-> DEV version in here, drift from master means currently unable to test... 

--> Updated master and added KMS key to topic. 

2. media-atom-pipeline - can't be deployed over the the aws console. Relies on variables injected from the build step... Have deployed this branch to CODE.

--> This is just a template of a template Will run [upload steps here](https://github.com/guardian/media-atom-maker/tree/master/uploader) to successfully generate the CF for this  