### PR TITLE
Fix embedding into Composer issue by moving setup behaviour to constructor

### DIFF
--- a/public/video-ui/src/components/VideoSelectBar/VideoSelectBar.js
+++ b/public/video-ui/src/components/VideoSelectBar/VideoSelectBar.js
@@ -37,11 +37,15 @@ export default class VideoSelectBar extends React.Component {
       return false;
     }
 
+    const title = this.props.video && this.props.video.title
+      ? this.props.video.title
+      : "Title missing";
+
     return (
       <div className="bar info-bar">
         <div className="bar__image">{this.renderItemImage()}</div>
         <div>
-          <span className="grid__item__title">{this.props.video.title}</span>
+          <span className="grid__item__title">{title}</span>
           {this.renderEmbedButton()}
         </div>
       </div>

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -30,9 +30,7 @@ class VideoDisplay extends React.Component {
       editingYoutubeFurniture: false,
       editingWorkflow: false
     };
-  }
 
-  componentDidMount() {
     if (this.state.isCreateMode) {
       this.props.videoActions.updateVideo(blankVideoData);
       this.updateEditingState({ key: 'editingFurniture', editing: true });


### PR DESCRIPTION
## What does this change?

While updating old deprecated `componentWillMount` syntax to the newer best practices, a mistake was made ~by me~ in moving some behaviour to `componentDidMount` rather than in the constructor. This meant that when rendering the `VideoSelectBar` component in the embedded MAM, it was missing a video prop, and would therefore bail on not being able to access `this.props.video.title` because `video` was `null`.

This PR ensures the component does not render until the setup behaviour is completed by moving the behaviour to the constructor, and also adds a ternary to ensure we don't run into the same issue again.

## How to test

If you create a space between paras in Composer and click "Video" in the embed menu, and then select a video to embed from the embedded version of MAM, the screen should not go blank and you can embed a video as expected.

## How can we measure success?
Users can embed videos as normal.

## Images

Problem email:
![image](https://user-images.githubusercontent.com/25747336/89889295-47ef5c80-dbc9-11ea-8cc7-40d25aef9fee.png)



