### PR TITLE
Add metals and vscode folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 logs
 .idea/
+.metals/
+.vscode/
 target/
 .dynamodb-local
 public/dist


### PR DESCRIPTION
## What does this change?
Adds the .metals/ and .vscode/ paths to .gitignore, so that we don't accidentally commit these local files.