### PR TITLE
Revert "Wrap thumbnail in try/catch to prevent publication failures"

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -176,14 +176,7 @@ case class PublishAtomCommand(
           createOrUpdateYoutubeClaim(publishedAtom, previewAtom, asset)
         }
         updateYoutubeMetadata(previewAtom, asset)
-        try {
-          updateYoutubeThumbnail(previewAtom, asset)
-        } catch {
-          case e: Throwable => {
-            log.error("Error updating Youtube thumbnail", e)
-            Future.successful(previewAtom)
-          }
-        }
+        updateYoutubeThumbnail(previewAtom, asset)
 
       case Some(_) =>
         // third party YouTube video that we do not have permission to edit


### PR DESCRIPTION
Reverts guardian/media-atom-maker#1014 as the issue was not fixed by this PR but has since been resolved. We need to consider how we might handle issues of this sort more gracefully in the future.