### PR TITLE
add pluto link button to the "Pluto" tab

### DIFF
--- a/public/video-ui/src/pages/Video/tabs/Pluto.js
+++ b/public/video-ui/src/pages/Video/tabs/Pluto.js
@@ -30,9 +30,8 @@ export class PlutoTabPanel extends React.Component {
       <TabPanel {...rest}>
         <div className="form__group">
           {
-            video.plutoData ?
-              <PlutoProjectLink projectId={video.plutoData.projectId}/> :
-              null
+            video.plutoData &&
+              <PlutoProjectLink projectId={video.plutoData.projectId}/>
           }
 
           <header className="video__detailbox__header">Commission</header>

--- a/public/video-ui/src/pages/Video/tabs/Pluto.js
+++ b/public/video-ui/src/pages/Video/tabs/Pluto.js
@@ -2,6 +2,7 @@ import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import { Tab, TabPanel } from 'react-tabs';
 import {getPlutoItemById} from "../../../services/PlutoApi";
+import PlutoProjectLink from "../../../components/Pluto/PlutoProjectLink";
 
 export class PlutoTab extends React.Component {
   static tabsRole = Tab.tabsRole;
@@ -28,6 +29,11 @@ export class PlutoTabPanel extends React.Component {
     return (
       <TabPanel {...rest}>
         <div className="form__group">
+          {
+            video.plutoData ?
+              <PlutoProjectLink projectId={video.plutoData.projectId}/> :
+              null
+          }
 
           <header className="video__detailbox__header">Commission</header>
           <ReadOnlyPlutoItem id={video.plutoData && video.plutoData.commissionId} itemType="commission" />

--- a/public/video-ui/src/services/PlutoApi.js
+++ b/public/video-ui/src/services/PlutoApi.js
@@ -18,19 +18,12 @@ export function getPlutoItemById(id, itemType) {
   });
 }
 
+/**
+ * return a link to the given pluto project as a string.
+ * since we have changed the form of the pluto ID, we can't now detect which environment the item is from
+ * based on the ID so this is a static string for the time being.  Needs some thought about how to support prod/dev in future.
+ * @param projectId
+ */
 export function getPlutoProjectLink(projectId) {
-  // `plutoSources` lifted from flexible-content
-  // https://github.com/guardian/flexible-content/blob/master/composer/src/js/controllers/content/video/body-block.js
-  const plutoDev = { prefix: 'VX-', domain: 'pluto-dev' };
-
-  const plutoSources = [
-    { prefix: 'KP-', domain: 'pluto' },
-    { prefix: 'BK-', domain: 'pluto-dr' },
-    plutoDev
-  ];
-
-  const plutoSource = plutoSources.find(source => projectId.startsWith(source.prefix)) || plutoDev;
-
-  // pluto isn't accessible over https
-  return `http://${plutoSource.domain}/project/${projectId}`;
+  return `https://pluto.gnm.int/pluto-core/project/${projectId}`
 }


### PR DESCRIPTION
## What does this change?
- Remove the deprecated environment-detection logic for Pluto as it does not work any more (switched to plain numeric IDs)
- Add the "link to pluto" button to the Pluto tab in the main window

## How to test
Go to a "new style" project (i.e. one since Mon 19th Oct 2020) and check the URL when you hover over the "link to pluto" button. It should direct you to `https://pluto.gnm.int/pluto-core/project/{project-id}`

## How can we measure success?
You can successfully navigate to your edit project from your media atom

## Have we considered potential risks?
No risks, it's a bug fix

