### PR TITLE
Simplify caching

### DIFF
--- a/app/di.scala
+++ b/app/di.scala
@@ -5,12 +5,11 @@ import controllers._
 import data._
 import play.api.ApplicationLoader.Context
 import play.api._
-import play.api.cache.EhCacheComponents
 import play.api.inject.DefaultApplicationLifecycle
 import play.api.libs.ws.ahc.AhcWSComponents
 import router.Routes
 import util._
-import scala.concurrent.duration._
+import java.time.Duration
 
 class MediaAtomMakerLoader extends ApplicationLoader {
   override def load(context: Context): Application = new MediaAtomMaker(context).application
@@ -18,8 +17,7 @@ class MediaAtomMakerLoader extends ApplicationLoader {
 
 class MediaAtomMaker(context: Context)
   extends BuiltInComponentsFromContext(context)
-    with AhcWSComponents
-    with EhCacheComponents {
+    with AhcWSComponents {
 
   // required to start logging (https://www.playframework.com/documentation/2.5.x/ScalaCompileTimeDependencyInjection)
   LoggerConfigurator(context.environment.classLoader).foreach(_.configure(context.environment))
@@ -42,7 +40,7 @@ class MediaAtomMaker(context: Context)
 
   private val reindexer = buildReindexer()
 
-  private val youTube = YouTube(config, defaultCacheApi, 1.day)
+  private val youTube = YouTube(config, Duration.ofDays(1))
 
   private val uploaderMessageConsumer = PlutoMessageConsumer(stores, aws)
   uploaderMessageConsumer.start(actorSystem.scheduler)(actorSystem.dispatcher)
@@ -61,7 +59,7 @@ class MediaAtomMaker(context: Context)
 
   private val youtubeTags = new YoutubeTagController(hmacAuthActions)
 
-  private val transcoder = new util.Transcoder(aws, defaultCacheApi)
+  private val transcoder = new util.Transcoder(aws)
   private val transcoderController = new controllers.Transcoder(hmacAuthActions, transcoder)
 
   private val videoApp = new VideoUIApp(hmacAuthActions, configuration, aws, permissions, youTube)

--- a/app/util/Memoize.scala
+++ b/app/util/Memoize.scala
@@ -1,0 +1,16 @@
+package util
+
+import com.google.common.base.Suppliers.memoizeWithExpiration
+import com.google.common.base.Supplier
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+object Memoize {
+
+  def apply[T](refresh: => T, duration: Duration): Supplier[T] =
+    memoizeWithExpiration(makeSupplier(refresh), duration.toMillis, TimeUnit.MILLISECONDS)
+
+  private def makeSupplier[T](fn: => T): Supplier[T] = new Supplier[T] {
+    override def get(): T = fn
+  }
+}

--- a/app/util/Transcoder.scala
+++ b/app/util/Transcoder.scala
@@ -8,7 +8,7 @@ import java.time.Duration
 
 class Transcoder(awsConfig: AWSConfig) {
 
-  private val transcoderJobsCache = Memoize(updateJobsStatus(), Duration.ofSeconds(20))
+  private lazy val transcoderJobsCache = Memoize(updateJobsStatus(), Duration.ofSeconds(20))
 
   def getJobsStatus = transcoderJobsCache.get
 

--- a/app/util/Transcoder.scala
+++ b/app/util/Transcoder.scala
@@ -2,14 +2,15 @@ package util
 
 import com.amazonaws.services.elastictranscoder.model.ListJobsByPipelineRequest
 import model.transcoder.JobStatus
-import play.api.cache.CacheApi
 
 import scala.collection.JavaConverters._
-import scala.concurrent.duration._
+import java.time.Duration
 
-class Transcoder(awsConfig: AWSConfig, cache: CacheApi) {
+class Transcoder(awsConfig: AWSConfig) {
 
-  def getJobsStatus = cache.getOrElse[List[JobStatus]]("transcoderJobs", 20.seconds){updateJobsStatus()}
+  private val transcoderJobsCache = Memoize(updateJobsStatus(), Duration.ofSeconds(20))
+
+  def getJobsStatus = transcoderJobsCache.get
 
   private def updateJobsStatus() = {
     val pipelineRequest: ListJobsByPipelineRequest = new ListJobsByPipelineRequest()

--- a/app/util/YouTube.scala
+++ b/app/util/YouTube.scala
@@ -1,24 +1,23 @@
 package util
 
 import com.gu.media.logging.Logging
-import com.gu.media.model.PrivacyStatus
 import com.gu.media.youtube._
 import com.typesafe.config.Config
-import play.api.cache.CacheApi
 
-import scala.concurrent.duration.FiniteDuration
+import java.time.Duration
 
 trait YouTube extends Logging with YouTubeAccess with YouTubeVideos with YouTubePartnerApi {
-  val cache: CacheApi
-  val duration: FiniteDuration
+  val duration: Duration
 
-  override def categories: List[YouTubeVideoCategory] = {
-    cache.getOrElse("categories", duration) { super.categories }
-  }
+  private val categoriesCache = Memoize(super.categories, duration)
 
-  override def channels: List[YouTubeChannel] = {
-    cache.getOrElse("channels", duration) { super.channels }
-  }
+  private val channelsCache = Memoize(super.channels, duration)
+
+  override def categories: List[YouTubeVideoCategory] =
+    categoriesCache.get
+
+  override def channels: List[YouTubeChannel] =
+    channelsCache.get
 
   def getCommercialVideoInfo(videoId: String) = {
     getVideo(videoId, "snippet,contentDetails,status").map(video => {
@@ -33,9 +32,8 @@ trait YouTube extends Logging with YouTubeAccess with YouTubeVideos with YouTube
 }
 
 object YouTube {
-  def apply(_config: Config, _cache: CacheApi, _duration: FiniteDuration): YouTube = new YouTube {
+  def apply(_config: Config, _duration: Duration): YouTube = new YouTube {
     override def config: Config = _config
-    override val cache: CacheApi = _cache
-    override val duration: FiniteDuration = _duration
+    override val duration: Duration = _duration
   }
 }

--- a/app/util/YouTube.scala
+++ b/app/util/YouTube.scala
@@ -9,9 +9,9 @@ import java.time.Duration
 trait YouTube extends Logging with YouTubeAccess with YouTubeVideos with YouTubePartnerApi {
   val duration: Duration
 
-  private val categoriesCache = Memoize(super.categories, duration)
+  private lazy val categoriesCache = Memoize(super.categories, duration)
 
-  private val channelsCache = Memoize(super.channels, duration)
+  private lazy val channelsCache = Memoize(super.channels, duration)
 
   override def categories: List[YouTubeVideoCategory] =
     categoriesCache.get


### PR DESCRIPTION
## What does this change?

Replaces Play's EhCache with memoization from Google's Guava library. Play's cache seems a bit heavyweight for some basic memoization.  

My motivation for changing this is really because migrating from EhCache in Play 2.5 to Play 2.6 will be more work than switching to a simpler solution.