### PR TITLE
Correctly cache Youtube channels and categories

### DIFF
--- a/app/di.scala
+++ b/app/di.scala
@@ -43,7 +43,7 @@ class MediaAtomMaker(context: Context)
 
   private val reindexer = buildReindexer()
 
-  private val youTube = YouTube(config, defaultCacheApi, 1.hour)
+  private val youTube = YouTube(config, defaultCacheApi, 1.day)
 
   private val uploaderMessageConsumer = PlutoMessageConsumer(stores, aws)
   uploaderMessageConsumer.start(actorSystem.scheduler)(actorSystem.dispatcher)


### PR DESCRIPTION
Extend cache for Youtube channels and categories to one day -- we ran over quota yesterday and we're keen not to repeat the incident.

This will save us at maximum

24 requests per service *
2 services (channels, categories) *
3 boxes

= 144 requests a day, or 0.18% of our quota of 80,000, which isn't much, but is arguably better than nothing?