### PR TITLE
Fix cursor jump and undo CMD-Z by knocking react-redux down to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-datepicker": "^3.1.3",
     "react-dom": "^16.13.1",
     "react-drag-sortable": "^1.0.4",
-    "react-redux": "^7.2.1",
+    "react-redux": "6",
     "react-router": "^3.0.0",
     "react-router-redux": "^4.0.8",
     "react-tabs": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -898,7 +898,7 @@
     "@babel/plugin-transform-react-jsx-source" "^7.10.4"
     "@babel/plugin-transform-react-pure-annotations" "^7.10.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.8.4":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -7093,7 +7093,7 @@ react-hot-loader@^3.0.0-beta.5:
     redbox-react "^1.2.5"
     source-map "^0.4.4"
 
-react-is@^16.12.0, react-is@^16.13.0, react-is@^16.7.0, react-is@^16.9.0:
+react-is@^16.12.0, react-is@^16.13.0, react-is@^16.7.0, react-is@^16.8.2:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -7126,16 +7126,17 @@ react-proxy@^3.0.0-alpha.0:
   dependencies:
     lodash "^4.6.1"
 
-react-redux@^7.2.1:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.1.tgz#8dedf784901014db2feca1ab633864dee68ad985"
-  integrity sha512-T+VfD/bvgGTUA74iW9d2i5THrDQWbweXP0AVNI8tNd1Rk5ch1rnMiJkDD67ejw7YBKM4+REvcvqRuWJb7BLuEg==
+react-redux@6:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-6.0.1.tgz#0d423e2c1cb10ada87293d47e7de7c329623ba4d"
+  integrity sha512-T52I52Kxhbqy/6TEfBv85rQSDz6+Y28V/pf52vDWs1YRXG19mcFOGfHnY2HsNFHyhP+ST34Aih98fvt6tqwVcQ==
   dependencies:
-    "@babel/runtime" "^7.5.5"
+    "@babel/runtime" "^7.3.1"
     hoist-non-react-statics "^3.3.0"
+    invariant "^2.2.4"
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
-    react-is "^16.9.0"
+    react-is "^16.8.2"
 
 react-router-redux@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
## What does this change?

When upgrading react-redux from v5 to v7 in a previous PR, we _went too far_. There appears to be some [issues with newer versions of react-redux and form input cursor locations, but these issues don't exist in previous versions. This issue doesn't exist in v6 – v7.0.0 introduces the problem.

This PR changes react-redux to v6 to fix the issues experienced by users to do with the cursor jumping around and not being able to undo with keyboard shortcuts.

## How to test

Go to CODE, click on a video, go to YouTube furniture and try editing the description. You should be able to use it as normal and the cursor should stay in the same place upon changes. You can also use CTRL/CMD-Z to undo changes.

## How can we measure success?
Users can edit textinput fields as normal.
