### PR TITLE
Moved Xenial AMI to Bionic as it is no longer supported

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -12,7 +12,7 @@ deployments:
       app: media-atom-maker
       parameters:
         amiTags:
-          Recipe: editorial-tools-xenial-java8
+          Recipe: editorial-tools-bionic-java8
           AmigoStage: PROD
   media-atom-maker:
     type: autoscaling


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Moves AMI from Xenial to Bionic because Xenial is no longer supported.

Related card [here](https://trello.com/c/NLpikw2C/2330-update-xenial-amis-to-use-bionic).

## Has this been successfully deployed yet?

Yes - [here](https://riffraff.gutools.co.uk/deployment/view/7ccc0d16-8a59-46aa-aa81-6b662961c6cf). CODE worked as intended.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Deploy to [CODE](https://video.code.dev-gutools.co.uk/videos) via RiffRaff (it's under `media-service:media-atom-maker`), and ensure it deploys and runs correctly.