### PR TITLE
Render web title for youtube furniture keywords

### DIFF
--- a/public/video-ui/src/components/Tags/TagFieldValue.js
+++ b/public/video-ui/src/components/Tags/TagFieldValue.js
@@ -13,10 +13,10 @@ export default class TagFieldValue extends React.Component {
     }
 
     if (index === 0 || value === ',') {
-      return value;
+      return value.webTitle || value;
     }
 
-    return ` ${value}`;
+    return ` ${value.webTitle || value}`;
   }
 
   render() {

--- a/public/video-ui/src/components/Tags/TagFieldValue.js
+++ b/public/video-ui/src/components/Tags/TagFieldValue.js
@@ -10,13 +10,16 @@ export default class TagFieldValue extends React.Component {
           </span>{' '}
         </span>
       );
+    } else if (value.webTitle) {
+      // In YouTube Furniture tab, the `keyword` field passes an object with webTitle to this component
+      return value.webTitle;
     }
 
     if (index === 0 || value === ',') {
-      return value.webTitle || value;
+      return value;
     }
 
-    return ` ${value.webTitle || value}`;
+    return ` ${value}`;
   }
 
   render() {


### PR DESCRIPTION
## What does this change?

This PR (https://github.com/guardian/media-atom-maker/pull/949) unfortunately introduced a regression where the `TagFieldValue` component breaks the site, as it receives an object with `id` and `webTitle` fields that isn't being dealt with.

This PR fixes that and renders the `webTitle` field, and adds a comment to explain the reasoning.

## How to test

Spin up the branch, go to a video, add some keywords to YouTube Furniture and see it add successfully!

## How can we measure success?

Adding keywords to YouTube Furniture doesn't crash the site!