### PR TITLE
Send requested scheduled launch value when creating in composer

### DIFF
--- a/public/video-ui/src/util/getComposerData.js
+++ b/public/video-ui/src/util/getComposerData.js
@@ -32,6 +32,7 @@ export function getComposerData(video) {
       : null,
     expiryDate: expiryDate,
     scheduledLaunch: scheduledLaunch,
+    requestedScheduledLaunch: scheduledLaunch,
     embargoedUntil: embargoedUntil,
     embargoedIndefinitely: isEmbargoedIndefinitely
   };


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds the `requestedScheduledDate` to the Composer integration payload. It will mean this value gets set when a linked Composer piece is created or updated.

[Trello card
](https://trello.com/c/trbgrwxk/2323-mam-video-schedule-launch-issue)
## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
It would be best to test this with the corresponding [Composer PR](https://github.com/guardian/flexible-content/pull/3829), on CODE. It can be tested by creating an atom, filling out the necessary fields, scheduling the atom for release, creating a linked composer article, opening the article in composer.  The article should show the scheduled launch date, correctly set and not removed.

