### PR TITLE
Split CAPI and logging roles to enable us to log to our account-specific logging stream

### DIFF
--- a/common/src/main/scala/com/gu/media/aws/AwsAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/AwsAccess.scala
@@ -9,7 +9,6 @@ trait AwsAccess { this: Settings =>
   def readTag(tag: String): Option[String]
 
   val credentials: AwsCredentials
-  val loggingCredentials: AwsCredentials
   // To avoid renaming references everywhere
   def credsProvider: AWSCredentialsProvider = credentials.instance
 

--- a/common/src/main/scala/com/gu/media/aws/AwsAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/AwsAccess.scala
@@ -9,6 +9,7 @@ trait AwsAccess { this: Settings =>
   def readTag(tag: String): Option[String]
 
   val credentials: AwsCredentials
+  val loggingCredentials: AwsCredentials
   // To avoid renaming references everywhere
   def credsProvider: AWSCredentialsProvider = credentials.instance
 

--- a/common/src/main/scala/com/gu/media/aws/AwsCredentials.scala
+++ b/common/src/main/scala/com/gu/media/aws/AwsCredentials.scala
@@ -49,20 +49,20 @@ object AwsCredentials {
     val crossAccountRoleArn = settings.getMandatoryString("aws.kinesis.stsCapiRoleToAssume",
       "Role to assume to access CAPI streams (in format arn:aws:iam::<account>:role/<role_name>)")
 
-    assumeAccountRole(instance, crossAccountRoleArn)
+    assumeAccountRole(instance, crossAccountRoleArn, "capi")
   }
 
   private def assumeLoggingRole(instance: AWSCredentialsProvider, settings: Settings) = {
     val loggingRoleArn = settings.getMandatoryString("aws.kinesis.stsLoggingRoleToAssume",
       "Role to assume to access logging stream (in format arn:aws:iam::<account>:role/<role_name>)")
 
-    assumeAccountRole(instance, loggingRoleArn)
+    assumeAccountRole(instance, loggingRoleArn, "logging")
   }
 
-  private def assumeAccountRole(instance: AWSCredentialsProvider, roleArn: String): AWSCredentialsProvider = {
+  private def assumeAccountRole(instance: AWSCredentialsProvider, roleArn: String, sessionNameSuffix: String): AWSCredentialsProvider = {
     val securityTokens = new AWSSecurityTokenServiceClient(instance)
 
-    new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, "media-atom-maker")
+    new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, s"media-atom-maker-${sessionNameSuffix}")
       .withStsClient(securityTokens).build()
   }
 }

--- a/common/src/main/scala/com/gu/media/aws/AwsCredentials.scala
+++ b/common/src/main/scala/com/gu/media/aws/AwsCredentials.scala
@@ -46,7 +46,7 @@ object AwsCredentials {
   }
 
   private def assumeCrossAccountRole(instance: AWSCredentialsProvider, settings: Settings) = {
-    val crossAccountRoleArn = settings.getMandatoryString("aws.kinesis.stsRoleToAssume",
+    val crossAccountRoleArn = settings.getMandatoryString("aws.kinesis.stsCapiRoleToAssume",
       "Role to assume to access CAPI streams (in format arn:aws:iam::<account>:role/<role_name>)")
 
     assumeAccountRole(instance, crossAccountRoleArn)

--- a/common/src/main/scala/com/gu/media/logging/KinesisLogging.scala
+++ b/common/src/main/scala/com/gu/media/logging/KinesisLogging.scala
@@ -15,6 +15,7 @@ trait KinesisLogging { this: Settings with AwsAccess =>
 
     for {
       _stack <- stack
+      loggingCredentials <- credentials.logging
       stream <- getString("aws.kinesis.logging")
     } yield {
       rootLogger.info(s"bootstrapping kinesis appender with $stack -> $app -> $stage")
@@ -27,7 +28,7 @@ trait KinesisLogging { this: Settings with AwsAccess =>
       appender.setStreamName(stream)
       appender.setContext(context)
       appender.setLayout(Logging.layout(context, _stack, app, stage))
-      appender.setCredentialsProvider(credentials.crossAccount)
+      appender.setCredentialsProvider(loggingCredentials)
       appender.start()
 
       rootLogger.addAppender(appender)


### PR DESCRIPTION
_co-authored-by: @dskamiotis_

## What does this change?

At the moment, the permission to put records on our CAPI and logging streams are contained within a single role, that's consumed cross-account.

We're updating our apps to log into a stream that's contained within the app's account.

As a result, we'll need to split our current role into two – keeping the original role for cross-account access to our CAPI stream, and adding a new logging role to allow access to our in-account logging stream.

This PR makes that change, splitting `stsRoleToAssume` into two configuration options, `stsCapiRoleToAssume` and `stsLoggingRoleToAssume`. We've updated our configuration and code to assume the latter role for our logging.

## How to test

Deploy the [relevant cloudformation change](https://github.com/guardian/editorial-tools-platform/tree/jsh-dm/add-account-logging-to-mam) to the CODE stack, update the CODE configuration in S3 with the new parameters, and deploy this branch. The app should continue to work and log as normal. 

Tested in CODE:

![Screenshot 2021-11-11 at 11 30 36](https://user-images.githubusercontent.com/7767575/141290921-de080341-97e8-49bf-8537-a178fcd19269.png)

## How can we measure success?

We log to our new, account-specific stream.