### PR TITLE
Allow NVM from Brew

### DIFF
--- a/scripts/check-node-version.sh
+++ b/scripts/check-node-version.sh
@@ -12,15 +12,6 @@ fileExists() {
 }
 
 changeNodeVersion() {
-    BREW_NVM_SH="$(brew --prefix nvm)/nvm.sh"
-
-    if fileExists "$BREW_NVM_SH"; then
-        echo -e "${red}NVM was installed using brew, this is unsupported."
-        echo -e "Uninstall it using brew uninstall nvm and then"
-        echo -e "Install it from https://github.com/creationix/nvm#installation${plain}"
-        exit 1
-    fi
-
     if [[ -z "${NVM_DIR}" ]]; then
         echo -e "${red}NVM not found. NVM is required to run this project"
         echo -e "Install it from https://github.com/creationix/nvm#installation${plain}"

--- a/scripts/check-node-version.sh
+++ b/scripts/check-node-version.sh
@@ -5,6 +5,7 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 red='\x1B[0;31m'
+plain='\x1b[0m'
 
 fileExists() {
   test -e "$1"
@@ -37,7 +38,7 @@ checkNodeMatchesNvm() {
 
     if [[ "v${DESIRED_NODE_VERSION}" != "${NODE_MAJOR_VERSION}"* ]]; then
         echo -e "${red}Your node version ${NODE_MAJOR_VERSION}" does not match "${DESIRED_NODE_VERSION}"
-        echo -e "${red}Please run 'nvm use' to get the desired node version"
+        echo -e "Please run 'nvm use' to get the desired node version${plain}"
         exit 1
     fi
 }


### PR DESCRIPTION
## What does this change?

Allows you to use NVM from brew.  Also avoids turning your console red permanently.

I don't know whether there was some good reason not to allow NVM in the past, perhaps @akash1810 knows?

## How to test

* Install NVM via brew
* Run `scripts/setup.sh`
* No errors