### PR TITLE
chore(ci): observe the .nvmrc files to build in the correct environment

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.5")
 

--- a/teamcity.sh
+++ b/teamcity.sh
@@ -2,37 +2,51 @@
 
 set -e
 
-install_yarn() {
-  npm install -g yarn
+setupNvm() {
+  export NVM_DIR="$HOME/.nvm"
+  if [ -s "$NVM_DIR/nvm.sh" ]; then
+    # This loads nvm if installed directly
+    source "$NVM_DIR/nvm.sh"
+  elif [ -s "$(brew --prefix nvm)/nvm.sh" ]; then
+    # This will load nvm if installed via brew
+    source "$(brew --prefix nvm)/nvm.sh"
+  else
+    echo "Can't find NVM"
+    exit 1
+  fi
 }
 
-js_pluto_lambda(){
+buildPlutoLambda(){
   pushd pluto-message-ingestion
-  yarn install
-  yarn run build
+
+  # The pluto lambda uses a different version of node from main app.
+  # Change node versions and install yarn
+  # TODO use the same node version throughout the repo
+  nvm install
+  nvm use
+  npm install -g yarn
+
+  yarn
+  yarn build
   popd
 }
 
-js_deps() {
-  yarn install --force --non-interactive
-}
+buildApp() {
+  nvm install
+  nvm use
+  npm install -g yarn
 
-js_test() {
+  yarn install --force --non-interactive
   yarn lint
   yarn test
-}
-
-js_build() {
   yarn run build-autotrack
   yarn run build
 }
 
 main() {
-  install_yarn
-  js_pluto_lambda
-  js_deps
-  js_test
-  js_build
+  setupNvm
+  buildPlutoLambda
+  buildApp
 }
 
 main

--- a/teamcity.sh
+++ b/teamcity.sh
@@ -17,6 +17,7 @@ setupNvm() {
 }
 
 buildPlutoLambda(){
+  echo "##teamcity[compilationStarted compiler='pluto-lambda']"
   pushd pluto-message-ingestion
 
   # The pluto lambda uses a different version of node from main app.
@@ -29,9 +30,11 @@ buildPlutoLambda(){
   yarn
   yarn build
   popd
+  echo "##teamcity[compilationFinished compiler='pluto-lambda']"
 }
 
-buildApp() {
+buildJsApp() {
+  echo "##teamcity[compilationStarted compiler='js-app']"
   nvm install
   nvm use
   npm install -g yarn
@@ -41,12 +44,20 @@ buildApp() {
   yarn test
   yarn run build-autotrack
   yarn run build
+  echo "##teamcity[compilationFinished compiler='js-app']"
+}
+
+buildScalaApp() {
+  echo "##teamcity[compilationStarted compiler='sbt']"
+  sbt clean compile test riffRaffUpload
+  echo "##teamcity[compilationFinished compiler='sbt']"
 }
 
 main() {
   setupNvm
   buildPlutoLambda
-  buildApp
+  buildJsApp
+  buildScalaApp
 }
 
 main


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The continuous deployment of #977 partially failed - the [`pluto-message-ingestion`](https://github.com/guardian/media-atom-maker/blob/141babc65d37c7a8adbb0536cafcf3732940c948/conf/riff-raff.yaml#L34) deploy failed as the artefact couldn't be found. It looks like the artefact just wasn't produced by TeamCity. This is worrying as the build was green!

Previously, the build steps were:
1. Use node 10
2. Run `teamcity.sh` to do JS tasks
3. Perform sbt tasks using TeamCity's sbt runner

![image](https://user-images.githubusercontent.com/836140/110633481-b799ea00-81a0-11eb-99ab-19cdbe0d7a3f.png)

This is undesired for a few reasons:
1. The pluto lambda uses node 8, but was always being built in node 10.
2. TeamCity's sbt runner doesn't report errors properly. In some scenarios it exits 0 when there was an error!

This change updates the build configuration to only run `teamcity.sh`. This script now:
1. Observes the `.nvmrc` file per JS project
2. Performs the JS tasks
3. Performs the sbt tasks

As the script does a lot of things now, we're wrapping each sub task in magic TeamCity strings which results in grouped output that's easier to follow (I forget what this feature is actually called, sorry!).

![image](https://user-images.githubusercontent.com/836140/110634311-bb7a3c00-81a1-11eb-8921-04cc8c195862.png)

We're also bumping the version of `sbt-riffraff-artifact` as the build numbers were coming through as "unknown" rather than the TeamCity build number.

### Notes

This work has raised a few other questions that can be answered in future PRs:
- Why are we using different node versions?
- The pluto lambda was developed against node 8, built against node 10 and is run in a node 12 lambda. Why?!

I think we should move everything to the latest LTS version of node (14.15.5) for simplicity. However, the pluto lambda doesn't build in node 14, so we should do this work in a different PR.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Observe CI and its output in RiffRaff using the "preview files" feature.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

The build is deterministic and reproducible locally as one can simply run `./teamcity.sh`.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

n/a