### PR TITLE
Add additional logging when updating youtube metadata

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -249,7 +249,7 @@ case class PublishAtomCommand(
       asset.id,
       if (previewAtom.blockAds) metadata.withoutContentBundleTags() else metadata.withContentBundleTags() // content bundle tags only needed on monetized videos
     )
-
+    log.info(s"updateYoutubeMetadata: update complete, result: ${youTubeMetadataUpdate}")
     handleYouTubeMessages(youTubeMetadataUpdate, "YouTube Metadata Update", previewAtom, asset.id)
   }
 

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -78,7 +78,7 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
 
               YoutubeRequestLogger.logRequest(YoutubeApiType.DataApi, YoutubeRequestType.UpdateVideoMetadata)
               request.execute()
-
+              log.info(s"Youtube video updated: ${video.getId}")
               Right(prettyMetadata)
             }
             catch {


### PR DESCRIPTION
## What does this change?

Adds additional logging to confirm when we've successfully handed an update to the Youtube metadata API.

We have situations where updates take a very long time to appear, or don't appear at all – this should help us clarify whether the problem is on our side, or Youtube's.

## How to test

Update a Youtube field in the MAM UI on e.g. CODE. Do the log messages appear as expected once the update is complete?