### PR TITLE
Configure bash script options at runtime

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -136,9 +136,7 @@ lazy val app = (project in file("."))
 
     aggregate in run := false,
 
-    javaOptions in Universal ++= Seq(
-      "-Dpidfile.path=/dev/null"
-    ),
+    bashScriptConfigLocation := Some("/etc/gu/media-atom-maker.ini"),
 
     buildInfoKeys := Seq[BuildInfoKey](
       name,


### PR DESCRIPTION
## What does this change?

Instead of adding values to the `application.ini` file as part of the [build](https://www.scala-sbt.org/sbt-native-packager/archetypes/java_app/customize.html?highlight=bash#via-build-sbt), create it at runtime so that properties can be  based on the environment.

The motivating example is wanting a different value of the Java option `-Xmx` for CODE and PROD (since they use different instance sizes). We want to override the default value (apparently 1/4 of the instance memory; confirmed by inspecting the output of `java -XX:+PrintFlagsFinal -version | grep MaxHeapSize`) since it wasn't sufficient for reindexing media atoms i.e. out of memory errors were incurred.

Notes:
- It's possible that you could define static configuration in your build and append dynamic configuration at runtime, but have decided to keep it simple(r) and set everything at runtime.
- The default location of the bash script options file is [`${app_home}/../conf/application.ini`](https://www.scala-sbt.org/sbt-native-packager/archetypes/java_app/customize.html?highlight=bash#configuration-file). I've to decided to override this to aid transparency - the value of `${app_home}` is obtuse
- See [#465](https://github.com/guardian/editorial-tools-platform/pull/465) for corresponding changes to the `UserData` script