### PR TITLE
 Fix MatchError exceptions in the log 

### DIFF
--- a/common/src/main/scala/com/gu/media/upload/PlutoUploadActions.scala
+++ b/common/src/main/scala/com/gu/media/upload/PlutoUploadActions.scala
@@ -30,6 +30,8 @@ class PlutoUploadActions(config: Settings with DynamoAccess with KinesisAccess w
           )
         }
       }
+      case _=>
+        //there is nothing extra to do for AtomAssignedProjectMessage, PacFileMessage, or PlutoResyncMetadataMessage
     }
   }
 


### PR DESCRIPTION
## What does this change?

We found a non-exhaustive match in `PlutoUploadActions` which was causing errors in the log. It turns out that there is nothing more that needs to be done for the extra cases, so a simple do-nothing "default" case is added

## How to test

Once deployed, there should be no MatchError nor 500 reported in response to a pluto resync request

## How can we measure success?

No more MatchErrors from the `PlutoUploadActions` class

## Have we considered potential risks?

n/a
