### PR TITLE
Youtube service account

### DIFF
--- a/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
@@ -46,6 +46,7 @@ trait YouTubeAccess extends Settings with Logging {
   private val jacksonFactory = new JacksonFactory()
 
 
+  // This needs to be lazy so that the tests don't attempt to initialise the credentials
   private lazy val credentials: GoogleCredential = GoogleCredential.fromStream(
     new FileInputStream(serviceAccountCertPath)
   ).createScoped(YouTubeScopes.all())
@@ -62,6 +63,7 @@ trait YouTubeAccess extends Settings with Logging {
     }
   }
 
+  // This needs to be lazy so that the tests don't attempt to initialise the credentials
   private lazy val partnerCredentials = credentials.createScoped(List(YouTubeScopes.YOUTUBEPARTNER))
 
   // lazy to avoid initialising when in test


### PR DESCRIPTION
## What does this change?

Changes the mechanism for authenticating with Youtube.  We now use a service account associated with the media atom maker Google cloud project.  Previously we used oath credentials generated using https://github.com/akash1810/google-oauth2-token-viewer which were associated with a developer.

NB - depends on https://github.com/guardian/editorial-tools-platform/pull/615