### PR TITLE
Stop just targeting to commissioning desks

### DIFF
--- a/public/video-ui/src/components/Targeting/Targeting.js
+++ b/public/video-ui/src/components/Targeting/Targeting.js
@@ -85,7 +85,7 @@ class Targeting extends React.Component {
                       fieldLocation="tagPaths"
                       name="Targeting tags"
                       formRowClass="form__row__byline"
-                      tagType={TagTypes.tracking}
+                      tagType={TagTypes.keyword}
                       isDesired={false}
                       isRequired={false}
                       inputPlaceholder="Target these tags (type '*' to show all)"


### PR DESCRIPTION
Change the tag type for the picker to keyword to allow video targeting.