### PR TITLE
TEMPORARY: tolerate the thumbnail update failing with generic UI warning

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -276,9 +276,14 @@ case class PublishAtomCommand(
           case _ => thumbnailGenerator.getBrandedThumbnail(image, atom.id)
         }
 
-        val thumbnailUpdate = youtube.updateThumbnail(asset.id, thumbnail)
+        try {
+          val thumbnailUpdate = youtube.updateThumbnail(asset.id, thumbnail)
 
-        handleYouTubeMessages(thumbnailUpdate, "YouTube Thumbnail Update", atom, asset.id)
+          handleYouTubeMessages(thumbnailUpdate, "YouTube Thumbnail Update", atom, asset.id)
+        }
+        catch {
+          case _: Throwable => atom // if any problems updating thumbnail, don't prevent publish just return previous state
+        }
       }
       case None => atom
     }

--- a/public/video-ui/src/components/VideoImages/VideoImages.js
+++ b/public/video-ui/src/components/VideoImages/VideoImages.js
@@ -10,7 +10,8 @@ export default class VideoImages extends React.Component {
     video: PropTypes.object.isRequired,
     saveAndUpdateVideo: PropTypes.func.isRequired,
     videoEditOpen: PropTypes.bool.isRequired,
-    updateErrors: PropTypes.func.isRequired
+    updateErrors: PropTypes.func.isRequired,
+    youtubeAsset: PropTypes.object
   };
 
   saveAndUpdateVideoImage = (image, location) => {
@@ -53,6 +54,10 @@ export default class VideoImages extends React.Component {
             />
           </div>
           <GridImage image={this.props.video.posterImage} />
+          {this.props.youtubeAsset && <>
+            WARNING: due to a YouTube bug, thumbnails are sometimes failing to save correctly. So please double check and update manually{" "}
+            <a href={`https://studio.youtube.com/video/${this.props.youtubeAsset.id}/edit`} target="_blank" rel="noopener">here</a>
+          </>}
         </div>
         <div className="video__detailbox">
           <div className="video__detailbox__header__container">

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -88,7 +88,7 @@ class VideoDisplay extends React.Component {
     );
   };
 
-  renderImages() {
+  renderImages(youtubeAsset) {
     return (
       <VideoImages
         gridDomain={this.props.config.gridUrl}
@@ -96,6 +96,7 @@ class VideoDisplay extends React.Component {
         saveAndUpdateVideo={this.saveAndUpdateVideo}
         videoEditOpen={this.props.videoEditOpen}
         updateErrors={this.props.formErrorActions.updateFormErrors}
+        youtubeAsset={youtubeAsset}
       />
     );
   }
@@ -123,7 +124,7 @@ class VideoDisplay extends React.Component {
         </div>
         <div className="video-preview">
           {this.renderPreview()}
-          {this.renderImages()}
+          {this.renderImages(youtubeAsset)}
         </div>
       </div>
     );


### PR DESCRIPTION
Co-authored-by: @jennygrahamjones 

## Context
Much like https://issuetracker.google.com/issues/175959405 we've been experiencing 403s when trying to update the thumbnails on live (or previously live) YouTube videos. Previously the thumbnail updates are a critical part of the process and this was blocking publishing.

## What does this change?
We now catch and log the exception but allow the publish to complete. We present a generic warning in the UI with a link to update the thumbnail manually...
![image](https://user-images.githubusercontent.com/19289579/102807400-791d3c00-43b6-11eb-85e1-0dc6a05d22a1.png)


## How to test
With this deployed to CODE, update a thumbnail on a live (or previously live) YouTube video (e.g. https://video.code.dev-gutools.co.uk/videos/7d417a50-3df4-4db0-8ac8-325abd812fc6) and observe the `Failed to update thumbnail` in logs.gutools.co.uk

## How can we measure success?
Video team can publish live video atoms (albeit having to update thumbnails manually).

## Have we considered potential risks?
The thumbnail auto-selected by google might be undesirable until it is updated manually (likely only CP and/or devs will be able to update manually).
