### PR TITLE
Set video adformats on all API uploads

### DIFF
--- a/common/src/main/scala/com/gu/media/logging/YoutubeRequestLogger.scala
+++ b/common/src/main/scala/com/gu/media/logging/YoutubeRequestLogger.scala
@@ -36,6 +36,7 @@ object YoutubeRequestType extends Enum[YoutubeRequestType] {
   case object UpdateVideoClaim extends YoutubeRequestType
   case object GetVideoClaim extends YoutubeRequestType
   case object GetVideoAdvertisingOptions extends YoutubeRequestType
+  case object UpdateVideoAdvertisingOptions extends YoutubeRequestType
 
   case object DeleteVideo extends YoutubeRequestType
 

--- a/common/src/main/scala/com/gu/media/youtube/YouTubePartnerApi.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubePartnerApi.scala
@@ -174,6 +174,7 @@ trait YouTubePartnerApi { this: YouTubeAccess with Logging =>
   }
 
   private def updateTheVideoAdvertisingOptions(videoId: String, atomId: String): Either[VideoUpdateError, String] = {
+    // All possible formats can be found on YouTube developer docs: https://developers.google.com/youtube/partner/docs/v1/videoAdvertisingOptions#properties
     val formats: util.List[String] = List("standard_instream","trueview_instream","display").asJava
     val advertisingOption: VideoAdvertisingOption = new VideoAdvertisingOption().setAdFormats(formats)
     try {

--- a/common/src/main/scala/com/gu/media/youtube/YouTubePartnerApi.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubePartnerApi.scala
@@ -190,6 +190,9 @@ trait YouTubePartnerApi { this: YouTubeAccess with Logging =>
 
   def createOrUpdateClaim(atomId: String, videoId: String, blockAds: Boolean): Either[VideoUpdateError, String] = {
     try {
+      if(!blockAds) {
+        updateTheVideoAdvertisingOptions(videoId)
+      }
       getPartnerClaim(videoId) match {
         case Some(claimSnippet) => {
           val claimId = claimSnippet.getId
@@ -202,7 +205,6 @@ trait YouTubePartnerApi { this: YouTubeAccess with Logging =>
           createVideoClaim(atomId, blockAds, videoId)
         }
       }
-      updateTheVideoAdvertisingOptions(videoId)
     }
 
     catch {

--- a/common/src/main/scala/com/gu/media/youtube/YouTubePartnerApi.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubePartnerApi.scala
@@ -174,7 +174,7 @@ trait YouTubePartnerApi { this: YouTubeAccess with Logging =>
   }
 
   private def updateTheVideoAdvertisingOptions(videoId: String, atomId: String): Either[VideoUpdateError, String] = {
-    val formats: util.List[String] = List("trueview_instream", "long", "overlay", "product_listing", "standard_instream", "third_party", "display").asJava
+    val formats: util.List[String] = List("standard_instream","trueview_instream","display").asJava
     val advertisingOption: VideoAdvertisingOption = new VideoAdvertisingOption().setAdFormats(formats)
     try {
       MAMLogger.info(s"About to update video advertising options for ${videoId}",atomId,videoId)


### PR DESCRIPTION
## What does this change?
> YouTube has noted that some of our videos are not serving all the ad formats as they could, notably no pre-roll. This impacts revenue potential - not serving ads means no ad revenue.

We believe that ad formats were previously being applied based on the default settings for our channel, however this no longer appears to be the case. This PR explicitly sets a list of `adFormats` on all videos created or updated, as long as the video has not been flagged specifically to block ads. See [the YouTube developer docs](https://developers.google.com/youtube/partner/docs/v1/videoAdvertisingOptions/update) for more information on the APIs being used.

## How to test
In local or CODE, upload a new video clip that is longer than 30 seconds and publish it. Use the `.../api/youtube/video-info/<youtube-id-here>` endpoint in MAM to see which `adFormats` are applied to the video. Alternatively/additionally, navigate to the YouTube dashboard for the relevant channel and check the monetisation settings for the video. 

## How can we measure success?
Desired ad formats are applied to videos uploaded via the API.

