### PR TITLE
Display warning when creating Hosted content

### DIFF
--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -8,6 +8,7 @@ import ComposerPageCreate from './Videos/ComposerPageCreate';
 import Icon from './Icon';
 import { Presence } from './Presence';
 import { canonicalVideoPageExists } from '../util/canonicalVideoPageExists';
+import VideoUtils from '../util/video';
 
 export default class Header extends React.Component {
   state = { presence: null };
@@ -109,6 +110,15 @@ export default class Header extends React.Component {
       return null;
     }
 
+    if (VideoUtils.isHosted(this.props.video)) {
+      return (
+        <div className="header__fields__missing__warning">
+          Hosted video pages need a call to action. Please create this video in
+          Composer
+        </div>
+      );
+    }
+
     if (canonicalVideoPageExists(this.props.usages)) {
       return (
         <div className="header__fields__missing__warning">
@@ -164,7 +174,6 @@ export default class Header extends React.Component {
             {this.renderCreateVideo()}
             {this.renderHelpLink()}
           </div>
-
         </header>
       );
     } else {

--- a/public/video-ui/src/components/Videos/ComposerPageCreate.js
+++ b/public/video-ui/src/components/Videos/ComposerPageCreate.js
@@ -57,9 +57,6 @@ export default class ComposerPageCreate extends React.Component {
 
     const { usages, videoEditOpen, requiredComposerFieldsMissing } = this.props;
 
-    if (this.isHosted() && !canonicalVideoPageExists(usages)) {
-      return null;
-    }
 
     if (canonicalVideoPageExists(usages)) {
       return (
@@ -67,9 +64,9 @@ export default class ComposerPageCreate extends React.Component {
           <Icon icon="pageview">Open in Composer</Icon>
         </a>
       );
-    }
-
-    else {
+    } else if (this.isHosted()) {
+      return null;
+    } else {
       const helpMsg = this.usageErrorsExist() ? 'Cannot create a video page because of errors in fetching video usages' : '';
 
       return (

--- a/public/video-ui/src/components/Videos/ComposerPageCreate.js
+++ b/public/video-ui/src/components/Videos/ComposerPageCreate.js
@@ -56,9 +56,12 @@ export default class ComposerPageCreate extends React.Component {
   render() {
 
     const { usages, videoEditOpen, requiredComposerFieldsMissing } = this.props;
-    const showOpenPage = canonicalVideoPageExists(usages) || this.isHosted();
 
-    if (showOpenPage) {
+    if (this.isHosted() && !canonicalVideoPageExists(usages)) {
+      return null;
+    }
+
+    if (canonicalVideoPageExists(usages)) {
       return (
         <a className="button__secondary" href={this.getComposerLink()} target="_blank">
           <Icon icon="pageview">Open in Composer</Icon>
@@ -76,9 +79,9 @@ export default class ComposerPageCreate extends React.Component {
             onClick={this.pageCreate}
             disabled={videoEditOpen || this.state.composerUpdateInProgress || requiredComposerFieldsMissing() || this.usageErrorsExist()}
           >
-          <Icon icon="add_to_queue">Create Video Page</Icon>
-        </button>
-      </span>
+            <Icon icon="add_to_queue">Create Video Page</Icon>
+          </button>
+        </span>
       );
     }
   }

--- a/public/video-ui/src/util/video.js
+++ b/public/video-ui/src/util/video.js
@@ -81,6 +81,10 @@ export default class VideoUtils {
     return category === 'Livestream';
   }
 
+  static isHosted({ category }) {
+    return category === 'Hosted';
+  }
+
   static isEligibleForAds(atom) {
     if (!VideoUtils.hasAssets(atom)) {
       return true;
@@ -133,11 +137,11 @@ export default class VideoUtils {
     return embargo ? moment(embargo) : null;
   }
 
-  static isPublished({contentChangeDetails}) {
+  static isPublished({ contentChangeDetails }) {
     return !!contentChangeDetails.published;
   }
 
-  static hasExpired({contentChangeDetails}) {
+  static hasExpired({ contentChangeDetails }) {
     return !!contentChangeDetails.expiry && contentChangeDetails.expiry.date <= Date.now();
   }
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
When creating a video directly through MAM, a check is made on whether the category "GLabs - Hosted by" has been applied to the video. Previously, if this evaluated as true, the 'Open in Composer' button would display. This button would always link to https://composer.gutools.co.uk/content/undefined, as no corresponding Composer page is created by MAM on creation of a video. The relevant Composer video page will only be created if users create their Hosted video through the Composer dashboard, i.e. through the following menu under 'Create new':

![Screenshot 2020-07-22 at 13 15 39](https://user-images.githubusercontent.com/12645938/88175234-7f4b9880-cc1d-11ea-86ea-bfbe683bb48d.png)

This PR changes the logic for when the 'Open in Composer' button should display, removing the button entirely if the category of the video is Hosted and there are no recorded usages of the video. Instead, a warning is displayed advising that the user should create their Hosted video through Composer.

## What prompted this change?

CP reported an issue whereby a Hosted video appeared to have a Composer video page of https://composer.gutools.co.uk/content/undefined. This happened be cause the content was created via Composer, and the Composer page itself was then deleted manually by CP from the relevant database. As a result, the 'Open in Composer' button had no content to link to.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Running this branch locally, create a new video with the category "GLabs - Hosted by". You should see a warning message, advising that you need to create your Hosted video in Composer.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users do not end up in a situation where they see an 'Open in Composer' button that links to nothing.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
It's possible that users will complete the entirety of setting up their video in MAM before realising that this problem exists and this isn't an ideal user experience. After discussion, we believe this risk to be minimal. The current implementation would also cause the user to experience the same frustration, with the additional confusion of displaying the 'Open in Composer' button that linked to nothing. Additionally, Hosted video content has to be created through Composer directly, to provide the relevant 'call to action' metadata, so we do not believe this workflow is a common one.

Ideally, we would want to either a) provide a link to create a Hosted video via Composer or, even better, b) automatically created a corresponding Composer video page when a Hosted video is creating in MAM. This change is therefore only catering to edge cases, such as the uncommon series of steps mentioned in the 'What prompted this change?' section above.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
Before: 
![Screenshot 2020-07-22 at 13 01 30](https://user-images.githubusercontent.com/12645938/88174066-84a7e380-cc1b-11ea-9d5d-3083b0c02ffe.png)

After:
![Screenshot 2020-07-22 at 13 00 51](https://user-images.githubusercontent.com/12645938/88174075-87a2d400-cc1b-11ea-9a47-d732e6380bf0.png)

