### PR TITLE
also allow channel selection when its currently null

### DIFF
--- a/public/video-ui/src/components/YoutubeFurniture/index.js
+++ b/public/video-ui/src/components/YoutubeFurniture/index.js
@@ -96,7 +96,7 @@ class YoutubeFurniture extends React.Component {
     const availableChannels = VideoUtils.getAvailableChannels(video);
     const availablePrivacyStates = VideoUtils.getAvailablePrivacyStates(video);
     const hasYoutubeWriteAccess = VideoUtils.hasYoutubeWriteAccess(video);
-    const hasAssets = VideoUtils.hasAssets(video);
+    const isChannelSelectionDisabled = VideoUtils.hasAssets(video) && video.channelId;
 
     return (
       <ManagedForm
@@ -108,7 +108,7 @@ class YoutubeFurniture extends React.Component {
         formName={formNames.youtubeFurniture}
         formClass="atom__edit__form"
       >
-        <ManagedField fieldLocation="channelId" name="Channel" disabled={hasAssets}>
+        <ManagedField fieldLocation="channelId" name="Channel" disabled={isChannelSelectionDisabled}>
           <SelectBox selectValues={availableChannels} />
         </ManagedField>
         <ManagedField


### PR DESCRIPTION
A slight variant of https://github.com/guardian/media-atom-maker/pull/981 (which was closed in favour of this PR) which instead allows channel selection when channel is null or when there are no assets (as before) but not ALL the time. This PR seeks to unblock users whilst also trying to limit some of the risk outlined in https://github.com/guardian/media-atom-maker/pull/981.