### PR TITLE
Remove Snyk test step and only monitor on push to main branch

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -7,8 +7,8 @@ on:
   schedule:
     - cron: "0 6 * * *"
   push:
-#    branches:
-#      - main
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What does this change?
Removes the test step from Snyk GitHub action and runs monitor on push to main. This should update the Snyk dashboard whenever a branch is merged to main.