### PR TITLE
handle null responses when listing YouTube 'partner claims'

### DIFF
--- a/common/src/main/scala/com/gu/media/youtube/YouTubePartnerApi.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubePartnerApi.scala
@@ -153,7 +153,7 @@ trait YouTubePartnerApi { this: YouTubeAccess with Logging =>
     }
   }
 
-  private def getPartnerClaim(videoId: String): Option[ClaimSnippet] = {
+  private def getPartnerClaim(atomId: String, videoId: String): Option[ClaimSnippet] = {
     val request = partnerClient
       .claimSearch()
       .list
@@ -165,7 +165,11 @@ trait YouTubePartnerApi { this: YouTubeAccess with Logging =>
     YoutubeRequestLogger.logRequest(YoutubeApiType.PartnerApi, YoutubeRequestType.GetVideoClaim)
     val response = request.execute()
 
-    if (response.getPageInfo.getTotalResults == 0) {
+    if(response == null || response.getPageInfo == null || response.getPageInfo.getTotalResults == null || response.getItems == null) {
+      MAMLogger.error(s"null response when trying to list partner claims. response = ${response}", atomId, videoId)
+      None
+    }
+    else if (response.getPageInfo.getTotalResults == 0) {
       None
     } else {
       response.getItems.asScala.toList.headOption
@@ -204,7 +208,7 @@ trait YouTubePartnerApi { this: YouTubeAccess with Logging =>
       if(!adSettings.blockAds) {
         updateTheVideoAdvertisingOptions(videoId, atomId, adSettings.enableMidroll)
       }
-      getPartnerClaim(videoId) match {
+      getPartnerClaim(atomId, videoId) match {
         case Some(claimSnippet) => {
           val claimId = claimSnippet.getId
           val assetId = claimSnippet.getAssetId


### PR DESCRIPTION
Occasionally users were getting an error when deleting an atom...
![image](https://user-images.githubusercontent.com/19289579/110515527-6508f100-8100-11eb-8b43-bdc015da6d98.png)
... the logs revealed this was due to null responses when trying to list 'partner claims' (YouTube API).

## What does this change?
This PR first checks for null on both the response itself but also all the fields that will be used and returns None, much like if the response had been fully formed but was an empty list.

## How to test
I guess one could try to use a problematic you tube video (for example the one from https://video.gutools.co.uk/videos/b9aca7f6-181d-4ae4-a043-ba04d74492bc) and create a new atom, then attempt to delete.
