### PR TITLE
bug fix for extracting Youtube description as empty string

### DIFF
--- a/common/src/main/scala/com/gu/media/model/MediaAtom.scala
+++ b/common/src/main/scala/com/gu/media/model/MediaAtom.scala
@@ -231,7 +231,7 @@ object MediaAtom extends MediaAtomImplicits {
   def fromThrift(atom: ThriftAtom) = {
     val data = atom.tdata
 
-    val youtubeDescription: Option[String] = MediaAtomYoutubeDescriptionHandler.extractYoutubeDescriptionFrom(data)
+    val youtubeDescription: Option[String] = MediaAtomYoutubeDescriptionHandler.getYoutubeDescription(data)
 
     MediaAtom(
       id = atom.id,

--- a/common/src/main/scala/com/gu/media/model/MediaAtom.scala
+++ b/common/src/main/scala/com/gu/media/model/MediaAtom.scala
@@ -4,7 +4,7 @@ import com.gu.contentatom.thrift.atom.media.{MediaAtom => ThriftMediaAtom, Metad
 import play.api.libs.json.Format
 import com.gu.contentatom.thrift.{AtomData, Atom => ThriftAtom, AtomType => ThriftAtomType, Flags => ThriftFlags}
 import com.gu.media.util.MediaAtomImplicits
-import com.gu.media.youtube.YoutubeDescription
+import com.gu.media.youtube.{MediaAtomYoutubeDescriptionHandler, YoutubeDescription}
 import org.cvogt.play.json.Jsonx
 
 abstract class MediaAtomBase {
@@ -231,10 +231,7 @@ object MediaAtom extends MediaAtomImplicits {
   def fromThrift(atom: ThriftAtom) = {
     val data = atom.tdata
 
-    val youtubeDescription: Option[String] = data.metadata.flatMap(_.youtube) match {
-      case Some(youtubeData) if youtubeData.description.isDefined => youtubeData.description
-      case _ => YoutubeDescription.clean(data.description)
-    }
+    val youtubeDescription: Option[String] = MediaAtomYoutubeDescriptionHandler.extractYoutubeDescriptionFrom(data)
 
     MediaAtom(
       id = atom.id,

--- a/common/src/main/scala/com/gu/media/youtube/MediaAtomYoutubeDescriptionHandler.scala
+++ b/common/src/main/scala/com/gu/media/youtube/MediaAtomYoutubeDescriptionHandler.scala
@@ -1,0 +1,23 @@
+package com.gu.media.youtube
+
+import com.gu.contentatom.thrift.atom.media.{MediaAtom => ThriftMediaAtom}
+import com.gu.media.model.MediaAtom
+import com.gu.media.util.MediaAtomImplicits
+import org.cvogt.play.json.Jsonx
+
+
+object MediaAtomYoutubeDescriptionHandler extends MediaAtomImplicits {
+
+  private implicit val mediaAtomFormat = Jsonx.formatCaseClass[MediaAtom]
+
+  def extractYoutubeDescriptionFrom(data: ThriftMediaAtom): Option[String] = {
+
+    val youtubeDescription: Option[String] = data.metadata.flatMap(_.youtube) match {
+      case Some(youtubeData) if youtubeData.description.isDefined => youtubeData.description
+      case _ => YoutubeDescription.clean(data.description)
+    }
+
+    youtubeDescription
+  }
+
+}

--- a/common/src/main/scala/com/gu/media/youtube/MediaAtomYoutubeDescriptionHandler.scala
+++ b/common/src/main/scala/com/gu/media/youtube/MediaAtomYoutubeDescriptionHandler.scala
@@ -10,7 +10,7 @@ object MediaAtomYoutubeDescriptionHandler extends MediaAtomImplicits {
 
   private implicit val mediaAtomFormat = Jsonx.formatCaseClass[MediaAtom]
 
-  def extractYoutubeDescriptionFrom(data: ThriftMediaAtom): Option[String] = {
+  def getYoutubeDescription(data: ThriftMediaAtom): Option[String] = {
 
     val youtubeDescription: Option[String] = data.metadata.flatMap(_.youtube) match {
       case Some(youtubeData) if youtubeData.description.isDefined => youtubeData.description

--- a/common/src/main/scala/com/gu/media/youtube/YoutubeDescription.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YoutubeDescription.scala
@@ -18,6 +18,13 @@ object YoutubeDescription {
       html.text().replace("\\n", "\n")
     })
 
+    /**
+     * W edo this additional check if Option is defined and if ti contain empty string
+     * Ignore it and return None
+     * because if we will return Some("") we will have problems with putting that data into DynamoDB
+     * as DynamoDB does not allow empty string and will throw exception:
+     * Dynamo was unable to process this request. Error message One or more parameter values were invalid: An AttributeValue may not contain an empty string
+     */
     if (desc.isDefined && desc.get.isEmpty) return None
     desc
   }

--- a/common/src/main/scala/com/gu/media/youtube/YoutubeDescription.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YoutubeDescription.scala
@@ -4,7 +4,7 @@ import org.jsoup.Jsoup
 
 object YoutubeDescription {
   def clean(maybeDirtyDescription: Option[String]): Option[String] = {
-    maybeDirtyDescription.map(dirtyDescription => {
+    val desc = maybeDirtyDescription.map(dirtyDescription => {
       val html = Jsoup.parse(dirtyDescription)
 
       //Extracting the text removes line breaks
@@ -17,5 +17,8 @@ object YoutubeDescription {
 
       html.text().replace("\\n", "\n")
     })
+
+    if (desc.isDefined && desc.get.isEmpty) return None
+    desc
   }
 }

--- a/common/src/main/scala/com/gu/media/youtube/YoutubeDescription.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YoutubeDescription.scala
@@ -19,7 +19,7 @@ object YoutubeDescription {
     })
 
     /**
-     * W edo this additional check if Option is defined and if ti contain empty string
+     * We do this additional check if Option is defined and if ti contain empty string
      * Ignore it and return None
      * because if we will return Some("") we will have problems with putting that data into DynamoDB
      * as DynamoDB does not allow empty string and will throw exception:

--- a/common/src/test/scala/com/gu/media/youtube/MediaAtomYoutubeDescriptionHandlerTest.scala
+++ b/common/src/test/scala/com/gu/media/youtube/MediaAtomYoutubeDescriptionHandlerTest.scala
@@ -1,0 +1,26 @@
+package com.gu.media.youtube
+
+import com.gu.contentatom.thrift.atom.media.{Category => ThriftMediaCategory, MediaAtom => ThriftMediaAtom}
+import com.gu.media.youtube.MediaAtomYoutubeDescriptionHandler.extractYoutubeDescriptionFrom
+import org.scalatest.{FunSuite, MustMatchers}
+
+class MediaAtomYoutubeDescriptionHandlerTest extends FunSuite with MustMatchers {
+
+  val thriftAtomData = ThriftMediaAtom(
+    title = "a title",
+    category = ThriftMediaCategory.News
+  )
+
+  test("should return None if there was no text in HTML") {
+    val thriftAtomDataWithHtmlWithoutText = thriftAtomData.copy(description = Some("<p><br></p>"))
+    val actual = extractYoutubeDescriptionFrom(thriftAtomDataWithHtmlWithoutText)
+    actual must be(None)
+  }
+
+  test("should extract description from html template") {
+    val thriftAtomDataWithDescriptionInHtml = thriftAtomData.copy(description = Some("<p>test title</p>"))
+    val actual = extractYoutubeDescriptionFrom(thriftAtomDataWithDescriptionInHtml)
+    actual must be(Some("test title"))
+  }
+
+}

--- a/common/src/test/scala/com/gu/media/youtube/MediaAtomYoutubeDescriptionHandlerTest.scala
+++ b/common/src/test/scala/com/gu/media/youtube/MediaAtomYoutubeDescriptionHandlerTest.scala
@@ -1,7 +1,7 @@
 package com.gu.media.youtube
 
 import com.gu.contentatom.thrift.atom.media.{Category => ThriftMediaCategory, MediaAtom => ThriftMediaAtom}
-import com.gu.media.youtube.MediaAtomYoutubeDescriptionHandler.extractYoutubeDescriptionFrom
+import com.gu.media.youtube.MediaAtomYoutubeDescriptionHandler.getYoutubeDescription
 import org.scalatest.{FunSuite, MustMatchers}
 
 class MediaAtomYoutubeDescriptionHandlerTest extends FunSuite with MustMatchers {
@@ -13,13 +13,13 @@ class MediaAtomYoutubeDescriptionHandlerTest extends FunSuite with MustMatchers 
 
   test("should return None if there was no text in HTML") {
     val thriftAtomDataWithHtmlWithoutText = thriftAtomData.copy(description = Some("<p><br></p>"))
-    val actual = extractYoutubeDescriptionFrom(thriftAtomDataWithHtmlWithoutText)
+    val actual = getYoutubeDescription(thriftAtomDataWithHtmlWithoutText)
     actual must be(None)
   }
 
   test("should extract description from html template") {
     val thriftAtomDataWithDescriptionInHtml = thriftAtomData.copy(description = Some("<p>test title</p>"))
-    val actual = extractYoutubeDescriptionFrom(thriftAtomDataWithDescriptionInHtml)
+    val actual = getYoutubeDescription(thriftAtomDataWithDescriptionInHtml)
     actual must be(Some("test title"))
   }
 

--- a/common/src/test/scala/com/gu/media/youtube/YoutubeDescriptionTest.scala
+++ b/common/src/test/scala/com/gu/media/youtube/YoutubeDescriptionTest.scala
@@ -32,4 +32,9 @@ class YoutubeDescriptionTest extends FunSuite with MustMatchers {
 
     YoutubeDescription.clean(testHtml) must be(expected)
   }
+
+  test("ignore html without text") {
+    val htmlWithoutText = Some("<p><br></p>")
+    YoutubeDescription.clean(htmlWithoutText) must be(None)
+  }
 }


### PR DESCRIPTION
bug fix for extracting Youtube description

In current implementation we extract Youtube description from html description
if html tags do not have any text like: ```"<p><br></p>"``` we end up with empty string
And then DynamoDB will throw exception:

```
com.gu.atom.data.DynamoError: Dynamo was unable to process this request. Error message One or more parameter values were invalid: An AttributeValue may not contain an empty string
	at com.gu.atom.data.DynamoDataStore.handleException(DynamoDataStore.scala:120)
	at com.gu.atom.data.DynamoDataStore.put(DynamoDataStore.scala:70)
	at com.gu.atom.data.PreviewDynamoDataStore.updateAtom(DynamoDataStore.scala:161)
	at model.commands.UpdateAtomCommand.process(UpdateAtomCommand.scala:63)
	at model.commands.ActiveAssetCommand.process(ActiveAssetCommand.scala:47)
	at controllers.Api$$anonfun$setActiveAsset$1$$anonfun$apply$6.apply(Api.scala:149)
	at controllers.Api$$anonfun$setActiveAsset$1$$anonfun$apply$6.apply(Api.scala:147)
	at controllers.JsonRequestParsing$class.parse(JsonRequestParsing.scala:14)
	at controllers.Api.parse(Api.scala:22)
	at controllers.Api$$anonfun$setActiveAsset$1.apply(Api.scala:147)
	at controllers.Api$$anonfun$setActiveAsset$1.apply(Api.scala:146)
	at play.api.mvc.ActionBuilder$$anonfun$apply$13.apply(Action.scala:371)
	at play.api.mvc.ActionBuilder$$anonfun$apply$13.apply(Action.scala:370)
	at com.gu.pandomainauth.action.AuthActions$AbstractApiAuthAction$class.invokeBlock(Actions.scala:323)
	at com.gu.pandomainauth.action.AuthActions$APIAuthAction$.invokeBlock(Actions.scala:278)
	at com.gu.pandomainauth.action.AuthActions$APIAuthAction$.invokeBlock(Actions.scala:278)
	at play.api.mvc.ActionBuilder$$anon$2.apply(Action.scala:458)
	at play.api.mvc.Action$$anonfun$apply$2$$anonfun$apply$5$$anonfun$apply$6.apply(Action.scala:112)
	at play.api.mvc.Action$$anonfun$apply$2$$anonfun$apply$5$$anonfun$apply$6.apply(Action.scala:112)
	at play.utils.Threads$.withContextClassLoader(Threads.scala:21)
	at play.api.mvc.Action$$anonfun$apply$2$$anonfun$apply$5.apply(Action.scala:111)
	at play.api.mvc.Action$$anonfun$apply$2$$anonfun$apply$5.apply(Action.scala:110)
	at scala.Option.map(Option.scala:146)
	at play.api.mvc.Action$$anonfun$apply$2.apply(Action.scala:110)
	at play.api.mvc.Action$$anonfun$apply$2.apply(Action.scala:103)
	at scala.concurrent.Future$$anonfun$flatMap$1.apply(Future.scala:253)
	at scala.concurrent.Future$$anonfun$flatMap$1.apply(Future.scala:251)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:32)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:55)
	at akka.dispatch.BatchingExecutor$BlockableBatch$$anonfun$run$1.apply$mcV$sp(BatchingExecutor.scala:91)
	at akka.dispatch.BatchingExecutor$BlockableBatch$$anonfun$run$1.apply(BatchingExecutor.scala:91)
	at akka.dispatch.BatchingExecutor$BlockableBatch$$anonfun$run$1.apply(BatchingExecutor.scala:91)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:72)
	at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:90)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:39)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(AbstractDispatcher.scala:409)
	at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```

this change is to solve that problem to ignore description if it is empty string 

- [x] unit tests added
- [x] tested in CODE