### PR TITLE
Increase default textarea height to 200px

### DIFF
--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -138,6 +138,7 @@
 
   &--textarea {
     height: inherit;
+    min-height: 200px;
   }
 
   &--inline {


### PR DESCRIPTION
## What does this change?

We received the following feedback:

```
Just a suggestion related to this, to help Adam and others out, so they are not having to constantly scroll up and down, 
it might make sense to enlarge the default text field size when editing Youtube descriptions. 
At the moment it is about 3 or 4 lines, perhaps making it 20 lines by default would be better for user experience.
```

This PR increases the minimum height of the textarea fields (used in YT Furniture descriptions and Workflow note fields respectively) to 200px, which feels like a significant increase whilst not being too big? Happy to get feedback on this though!

## How to test

Spin up the branch locally, pick a video and edit the YouTube Furniture. You should see the height increase to allow for a better view of the content.

## How can we measure success?

Users scroll up and down through larger fields less!

## Images

Before:
![image](https://user-images.githubusercontent.com/25747336/89913989-408d7a80-dbec-11ea-8e9a-20b537982511.png)


After:
![image](https://user-images.githubusercontent.com/25747336/89913948-353a4f00-dbec-11ea-8c9d-8e9146351d0d.png)
