### PR TITLE
Fix scheduledDate bug

### DIFF
--- a/public/video-ui/src/actions/VideoActions/getVideo.js
+++ b/public/video-ui/src/actions/VideoActions/getVideo.js
@@ -38,6 +38,10 @@ export function getVideo(id) {
         if (scheduledLaunch) {
           res.contentChangeDetails.scheduledLaunch.date = moment(scheduledLaunch).valueOf();
         }
+        const embargo = res?.contentChangeDetails?.embargo?.date;
+        if (embargo) {
+          res.contentChangeDetails.embargo.date = moment(embargo).valueOf();
+        }
         dispatch(receiveVideo(res));
       })
       .catch(error => dispatch(errorReceivingVideo(error)));

--- a/public/video-ui/src/actions/VideoActions/getVideo.js
+++ b/public/video-ui/src/actions/VideoActions/getVideo.js
@@ -1,5 +1,6 @@
 import VideosApi from '../../services/VideosApi';
 import Logger from '../../logger';
+import moment from 'moment';
 
 function requestVideo(id) {
   return {
@@ -32,6 +33,11 @@ export function getVideo(id) {
     dispatch(requestVideo(id));
     return VideosApi.fetchVideo(id)
       .then(res => {
+        // We and downstream consumers expect the scheduled launch to be an integer, but our API provides a string representation
+        const scheduledLaunch = res?.contentChangeDetails?.scheduledLaunch?.date;
+        if (scheduledLaunch) {
+          res.contentChangeDetails.scheduledLaunch.date = moment(scheduledLaunch).valueOf();
+        }
         dispatch(receiveVideo(res));
       })
       .catch(error => dispatch(errorReceivingVideo(error)));

--- a/public/video-ui/src/components/FormFields/DatePicker.js
+++ b/public/video-ui/src/components/FormFields/DatePicker.js
@@ -41,9 +41,9 @@ function Selector({ values, value, disabled, onChange }) {
 function HourSelector({ date, onChange }) {
   const dateMoment = moment(date);
   const params = {
-    values: dateMoment ? HOURS : EMPTY,
-    value: dateMoment ? dateMoment.format('HH') : ' ',
-    disabled: !dateMoment,
+    values: date ? HOURS : EMPTY,
+    value: date ? dateMoment.format('HH') : ' ',
+    disabled: !date,
     onChange: newHour => onChange(dateMoment.hours(newHour))
   };
 
@@ -53,9 +53,9 @@ function HourSelector({ date, onChange }) {
 function MinuteSelector({ date, onChange }) {
   const dateMoment = moment(date);
   const params = {
-    values: dateMoment ? MINUTES : EMPTY,
-    value: dateMoment ? dateMoment.format('mm') : ' ',
-    disabled: !dateMoment,
+    values: date ? MINUTES : EMPTY,
+    value: date ? dateMoment.format('mm') : ' ',
+    disabled: !date,
     onChange: newMinute => onChange(dateMoment.minutes(newMinute))
   };
 
@@ -72,7 +72,7 @@ function DateSelector({ date, onChange }) {
     dateFormat: DATE_FORMAT,
     readOnly: false,
     onChange: newDate => {
-      const base = dateMoment ? dateMoment : moment().hours(0).minutes(0);
+      const base = date ? dateMoment : moment().hours(0).minutes(0);
       const onChangeDate = moment(newDate)
         .hours(base.hours())
         .minutes(base.minutes());
@@ -119,7 +119,7 @@ function Editor({ date, onChange, fieldName, canCancel, dayOnly }) {
 
 function Display({ date, placeholder, fieldName }) {
   const dateMoment = moment(date);
-  const displayString = dateMoment ? dateMoment.format(DATETIME_FORMAT) : placeholder;
+  const displayString = date ? dateMoment.format(DATETIME_FORMAT) : placeholder;
   const fieldClassName = () =>
     'details-list__field' + (!date ? ' details-list__empty' : '');
 

--- a/public/video-ui/src/components/FormFields/DatePicker.js
+++ b/public/video-ui/src/components/FormFields/DatePicker.js
@@ -39,22 +39,24 @@ function Selector({ values, value, disabled, onChange }) {
 }
 
 function HourSelector({ date, onChange }) {
+  const dateMoment = moment(date);
   const params = {
-    values: date ? HOURS : EMPTY,
-    value: date ? date.format('HH') : ' ',
-    disabled: !date,
-    onChange: newHour => onChange(date.hours(newHour))
+    values: dateMoment ? HOURS : EMPTY,
+    value: dateMoment ? dateMoment.format('HH') : ' ',
+    disabled: !dateMoment,
+    onChange: newHour => onChange(dateMoment.hours(newHour))
   };
 
   return <Selector {...params} />;
 }
 
 function MinuteSelector({ date, onChange }) {
+  const dateMoment = moment(date);
   const params = {
-    values: date ? MINUTES : EMPTY,
-    value: date ? date.format('mm') : ' ',
-    disabled: !date,
-    onChange: newMinute => onChange(date.minutes(newMinute))
+    values: dateMoment ? MINUTES : EMPTY,
+    value: dateMoment ? dateMoment.format('mm') : ' ',
+    disabled: !dateMoment,
+    onChange: newMinute => onChange(dateMoment.minutes(newMinute))
   };
 
   return <Selector {...params} />;
@@ -62,14 +64,15 @@ function MinuteSelector({ date, onChange }) {
 
 function DateSelector({ date, onChange }) {
   const minDate = moment().toDate();
+  const dateMoment = moment(date);
   const datePickerParams = {
     className: 'form__field',
-    selected: date ? date.toDate() : null,
+    selected: date ? dateMoment.toDate() : null,
     minDate,
     dateFormat: DATE_FORMAT,
     readOnly: false,
     onChange: newDate => {
-      const base = date ? date : moment().hours(0).minutes(0);
+      const base = dateMoment ? dateMoment : moment().hours(0).minutes(0);
       const onChangeDate = moment(newDate)
         .hours(base.hours())
         .minutes(base.minutes());
@@ -115,7 +118,8 @@ function Editor({ date, onChange, fieldName, canCancel, dayOnly }) {
 }
 
 function Display({ date, placeholder, fieldName }) {
-  const displayString = date ? date.format(DATETIME_FORMAT) : placeholder;
+  const dateMoment = moment(date);
+  const displayString = dateMoment ? dateMoment.format(DATETIME_FORMAT) : placeholder;
   const fieldClassName = () =>
     'details-list__field' + (!date ? ' details-list__empty' : '');
 
@@ -137,8 +141,7 @@ export default function CustomDatePicker({
   canCancel = true
 }) {
   const date =
-    fieldValue && fieldValue !== placeholder ? moment(fieldValue) : null;
-
+    fieldValue && fieldValue !== placeholder ? moment(fieldValue).valueOf() : null;
   if (editable) {
     return (
       <Editor

--- a/public/video-ui/src/components/FormFields/DatePicker.js
+++ b/public/video-ui/src/components/FormFields/DatePicker.js
@@ -4,8 +4,8 @@ import moment from 'moment';
 import 'react-datepicker/dist/react-datepicker.css';
 import Icon from '../Icon';
 
-const DATE_FORMAT = 'dd MMM yyyy';
-const DATETIME_FORMAT = `DD MMM yyyy HH:mm`;
+const DATE_FORMAT = 'dd MMM YYYY';
+const DATETIME_FORMAT = `DD MMM YYYY HH:mm`;
 
 const MINUTES = [0, 15, 30, 45].map(minute =>
   moment().minute(minute).format('mm')

--- a/public/video-ui/src/components/FormFields/DatePicker.js
+++ b/public/video-ui/src/components/FormFields/DatePicker.js
@@ -4,8 +4,8 @@ import moment from 'moment';
 import 'react-datepicker/dist/react-datepicker.css';
 import Icon from '../Icon';
 
-const DATE_FORMAT = 'dd MMM YYYY';
-const DATETIME_FORMAT = `DD MMM YYYY HH:mm`;
+const REACT_DATEPICKER_DATE_FORMAT = 'dd MMM yyyy';
+const MOMENT_DATETIME_FORMAT = `DD MMM YYYY HH:mm`;
 
 const MINUTES = [0, 15, 30, 45].map(minute =>
   moment().minute(minute).format('mm')
@@ -69,7 +69,7 @@ function DateSelector({ date, onChange }) {
     className: 'form__field',
     selected: date ? dateMoment.toDate() : null,
     minDate,
-    dateFormat: DATE_FORMAT,
+    dateFormat: REACT_DATEPICKER_DATE_FORMAT,
     readOnly: false,
     onChange: newDate => {
       const base = date ? dateMoment : moment().hours(0).minutes(0);
@@ -119,7 +119,7 @@ function Editor({ date, onChange, fieldName, canCancel, dayOnly }) {
 
 function Display({ date, placeholder, fieldName }) {
   const dateMoment = moment(date);
-  const displayString = date ? dateMoment.format(DATETIME_FORMAT) : placeholder;
+  const displayString = date ? dateMoment.format(MOMENT_DATETIME_FORMAT) : placeholder;
   const fieldClassName = () =>
     'details-list__field' + (!date ? ' details-list__empty' : '');
 

--- a/public/video-ui/src/components/VideoItem/index.js
+++ b/public/video-ui/src/components/VideoItem/index.js
@@ -5,6 +5,7 @@ import Icon from '../Icon';
 import ReactTooltip from 'react-tooltip';
 import VideoUtils from '../../util/video';
 import { impossiblyDistantDate } from '../../constants/dates';
+import moment from 'moment';
 
 export default class VideoItem extends React.Component {
   renderPublishStatus() {
@@ -43,8 +44,10 @@ export default class VideoItem extends React.Component {
 
   render() {
     const video = this.props.video;
-    const scheduledLaunch = VideoUtils.getScheduledLaunchAsDate(video);
-    const embargo = VideoUtils.getEmbargoAsDate(video);
+    const scheduledLaunch = VideoUtils.getScheduledLaunch(video);
+    const scheduledLaunchMoment = moment(scheduledLaunch);
+    const embargo = VideoUtils.getEmbargo(video);
+    const embargoMoment = moment(embargo);
     const hasPreventedPublication = embargo && embargo.valueOf() >= impossiblyDistantDate;
     return (
       <li className="grid__item">
@@ -61,7 +64,7 @@ export default class VideoItem extends React.Component {
                   data-tip={
                     hasPreventedPublication
                       ? 'This video has been embargoed indefinitely'
-                      : `Embargoed until ${embargo.format(
+                      : `Embargoed until ${embargoMoment.format(
                           'Do MMM YYYY HH:mm'
                         )}`
                   }
@@ -70,18 +73,18 @@ export default class VideoItem extends React.Component {
                   <Icon textClass="always-show" icon="not_interested">
                     {hasPreventedPublication
                       ? 'Embargoed indefinitely'
-                      : embargo.format('D MMM HH:mm')}
+                      : embargoMoment.format('D MMM HH:mm')}
                   </Icon>
                 </span>
               )}
               {scheduledLaunch && (
                 <span
                   data-tip={`Scheduled to launch ${
-                    scheduledLaunch.format('Do MMM YYYY HH:mm')}`}
+                    scheduledLaunchMoment.format('Do MMM YYYY HH:mm')}`}
                   className="publish__label label__frontpage__scheduledLaunch label__frontpage__overlay"
                 >
                   <Icon textClass="always-show" icon="access_time">
-                    {scheduledLaunch.format('D MMM HH:mm')}
+                    {scheduledLaunchMoment.format('D MMM HH:mm')}
                   </Icon>
                 </span>
               )}

--- a/public/video-ui/src/components/VideoItem/index.js
+++ b/public/video-ui/src/components/VideoItem/index.js
@@ -48,7 +48,7 @@ export default class VideoItem extends React.Component {
     const scheduledLaunchMoment = moment(scheduledLaunch);
     const embargo = VideoUtils.getEmbargo(video);
     const embargoMoment = moment(embargo);
-    const hasPreventedPublication = embargo && embargo.valueOf() >= impossiblyDistantDate;
+    const hasPreventedPublication = embargo && embargoMoment.valueOf() >= impossiblyDistantDate;
     return (
       <li className="grid__item">
         <Link className="grid__link" to={'/videos/' + video.id}>


### PR DESCRIPTION
Co-authored with @aracho1 and @jonathonherbert 

## What does this change?

This PR fixes a bug with the `scheduledLaunch` - where editing text fields could remove the `scheduledLaunch` or `embargo` from the associated Composer article for a video. This PR fixes the issue by consistently storing the `scheduledLaunch` as a number (milliseconds since Unix epoch) rather than a `moment` or a formatted string.

The UI is updated where it was expecting anything other than a number.

The PR also fixes a bug with the management tab where all times were rendered as 00:00 due to an incorrect format string, and a bug where embargoed videos showed `Embargoed: 1st Jan 2500 00:00` rather than `Embargoed indefinitely`.

## How to test

1. Deploy to CODE.
2. Add a video and schedule it. 
3. Publish the Composer page, and check schedule is working.
4. Make changes to required text fields on the MAM page. 
5. Is the Composer schedule still present?
6. Repeat this for an embargo.

Also:
- Check the date picker is working as expected
- Check that dates are rendered properly on the front page of the app
