### PR TITLE
Revert "add a border to the YouTube thumbnail"

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -273,10 +273,7 @@ case class PublishAtomCommand(
       case Some(image) => {
         val thumbnail = atom.isOnCommercialChannel(youtube.commercialChannels) match {
           case Some(isCommercial) if isCommercial => thumbnailGenerator.getThumbnail(image)
-          case _ => {
-            val withBorder = atom.shouldAddThumbnailBorder(youtube.borderedChannels)
-            thumbnailGenerator.getBrandedThumbnail(image, atom.id, withBorder)
-          }
+          case _ => thumbnailGenerator.getBrandedThumbnail(image, atom.id)
         }
 
         val thumbnailUpdate = youtube.updateThumbnail(asset.id, thumbnail)

--- a/app/util/ThumbnailGenerator.scala
+++ b/app/util/ThumbnailGenerator.scala
@@ -1,6 +1,6 @@
 package util
 
-import java.awt.{BasicStroke, Color, RenderingHints}
+import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.io._
 import java.net.URL
@@ -30,7 +30,7 @@ case class ThumbnailGenerator(logoFile: File) {
   private def imageAssetToBufferedImage(imageAsset: ImageAsset): BufferedImage =
     ImageIO.read(new URL(imageAsset.file))
 
-  private def overlayImages(bgImage: BufferedImage, bgImageMimeType: String, atomId: String, withBorder: Boolean): ByteArrayInputStream = {
+  private def overlayImages(bgImage: BufferedImage, bgImageMimeType: String, atomId: String): ByteArrayInputStream = {
     val logoWidth: Double = List(bgImage.getWidth() / 3.0, logo.getWidth()).min
     val logoHeight: Double = logo.getHeight() / (logo.getWidth() / logoWidth)
 
@@ -42,25 +42,6 @@ case class ThumbnailGenerator(logoFile: File) {
     graphics.drawImage(bgImage, 0, 0, null)
     Logger.info(s"Creating branded thumbnail for atom $atomId. Image dims ${bgImage.getWidth()} x ${bgImage.getHeight()}. Logo dims ${logoWidth.toInt} x ${logoHeight.toInt} (x:$logoX, y:$logoY)")
     graphics.drawImage(logo, logoX, logoY, logoWidth.toInt, logoHeight.toInt, null)
-
-    if(withBorder) {
-      val borderThickness = 40
-      val borderOffset = borderThickness / 2
-
-      val hexColour = "#C70000"
-      val colour = Color.decode(hexColour)
-
-      val currentStroke = graphics.getStroke
-
-      graphics.setStroke(new BasicStroke(borderThickness))
-      graphics.setColor(colour)
-      graphics.drawRect(borderOffset, borderOffset, bgImage.getWidth - borderThickness, bgImage.getHeight - borderThickness)
-
-      graphics.setStroke(currentStroke)
-
-      Logger.info(s"Added a ${borderThickness}px $hexColour border to thumbnail for atom $atomId")
-    }
-
     graphics.dispose()
 
     val os = new ByteArrayOutputStream()
@@ -79,14 +60,14 @@ case class ThumbnailGenerator(logoFile: File) {
     new ByteArrayInputStream(os.toByteArray)
   }
 
-  def getBrandedThumbnail(image: Image, atomId: String, withBorder: Boolean): InputStreamContent = {
+  def getBrandedThumbnail(image: Image, atomId: String): InputStreamContent = {
     val imageAsset = getGridImageAsset(image)
     val gridImage = imageAssetToBufferedImage(imageAsset)
     val mimeType = imageAsset.mimeType.getOrElse("image/jpeg")
 
     new InputStreamContent(
       mimeType,
-      new BufferedInputStream(overlayImages(gridImage, mimeType, atomId, withBorder))
+      new BufferedInputStream(overlayImages(gridImage, mimeType, atomId))
     )
   }
 

--- a/common/src/main/scala/com/gu/media/model/MediaAtom.scala
+++ b/common/src/main/scala/com/gu/media/model/MediaAtom.scala
@@ -42,8 +42,6 @@ abstract class MediaAtomBase {
   def isOnCommercialChannel(commercialChannels: Set[String]): Option[Boolean] = {
     channelId.map(commercialChannels.contains)
   }
-
-  def shouldAddThumbnailBorder(borderedChannels: Set[String]): Boolean = channelId.exists(borderedChannels.contains)
 }
 
 // This is used to parse the a media atom from a create atom

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
@@ -19,8 +19,7 @@ trait YouTubeAccess extends Settings {
   val allowedChannels: Set[String] = getStringSet("youtube.channels.allowed")
   val channelsRequiringPermission: Set[String] = getStringSet("youtube.channels.unlisted")
   val commercialChannels: Set[String] = getStringSet("youtube.channels.commercial")
-  val borderedChannels: Set[String] = getStringSet("youtube.channels.bordered")
-  val allChannels: Set[String] = allowedChannels ++ channelsRequiringPermission ++ commercialChannels ++ borderedChannels
+  val allChannels: Set[String] = allowedChannels ++ channelsRequiringPermission ++ commercialChannels
 
   val trainingChannels: Set[String] = getStringSet("youtube.channels.training")
 


### PR DESCRIPTION
Reverts guardian/media-atom-maker#927

This is yielding some inconsistent border sizes and can also cause us to exceed YouTube's 2MB thumbnail image limit. Reverting to prevent further issues.

![image](https://user-images.githubusercontent.com/836140/81962159-41be0400-960b-11ea-8ab7-c823515a48e6.png)
