### PR TITLE
better handle null responses when listing YouTube 'partner claims'

### DIFF
--- a/common/src/main/scala/com/gu/media/youtube/YouTubePartnerApi.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubePartnerApi.scala
@@ -165,14 +165,19 @@ trait YouTubePartnerApi { this: YouTubeAccess with Logging =>
     YoutubeRequestLogger.logRequest(YoutubeApiType.PartnerApi, YoutubeRequestType.GetVideoClaim)
     val response = request.execute()
 
-    if(response == null || response.getPageInfo == null || response.getPageInfo.getTotalResults == null || response.getItems == null) {
+    if(response == null) {
       MAMLogger.error(s"null response when trying to list partner claims. response = ${response}", atomId, videoId)
       None
     }
-    else if (response.getPageInfo.getTotalResults == 0) {
-      None
-    } else {
+    else if (response.getItems != null){
       response.getItems.asScala.toList.headOption
+    }
+    else if (response.getPageInfo != null && response.getPageInfo.getTotalResults == 0) {
+      None
+    }
+    else {
+      MAMLogger.error(s"part of response was null when trying to list partner claims. response = ${response}", atomId, videoId)
+      None
     }
   }
 


### PR DESCRIPTION
A slight tweak to https://github.com/guardian/media-atom-maker/pull/978 now that we've seen some log entries that show the response itself is not null, but in certain instances* doesn't include the `pageInfo` property and so we still want to avoid the original `NullPointerException` but we first check if there are `items` and check those... which I think is the more reliable behaviour.

\* youtube may have made a permanent _breaking_ change to their API 