### PR TITLE
Fix defaultMediaHtml

### DIFF
--- a/common/src/main/scala/com/gu/media/util/MediaAtomImplicits.scala
+++ b/common/src/main/scala/com/gu/media/util/MediaAtomImplicits.scala
@@ -33,7 +33,7 @@ trait MediaAtomImplicits extends AtomImplicits[MediaAtom] {
       case (Some(SelfHostedAsset(sources)), poster) => {
         s"""
            |<video controls="controls" preload="metadata" ${if (poster.isDefined) s"""poster="${poster.get}""""}>
-           | ${sources.map(s => s"""<source type="${s.mimeType}" src="${s.src}"/>""")}
+           | ${sources.map(s => s"""<source type="${s.mimeType}" src="${s.src}"/>""").mkString}
            |</video>
         """.stripMargin
       }


### PR DESCRIPTION
## What does this change?

Fix a problem in `defaultMediaHtml` by which the list wasn't converted into a string before returning. This was only noticed because of the following output in the data coming from CAPI.

![unnamed](https://user-images.githubusercontent.com/6035518/98563819-89b0a180-22a3-11eb-8392-dec87075df78.jpg)

In browsers that don't support HTML5 video, it would come out like this:

![unnamed-1](https://user-images.githubusercontent.com/6035518/98564208-ff1c7200-22a3-11eb-9653-0a186a8e64cb.jpg)

