### PR TITLE
Removes bintray resolver and changes panda-hmac to panda-hmac-play

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ import play.sbt.PlayImport
 val scroogeVersion = "4.12.0"
 val awsVersion = "1.11.125"
 val pandaVersion = "0.5.1"
-val pandaHmacVersion = "1.2.0"
+val pandaHmacVersion = "1.2.2"
 val atomMakerVersion = "1.2.2"
 val slf4jVersion = "1.7.21"
 val typesafeConfigVersion = "1.3.0" // to match what we get from Play transitively
@@ -56,7 +56,7 @@ lazy val commonSettings = Seq(
   scalaVersion in ThisBuild := "2.11.8",
   organization in ThisBuild := "com.gu",
 
-  resolvers ++= Seq("Guardian Bintray" at "https://dl.bintray.com/guardian/editorial-tools",
+  resolvers ++= Seq(
     "Sonatype OSS" at "http://oss.sonatype.org/content/repositories/releases/",
     "Sonatype OSS Snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
   ),
@@ -80,7 +80,7 @@ lazy val common = (project in file("common"))
       "com.gu" %% "pan-domain-auth-play_2-5" % pandaVersion,
       "com.gu" %% "pan-domain-auth-verification" % pandaVersion,
       "com.gu" %% "pan-domain-auth-core" % pandaVersion,
-      "com.gu" %% "panda-hmac" % pandaHmacVersion,
+      "com.gu" %% "panda-hmac-play_2-5" % pandaHmacVersion,
       PlayImport.ws,
       "com.gu" %% "atom-publisher-lib" % atomMakerVersion,
       "com.gu" %% "atom-publisher-lib" % atomMakerVersion % "test" classifier "tests",


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR removes the bintray resolver ahead of the end of service. The only change required was to use the Maven version of `panda-hmac` which I believe is `panda-hmac-play`: https://search.maven.org/search?q=panda-hmac

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Does the project compile and work as expected?