### PR TITLE
create new read-only Pluto tab

### DIFF
--- a/app/controllers/PlutoController.scala
+++ b/app/controllers/PlutoController.scala
@@ -3,7 +3,7 @@ package controllers
 import com.gu.media.aws._
 import com.gu.media.Settings
 import com.gu.media.logging.Logging
-import com.gu.media.pluto.PlutoUpsertRequest
+import com.gu.media.pluto.{PlutoCommissionDataStoreException, PlutoUpsertRequest}
 import com.gu.media.upload.PlutoUploadActions
 import com.gu.pandahmac.HMACAuthActions
 import com.gu.media.util.MediaAtomHelpers
@@ -32,9 +32,33 @@ class PlutoController(
     Ok(Json.toJson(plutoCommissions))
   }
 
+  def getCommission(commissionId: String) = APIAuthAction {
+    stores.plutoCommissionStore.getById(commissionId) match {
+      case Some(Right(commission)) => Ok(Json.toJson(commission))
+      case Some(Left(error)) =>
+        log.error(s"failed to get pluto commission with ID $commissionId", error)
+        ServiceUnavailable
+      case None =>
+        log.warn(s"no commission with ID $commissionId")
+        NotFound
+    }
+  }
+
   def getProjectsByCommissionId(id: String) = APIAuthAction {
     val plutoProjects = stores.plutoProjectStore.getByCommissionId(id)
     Ok(Json.toJson(plutoProjects))
+  }
+
+  def getProject(projectId:String) = APIAuthAction {
+    stores.plutoProjectStore.getById(projectId) match {
+      case Some(Right(project)) => Ok(Json.toJson(project))
+      case Some(Left(error)) =>
+        log.error(s"failed to get pluto project with ID $projectId", error)
+        ServiceUnavailable
+      case None =>
+        log.warn(s"no project with ID $projectId")
+        NotFound
+    }
   }
 
   def deleteCommission(id: String) = APIHMACAuthAction {

--- a/common/src/main/scala/com/gu/media/pluto/PlutoCommissionDataStore.scala
+++ b/common/src/main/scala/com/gu/media/pluto/PlutoCommissionDataStore.scala
@@ -13,6 +13,11 @@ case class PlutoCommissionDataStoreException(err: String) extends Exception(err)
 class PlutoCommissionDataStore(aws: DynamoAccess) extends Logging {
   private val table = Table[PlutoCommission](aws.plutoCommissionTableName)
 
+  def getById(commissionId: String): Option[Either[DynamoReadError, PlutoCommission]] = {
+    log.info(s"getting commission $commissionId")
+    Scanamo.exec(aws.dynamoDB)(table.get('id -> commissionId))
+  }
+
   def list(): List[PlutoCommission] = {
     val op = table.scan()
     val results = Scanamo.exec(aws.dynamoDB)(op)

--- a/common/src/main/scala/com/gu/media/pluto/PlutoProjectDataStore.scala
+++ b/common/src/main/scala/com/gu/media/pluto/PlutoProjectDataStore.scala
@@ -20,6 +20,11 @@ class PlutoProjectDataStore(aws: DynamoAccess, plutoCommissionDataStore: PlutoCo
   private val table = Table[PlutoProject](aws.plutoProjectTableName)
   private val commmissionIndex = table.index("commission-index")
 
+  def getById(projectId: String) = {
+    log.info(s"getting project $projectId")
+    Scanamo.exec(aws.dynamoDB)(table.get('id -> projectId))
+  }
+
   def getByCommissionId(commissionId: String): List[PlutoProject] = {
     val op = commmissionIndex.query('commissionId -> commissionId)
 

--- a/conf/routes
+++ b/conf/routes
@@ -17,9 +17,11 @@ PUT     /api/atom/:id/reset-duration-from-active     controllers.Api.resetDurati
 POST    /api/atom/:id/pac-file         controllers.Api.uploadPacFile(id)
 
 GET     /api/pluto/commissions         controllers.PlutoController.getCommissions()
+GET     /api/pluto/commissions/:id     controllers.PlutoController.getCommission(id)
 GET     /api/pluto/commissions/:id/projects  controllers.PlutoController.getProjectsByCommissionId(id)
 DELETE  /api/pluto/commissions/:id     controllers.PlutoController.deleteCommission(id)
 PUT     /api/pluto/projects            controllers.PlutoController.upsertProject()
+GET     /api/pluto/projects/:id        controllers.PlutoController.getProject(id)
 POST    /api/pluto/resend/:id          controllers.PlutoController.resendAtomMessage(id)
 
 # endpoint used by workflow

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -20,6 +20,7 @@ import { WorkflowTab, WorkflowTabPanel } from './tabs/Workflow';
 import { UsageTab, UsageTabPanel } from './tabs/Usage';
 import { TargetingTab, TargetingTabPanel } from './tabs/Targeting';
 import { ManagementTab, ManagementTabPanel } from './tabs/Management';
+import { PlutoTab, PlutoTabPanel } from './tabs/Pluto';
 
 class VideoDisplay extends React.Component {
   constructor(props) {
@@ -223,6 +224,7 @@ class VideoDisplay extends React.Component {
           <UsageTab disabled={videoEditOpen || isCreateMode} />
           <TargetingTab disabled={videoEditOpen || isCreateMode} />
           <ManagementTab disabled={videoEditOpen || isCreateMode} />
+          <PlutoTab disabled={videoEditOpen || isCreateMode} />
         </TabList>
         <FurnitureTabPanel
           editing={editingFurniture}
@@ -302,6 +304,7 @@ class VideoDisplay extends React.Component {
         />
         <TargetingTabPanel video={video} />
         <ManagementTabPanel video={video} updateVideo={this.updateVideo} />
+        <PlutoTabPanel video={video} />
       </Tabs>
     );
   }

--- a/public/video-ui/src/pages/Video/tabs/Pluto.js
+++ b/public/video-ui/src/pages/Video/tabs/Pluto.js
@@ -1,0 +1,58 @@
+import React, {useEffect, useState} from 'react';
+import PropTypes from 'prop-types';
+import { Tab, TabPanel } from 'react-tabs';
+import {getPlutoItemById} from "../../../services/PlutoApi";
+
+export class PlutoTab extends React.Component {
+  static tabsRole = Tab.tabsRole;
+
+  render() {
+    return (
+      <Tab {...this.props}>
+        Pluto
+      </Tab>
+    );
+  }
+}
+
+export class PlutoTabPanel extends React.Component {
+  static tabsRole = TabPanel.tabsRole;
+
+  static propTypes = {
+    video: PropTypes.object.isRequired
+  };
+
+  render() {
+    const { video, updateVideo, ...rest } = this.props;
+
+    return (
+      <TabPanel {...rest}>
+        <div className="form__group">
+
+          <header className="video__detailbox__header">Commission</header>
+          <ReadOnlyPlutoItem id={video.plutoData && video.plutoData.commissionId} itemType="commission" />
+
+          <header className="video__detailbox__header">Project</header>
+          <ReadOnlyPlutoItem id={video.plutoData && video.plutoData.projectId} itemType="project" />
+
+        </div>
+      </TabPanel>
+    );
+  }
+}
+
+const ReadOnlyPlutoItem = ({id, itemType}) => {
+
+  const [ title, setTitle ] = useState(id ? "Loading..." : "")
+
+  if(id) {
+    useEffect(() => {
+      getPlutoItemById(id, itemType).then(data => setTitle(data.title)).catch(e => {
+        const errorMessage = `Failed to lookup ${itemType} with ID '${id}'`;
+        console.error(errorMessage, e);
+        setTitle(errorMessage);
+      })}, [])
+  }
+
+  return <p className="details-list__field">{title}</p>
+}

--- a/public/video-ui/src/services/PlutoApi.js
+++ b/public/video-ui/src/services/PlutoApi.js
@@ -12,6 +12,12 @@ export function getPlutoProjects({commissionId}) {
   });
 }
 
+export function getPlutoItemById(id, itemType) {
+  return pandaReqwest({
+    url: `/api/pluto/${itemType}s/${id}`
+  });
+}
+
 export function getPlutoProjectLink(projectId) {
   // `plutoSources` lifted from flexible-content
   // https://github.com/guardian/flexible-content/blob/master/composer/src/js/controllers/content/video/body-block.js


### PR DESCRIPTION
https://trello.com/c/3mWezqbn/476-facilitate-pluto-upgrade

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Adds a new read-only tab containing Pluto commission and project data. Facilitated by two new endpoints for get commissions and projects by their IDs...

- `GET` `/api/pluto/commissions/:id`
- `GET` `/api/pluto/projects/:id`

We decided not to use Redux during the retrieval of these values, and instead used the methods directly from a nice functional component with hooks... to keep things simple mainly.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Open any video in MAM and click the 'Pluto' tab. Observe that the fields populate, if the atom has Pluto data. If there is no data, you can edit the video and select a Commission and Project. Block the call to retrieve the Pluto data in the browser and observe that a useful error message is displayed instead, e.g. 

![Screenshot 2020-10-16 at 14 10 06](https://user-images.githubusercontent.com/12645938/96262153-5129ea80-0fb9-11eb-80cb-6ead85875a5b.png)

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->


## Images

![Screenshot 2020-10-16 at 14 05 35](https://user-images.githubusercontent.com/12645938/96261716-b3362000-0fb8-11eb-8eea-201bac8c95e4.png)
