### PR TITLE
Add Snyk GitHub Action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -46,5 +46,5 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --org=guardian --project-name=${{ github.repository }}
+          args: --org=guardian --project-name=${{ github.repository }} --file=./build.sbt
           command: ${{ env.SNYK_COMMAND }}


### PR DESCRIPTION
## What does this change?
Adds a Snyk GitHub Action (GHA) to check for Node and Scala vulnerabilities.

## How can we measure success?
The GHA runs on push and every day at 6am and reports Node and Scala vulnerabilities.

## Have we considered potential risks?
We also have Dependabot security alerts set up on this repo - we might want to turn these off in favour of the Snyk GHA when it's up and running. Also, we might want to remove the existing project from Snyk.io when this is merged, as it will create another entry.