### PR TITLE
Corrects the pluto message ingestion logging role conf name

### DIFF
--- a/pluto-message-ingestion/kinesis-message-processor.js
+++ b/pluto-message-ingestion/kinesis-message-processor.js
@@ -27,7 +27,7 @@ class KinesisMessageProcessor {
             stage: EnvironmentConfig.stage,
             stack: EnvironmentConfig.stack,
             app: EnvironmentConfig.app,
-            roleArn: config.aws.kinesis.stsRoleToAssume,
+            roleArn: config.aws.kinesis.stsLoggingRoleToAssume,
             streamName: config.aws.kinesis.logging
           });
 


### PR DESCRIPTION
## What does this change?
 
Updates the Pluto message ingesting lambda to use the correct logging conf key. 

![image](https://user-images.githubusercontent.com/4633246/144609606-83e484c8-4eed-40ea-a321-fb6036a14fa7.png)

## How to test

Deploy to code?

## How can we measure success?

The lambda begins to work again.



