### PR TITLE
prevent commissions/projects with old style IDs from being selectable

### DIFF
--- a/common/src/main/scala/com/gu/media/pluto/PlutoCommissionDataStore.scala
+++ b/common/src/main/scala/com/gu/media/pluto/PlutoCommissionDataStore.scala
@@ -3,6 +3,7 @@ package com.gu.media.pluto
 import com.amazonaws.services.dynamodbv2.model.DeleteItemResult
 import com.gu.media.aws.DynamoAccess
 import com.gu.media.logging.Logging
+import com.gu.media.pluto.PlutoItem.numericIdsOnlyFilter
 import org.scanamo.error.DynamoReadError
 import org.scanamo.syntax._
 import org.scanamo.{Scanamo, Table}
@@ -28,7 +29,7 @@ class PlutoCommissionDataStore(aws: DynamoAccess) extends Logging {
         throw PlutoCommissionDataStoreException(error.toString)
       case Right(commission) =>
         commission
-    }.sortBy(_.title)
+    }.filter(numericIdsOnlyFilter).sortBy(_.title)
   }
 
   def upsert(plutoUpsertRequest: PlutoUpsertRequest): Option[Either[DynamoReadError, PlutoCommission]] = {

--- a/common/src/main/scala/com/gu/media/pluto/PlutoProject.scala
+++ b/common/src/main/scala/com/gu/media/pluto/PlutoProject.scala
@@ -5,10 +5,18 @@ import org.joda.time.DateTime
 import play.api.libs.json._
 import com.gu.media.util.JsonDate._
 
+sealed trait PlutoItem {
+  val id: String
+}
+
+object PlutoItem {
+  def numericIdsOnlyFilter(item: PlutoItem): Boolean = item.id.matches("[0-9]+")
+}
+
 case class PlutoCommission (
   id: String,
   title: String
-)
+) extends PlutoItem
 
 object PlutoCommission {
   implicit val format: Format[PlutoCommission] = Jsonx.formatCaseClass[PlutoCommission]
@@ -28,7 +36,7 @@ case class PlutoProject (
   commissionId: String,
   commissionTitle: String, //TODO remove this once migrated
   productionOffice: String
-)
+) extends PlutoItem
 
 object PlutoProject {
   implicit val format: Format[PlutoProject] = Jsonx.formatCaseClass[PlutoProject]

--- a/common/src/main/scala/com/gu/media/pluto/PlutoProjectDataStore.scala
+++ b/common/src/main/scala/com/gu/media/pluto/PlutoProjectDataStore.scala
@@ -4,11 +4,10 @@ import com.amazonaws.services.dynamodbv2.model.DeleteItemResult
 import com.gu.media.aws.DynamoAccess
 import com.gu.media.logging.Logging
 import com.gu.media.pluto.PlutoItem.numericIdsOnlyFilter
-import org.scanamo.{Scanamo, Table}
-import org.scanamo.DynamoFormat.{enumDynamoFormatCNil, _}
-import org.scanamo.DynamoFormat
-import org.scanamo.syntax._
 import org.joda.time.{DateTime, DateTimeZone}
+import org.scanamo.DynamoFormat._
+import org.scanamo.syntax._
+import org.scanamo.{DynamoFormat, Scanamo, Table}
 import org.scanamo.auto._
 
 case class PlutoProjectDataStoreException(err: String) extends Exception(err)

--- a/common/src/main/scala/com/gu/media/pluto/PlutoProjectDataStore.scala
+++ b/common/src/main/scala/com/gu/media/pluto/PlutoProjectDataStore.scala
@@ -3,8 +3,9 @@ package com.gu.media.pluto
 import com.amazonaws.services.dynamodbv2.model.DeleteItemResult
 import com.gu.media.aws.DynamoAccess
 import com.gu.media.logging.Logging
+import com.gu.media.pluto.PlutoItem.numericIdsOnlyFilter
 import org.scanamo.{Scanamo, Table}
-import org.scanamo.DynamoFormat._
+import org.scanamo.DynamoFormat.{enumDynamoFormatCNil, _}
 import org.scanamo.DynamoFormat
 import org.scanamo.syntax._
 import org.joda.time.{DateTime, DateTimeZone}
@@ -36,7 +37,7 @@ class PlutoProjectDataStore(aws: DynamoAccess, plutoCommissionDataStore: PlutoCo
         throw PlutoProjectDataStoreException(error.toString)
       case Right(plutoProject) =>
         plutoProject
-    }.sortBy(_.title)
+    }.filter(numericIdsOnlyFilter).sortBy(_.title)
   }
 
   def upsert(plutoUpsertRequest: PlutoUpsertRequest): PlutoProject = {

--- a/common/src/test/scala/com/gu/media/pluto/PlutoItemTest.scala
+++ b/common/src/test/scala/com/gu/media/pluto/PlutoItemTest.scala
@@ -1,0 +1,25 @@
+package com.gu.media.pluto
+
+import com.gu.media.pluto.PlutoItem.numericIdsOnlyFilter
+import org.scalatest.{FunSuite, ShouldMatchers}
+
+class PlutoItemTest extends FunSuite with ShouldMatchers {
+
+  test("numericIdsOnlyFilter must filter out items with non-numeric IDs") {
+    val numericItems = List(
+      PlutoCommission("12345",""),
+      PlutoCommission("67890",""),
+      PlutoCommission("0","")
+    )
+    val nonNumericItems = List(
+      PlutoCommission("KP-12345678",""),
+      PlutoCommission("DR-12345678",""),
+      PlutoCommission("asfsdfsds",""),
+      PlutoCommission("","")
+    )
+    val result = (nonNumericItems ++ numericItems).filter(numericIdsOnlyFilter)
+    result shouldBe numericItems
+    result shouldNot be(nonNumericItems)
+  }
+
+}

--- a/public/video-ui/src/components/FormFields/SelectBox.js
+++ b/public/video-ui/src/components/FormFields/SelectBox.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+const pleaseSelect = "Please select..."
+
 export default class SelectBox extends React.Component {
   getClassName = () => {
     return (
@@ -12,19 +14,20 @@ export default class SelectBox extends React.Component {
     if (this.props.displayDefault || !this.props.fieldValue) {
       return (
         <option value={null}>
-          {this.props.defaultOption || 'Please select...'}
+          {this.props.defaultOption || pleaseSelect}
         </option>
       );
     }
   };
 
   renderField = () => {
+    const matchingValues = this.props.selectValues.filter(
+      fieldValue =>
+        this.props.fieldValue &&
+        fieldValue.id.toString() === this.props.fieldValue.toString()
+    );
+
     if (!this.props.editable) {
-      const matchingValues = this.props.selectValues.filter(
-        fieldValue =>
-          this.props.fieldValue &&
-          fieldValue.id.toString() === this.props.fieldValue.toString()
-      );
 
       const displayValue = matchingValues.length
         ? matchingValues[0].title
@@ -65,7 +68,11 @@ export default class SelectBox extends React.Component {
             this.props.onUpdateField(e.target.value);
           }}
         >
-
+          {this.props.fieldValue && matchingValues.length===0 && (
+            <option value={this.props.fieldValue.id} key={this.props.fieldValue.id}>
+              {pleaseSelect}
+            </option>
+          )}
           {this.renderDefaultOption()}
           {this.props.selectValues.map(function (value) {
             return (


### PR DESCRIPTION
https://trello.com/c/3mWezqbn/476-facilitate-pluto-upgrade

Following https://github.com/guardian/media-atom-maker/pull/963 MAM now displays the commission and project in a new (read-only) Pluto tab (where the information is looked up directly by ID - regardless of new/old style IDs).

## What does this change?
This PR simply limits the selectable commissions/projects in the edit mode, to be the new style (numeric) IDs.

## How to test
After Pluto upgrade projects/commissions with old-style IDs should no longer be selectable in the 'Edit' mode of MAM (because they're no longer returned by the API, due to server-side filtering using the unit-tested `numericIdsOnlyFilter` function).

## How can we measure success?
New videos can only be assigned to new Pluto commissions/projects... which is the desired behaviour after the upgrade. Success is 'facilitating the Pluto upgrade'.

## Have we considered potential risks?
This PR was intentionally separated from https://github.com/guardian/media-atom-maker/pull/963 to make it as small possible, such that it can be merged and rolled back directly by the Pluto team (if needs be).

## Images
N/A