### PR TITLE
fix: re-id the blockAds DOM element

### DIFF
--- a/public/video-ui/src/components/Flags/index.js
+++ b/public/video-ui/src/components/Flags/index.js
@@ -48,7 +48,8 @@ class Flags extends React.Component {
           disabled={!isYoutubeAtom || !isEligibleForAds}
           tooltip={!isEligibleForAds ? `Not eligible for pre-roll.` : ''}
         >
-          <CheckBox />
+          {/* use a different field identifier to `fieldLocation` to ensure ad blockers don't remove it from the DOM */}
+          <CheckBox fieldId="what-a-time-to-be-alive"/>
         </ManagedField>
         <ManagedField
           fieldLocation="composerCommentsEnabled"

--- a/public/video-ui/src/components/FormFields/CheckBox.js
+++ b/public/video-ui/src/components/FormFields/CheckBox.js
@@ -8,7 +8,7 @@ export default class CheckBox extends React.Component {
     return (
       <div>
         <input
-          id={this.props.fieldLocation}
+          id={this.props.fieldId || this.props.fieldLocation}
           type="checkbox"
           disabled={!this.props.editable}
           checked={checked}


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Although we previously rejected this change in #574, we've just had an issue with a [shopping browser extension](https://chrome.google.com/webstore/detail/honey/bmnlcjabgnpnenekpadlanbbkooimhnj?hl=en).

Some extensions are removing the checkbox for the block ads field from the DOM because they think it is an advert (it's ID was `blockAds`).

This change changes the DOM element's ID to a less vulnerable one, hopefully preventing ad-blockers and other browser extensions from finding it, creating an application that is usable in more situations.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy main to CODE
- Enable adblocker
- Observe blockAds checkbox not on the DOM
- Deploy this branch
- Keeping adblocker enable, observe the blockAds checkbox on the DOM

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

The app is easier to use.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

https://www.theguardian.com/media/2019/aug/07/guardian-broke-even-last-year-parent-company-confirms (it won't have massive impact, but...)

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

### Before
![image](https://user-images.githubusercontent.com/836140/139913946-abd3217d-a6ab-4c4c-8c55-50f720369e8a.png)


### After
![image](https://user-images.githubusercontent.com/836140/139914642-969da985-c3e0-4646-9692-260993be3b1a.png)
