### PR TITLE
Ensure all sub projects are monitored by Snyk

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --org=guardian --project-name=${{ github.repository }} --file=./pluto-message-ingestion/yarn.lock
+          args: --org=guardian --project-name=${{ github.repository }}/pluto-message-ingestion --file=./pluto-message-ingestion/yarn.lock
           command: ${{ env.SNYK_COMMAND }}
 
       - name: Run Snyk to monitor Scala vulnerabilities


### PR DESCRIPTION
## What does this change?
We have previously set up GitHub Actions to perform Snyk dependency alerts.

We noticed that the Pluto project was not being checked, in this PR we have added it as  a path on the `project-name` argument to ensure it is picked up.

