### PR TITLE
Grant permission on KMS key used to encrypt stream

### DIFF
--- a/uploader/src/main/resources/cfn-template.yaml
+++ b/uploader/src/main/resources/cfn-template.yaml
@@ -45,6 +45,9 @@ Parameters:
   PlutoSendbackStreamName:
     Description: Name (not ARN) of the Kinesis stream which passes messages back to Pluto
     Type: String
+  PlutoSendbackStreamKmsKey:
+    Description: ARN of the KMS key used to encrypt messages sent to pluto
+    Type: String
 
 Conditions:
   CreateProdResources: !Equals [!Ref "Stage", "PROD"]
@@ -103,6 +106,9 @@ Resources:
                   - kinesis:PutRecords
                 Resource:
                   - !Sub "arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${PlutoSendbackStreamName}"
+              - Effect: Allow
+                Action: kms:GenerateDataKey
+                Resource: !Ref PlutoSendbackStreamKmsKey
 
   ContentAtomCrossAccountPolicyCODE:
     Type: AWS::IAM::Policy


### PR DESCRIPTION
## What does this change?
This adds permission to access the key used for encrypting data sent on the Pluto kinesis stream. See also https://github.com/guardian/editorial-tools-platform/pull/435