### PR TITLE
Run dev-nginx setup-app as part of setup script

### DIFF
--- a/docs/01-dev-setup.md
+++ b/docs/01-dev-setup.md
@@ -8,50 +8,20 @@ Ensure you have the following installed:
 - node v10+
 - npm
 - yarn
-- nvm (optional)
+- nvm
+- [dev-nginx](https://github.com/guardian/dev-nginx#installation)
 
-### Other repositories
-You'll also need to checkout these repositories:
-- [dev-nginx](https://github.com/guardian/dev-nginx#nginx-dev-setup)
-
-### Security credentials
 You'll also need Janus credentials to the `media-service` account.
 
-## nginx
-Create a new site config in nginx using [dev-nginx](https://github.com/guardian/dev-nginx#nginx-dev-setup):
+## Local setup 
 
-```bash
-sudo /path/to/dev-nginx/setup-app.rb nginx/nginx-mapping.yml
-```
-
-### server_names_hash_bucket_size
-The nginx `server_names_hash_bucket_size` should be `128`, up from the default of `64`.
-
-Edit `/usr/local/etc/nginx/nginx.conf` setting the `server_names_hash_bucket_size` directive to `128` within the `http` directive.
-
-For example:
-
-```
-http {
-    include mime.types;
-    include sites-enabled/*;
-    client_max_body_size 20m;
-
-    server_names_hash_bucket_size 128;
-
-    default_type  application/octet-stream;
-}
-```
-
-## Config
 We use a shared DEV stack, with a shared config. Fetch it by running:
 
 ```bash
 ./scripts/fetch-dev-config.sh
 ```
 
-## Client side requirements
-Install client side requirements by running:
+Next, setup nginx and install client side requirements by running:
 
 ```bash
 ./scripts/setup.sh

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -21,6 +21,10 @@ install_yarn() {
   fi
 }
 
+setup_nginx() {
+  dev-nginx setup-app ${DIR}/../nginx/nginx-mappings.yml
+}
+
 install_deps_and_build() {
   yarn install
   printf "\n\Compiling Javascript... \n\r\n\r"
@@ -30,6 +34,7 @@ install_deps_and_build() {
 main() {
   check_node_version
   install_yarn
+  setup_nginx
   install_deps_and_build
   printf "\n\rDone.\n\r\n\r"
 }


### PR DESCRIPTION
## What does this change?
Adds the `dev-nginx setup-app` command to the setup script. This makes setup for local development more straightforward, by following a pattern we use in other tools (e.g. [fronts](https://github.com/guardian/facia-tool/blob/2bf277d17f4a500651bb001d57d36a5fa87c349a/scripts/setup.sh#L48), [grid](https://github.com/guardian/grid/blob/86731ccab339bd2a2756cb3f96cd3f0e4e1db6fb/dev/script/setup.sh#L68), [atom-workshop](https://github.com/guardian/atom-workshop/blob/81ab19b64c6fdf315dda05072978b9a92460c8ec/scripts/setup.sh#L18)).

## How to test
Run the setup script and observe that relevant certificates are created.
