### PR TITLE
adding more logs while atom update

### DIFF
--- a/app/model/commands/UpdateAtomCommand.scala
+++ b/app/model/commands/UpdateAtomCommand.scala
@@ -64,7 +64,7 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom, override val stores: D
 
     previewDataStore.updateAtom(thrift).fold(
       err => {
-        log.error(s"Unable to update atom id=${atom.id} new_content=$newAtom", err)
+        log.error(s"Unable to update atom id=${atom.id} in ${awsConfig.dynamoTableName} new_content=$newAtom", err)
         AtomUpdateFailed(err.msg)
       },
       _ => {
@@ -79,7 +79,7 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom, override val stores: D
 
             AuditMessage(atom.id, "Update", getUsername(user), Some(diffString)).logMessage()
 
-            log.info(s"atom ${atom.id} updated successfully to $updatedMediaAtom")
+            log.info(s"atom ${atom.id} updated successfully in ${awsConfig.dynamoTableName} to $updatedMediaAtom")
 
             updatedMediaAtom
           }

--- a/app/model/commands/UpdateAtomCommand.scala
+++ b/app/model/commands/UpdateAtomCommand.scala
@@ -64,7 +64,7 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom, override val stores: D
 
     previewDataStore.updateAtom(thrift).fold(
       err => {
-        log.error(s"Unable to update atom id=${atom.id} in ${awsConfig.dynamoTableName} new_content=$newAtom", err)
+        log.error(s"Unable to update atom with id ${atom.id} in ${awsConfig.dynamoTableName} table to new content $newAtom", err)
         AtomUpdateFailed(err.msg)
       },
       _ => {
@@ -79,7 +79,7 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom, override val stores: D
 
             AuditMessage(atom.id, "Update", getUsername(user), Some(diffString)).logMessage()
 
-            log.info(s"atom ${atom.id} updated successfully in ${awsConfig.dynamoTableName} to $updatedMediaAtom")
+            log.info(s"atom with id ${atom.id} updated successfully in ${awsConfig.dynamoTableName} table to $updatedMediaAtom")
 
             updatedMediaAtom
           }

--- a/app/model/commands/UpdateAtomCommand.scala
+++ b/app/model/commands/UpdateAtomCommand.scala
@@ -58,11 +58,13 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom, override val stores: D
       embargo = embargo.map(ChangeRecord.build(_, user)),
       expiry = expiry.map(ChangeRecord.build(_, user))
     )
-    val thrift = atom.copy(contentChangeDetails = details).asThrift
+
+    val newAtom = atom.copy(contentChangeDetails = details)
+    val thrift = newAtom.asThrift
 
     previewDataStore.updateAtom(thrift).fold(
       err => {
-        log.error(s"Unable to update atom ${atom.id}", err)
+        log.error(s"Unable to update atom id=${atom.id} new_content=$newAtom", err)
         AtomUpdateFailed(err.msg)
       },
       _ => {
@@ -77,10 +79,12 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom, override val stores: D
 
             AuditMessage(atom.id, "Update", getUsername(user), Some(diffString)).logMessage()
 
+            log.info(s"atom ${atom.id} updated successfully to $updatedMediaAtom")
+
             updatedMediaAtom
           }
           case Failure(err) =>
-            log.error(s"Unable to publish updated atom ${atom.id}", err)
+            log.error(s"Unable to publish updated atom id=${atom.id} new_content=$newAtom", err)
             AtomPublishFailed(s"could not publish: ${err.toString}")
         }
       }


### PR DESCRIPTION
adding more logs while atom update to investigate issue, when we can not update or activate Video on atom

Related to exception:
```
om.gu.atom.data.DynamoError: Dynamo was unable to process this request. Error message One or more parameter values were invalid: An AttributeValue may not contain an empty string
	at com.gu.atom.data.DynamoDataStore.handleException(DynamoDataStore.scala:120)
	at com.gu.atom.data.DynamoDataStore.put(DynamoDataStore.scala:70)
	at com.gu.atom.data.PreviewDynamoDataStore.updateAtom(DynamoDataStore.scala:161)
	at model.commands.UpdateAtomCommand.process(UpdateAtomCommand.scala:63)
	at model.commands.ActiveAssetCommand.process(ActiveAssetCommand.scala:47)
	at controllers.Api$$anonfun$setActiveAsset$1$$anonfun$apply$6.apply(Api.scala:149)
	at controllers.Api$$anonfun$setActiveAsset$1$$anonfun$apply$6.apply(Api.scala:147)
	at controllers.JsonRequestParsing$class.parse(JsonRequestParsing.scala:14)
	at controllers.Api.parse(Api.scala:22)
	at controllers.Api$$anonfun$setActiveAsset$1.apply(Api.scala:147)
	at controllers.Api$$anonfun$setActiveAsset$1.apply(Api.scala:146)
	at play.api.mvc.ActionBuilder$$anonfun$apply$13.apply(Action.scala:371)
	at play.api.mvc.ActionBuilder$$anonfun$apply$13.apply(Action.scala:370)
	at com.gu.pandomainauth.action.AuthActions$AbstractApiAuthAction$class.invokeBlock(Actions.scala:323)
	at com.gu.pandomainauth.action.AuthActions$APIAuthAction$.invokeBlock(Actions.scala:278)
	at com.gu.pandomainauth.action.AuthActions$APIAuthAction$.invokeBlock(Actions.scala:278)
	at play.api.mvc.ActionBuilder$$anon$2.apply(Action.scala:458)
	at play.api.mvc.Action$$anonfun$apply$2$$anonfun$apply$5$$anonfun$apply$6.apply(Action.scala:112)
	at play.api.mvc.Action$$anonfun$apply$2$$anonfun$apply$5$$anonfun$apply$6.apply(Action.scala:112)
	at play.utils.Threads$.withContextClassLoader(Threads.scala:21)
	at play.api.mvc.Action$$anonfun$apply$2$$anonfun$apply$5.apply(Action.scala:111)
	at play.api.mvc.Action$$anonfun$apply$2$$anonfun$apply$5.apply(Action.scala:110)
	at scala.Option.map(Option.scala:146)
	at play.api.mvc.Action$$anonfun$apply$2.apply(Action.scala:110)
	at play.api.mvc.Action$$anonfun$apply$2.apply(Action.scala:103)
	at scala.concurrent.Future$$anonfun$flatMap$1.apply(Future.scala:253)
	at scala.concurrent.Future$$anonfun$flatMap$1.apply(Future.scala:251)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:32)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:55)
	at akka.dispatch.BatchingExecutor$BlockableBatch$$anonfun$run$1.apply$mcV$sp(BatchingExecutor.scala:91)
	at akka.dispatch.BatchingExecutor$BlockableBatch$$anonfun$run$1.apply(BatchingExecutor.scala:91)
	at akka.dispatch.BatchingExecutor$BlockableBatch$$anonfun$run$1.apply(BatchingExecutor.scala:91)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:72)
	at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:90)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:39)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(AbstractDispatcher.scala:409)
	at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```