### PR TITLE
Install hocon-parser from npm instead of GitHub

### DIFF
--- a/pluto-message-ingestion/file-config.js
+++ b/pluto-message-ingestion/file-config.js
@@ -1,5 +1,5 @@
 const AWS = require('aws-sdk');
-const parseHocon = require('hoconjs/build/hoconjs');
+const parseHocon = require('hocon-parser');
 
 const EnvironmentConfig = require('./environment-config');
 

--- a/pluto-message-ingestion/package.json
+++ b/pluto-message-ingestion/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@guardian/elk-kinesis-logger": "0.1.0",
     "crypto": "0.0.3",
-    "hoconjs": "github:yellowblood/hocon-js",
+    "hocon-parser": "^1.0.1",
     "reqwest": "^2.0.5",
     "xhr2": "^0.1.4"
   },

--- a/pluto-message-ingestion/yarn.lock
+++ b/pluto-message-ingestion/yarn.lock
@@ -1791,9 +1791,10 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-"hoconjs@github:yellowblood/hocon-js":
+hocon-parser@^1.0.1:
   version "1.0.1"
-  resolved "https://codeload.github.com/yellowblood/hocon-js/tar.gz/3d675ff6ae905f46aadd4834c4748dadb8b5620b"
+  resolved "https://registry.yarnpkg.com/hocon-parser/-/hocon-parser-1.0.1.tgz#b79b66143999b255e08b673c83291b5e363f0b78"
+  integrity sha1-t5tmFDmZslXgi2c8gykbXjY/C3g=
 
 home-or-tmp@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## What does this change?
Users reported that new commisions/projects created in Pluto were not showing in the MAM user interface. On investigation, the `pluto-message-ingestion` lambda is reporting the following error on each invocation:

`"errorType":"Runtime.ImportModuleError","errorMessage":"Error: Cannot find module 'hoconjs/build/hoconjs'`

To potentially resolve this, we can change the way that we install the `hocon-parser` package into the project.

## How to test
Deploy and observe logs?

## How can we measure success?
The `pluto-message-ingestion` is able to correctly handle messages received from Pluto via it's Kinesis integration stream, and logs from the app are not full of `Runtime.ImportModuleError` errors.

## Have we considered potential risks?
n/a

## Images
n/a
