### PR TITLE
feat: never disable the channel selection box

### DIFF
--- a/public/video-ui/src/components/YoutubeFurniture/index.js
+++ b/public/video-ui/src/components/YoutubeFurniture/index.js
@@ -96,7 +96,6 @@ class YoutubeFurniture extends React.Component {
     const availableChannels = VideoUtils.getAvailableChannels(video);
     const availablePrivacyStates = VideoUtils.getAvailablePrivacyStates(video);
     const hasYoutubeWriteAccess = VideoUtils.hasYoutubeWriteAccess(video);
-    const hasAssets = VideoUtils.hasAssets(video);
 
     return (
       <ManagedForm
@@ -108,7 +107,7 @@ class YoutubeFurniture extends React.Component {
         formName={formNames.youtubeFurniture}
         formClass="atom__edit__form"
       >
-        <ManagedField fieldLocation="channelId" name="Channel" disabled={hasAssets}>
+        <ManagedField fieldLocation="channelId" name="Channel">
           <SelectBox selectValues={availableChannels} />
         </ManagedField>
         <ManagedField


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We've had a few reports around YouTube channel selection. Namely, in some scenarios we end up with an Atom without a YouTube channel unexpectedly.

This change lifts the editing restrictions on this field - you can now edit the channel at any time.

I'm not sure if this is the correct thing to do as the restriction was added for a reason, though I'm struggling to find a PR that explains this rule. My memory thinks one reason is we don't want to be in a position where we upload a video to channel A, switch channels, then upload an edited version of the video to channel B. Need to confirm with the video team.

I think we'd want to introduce tests against the [problematic code](https://github.com/guardian/media-atom-maker/blob/ad2bb4aa44a04847a3ac1de71f77d87fe8941f2c/app/model/commands/AddAssetCommand.scala#L66-L115) as a better solution to these user reports too... I'll let you be the judge!

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy to CODE
- Create an atom
- Set the channel
- Upload a video
- Observe the channel can be changed

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Empowering our users!

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

See above concerns.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

n/a