### PR TITLE
Wrap thumbnail in try/catch to prevent publication failures

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -176,7 +176,14 @@ case class PublishAtomCommand(
           createOrUpdateYoutubeClaim(publishedAtom, previewAtom, asset)
         }
         updateYoutubeMetadata(previewAtom, asset)
-        updateYoutubeThumbnail(previewAtom, asset)
+        try {
+          updateYoutubeThumbnail(previewAtom, asset)
+        } catch {
+          case e: Throwable => {
+            log.error("Error updating Youtube thumbnail", e)
+            Future.successful(previewAtom)
+          }
+        }
 
       case Some(_) =>
         // third party YouTube video that we do not have permission to edit


### PR DESCRIPTION
## What does this change?

We've got a problem where our thumbnail uploading is failing at the moment. This could be a problem with Youtube, but in the meantime, we have videos to publish.

This PR wraps our publication thumbnail-changing code in a try-catch to ensure a failure here doesn't block publication.

## How to test

Deploy and see if publication works. Any thumbnail-related errors should be logged.
