### PR TITLE
Warn user when node version is wrong but don't require nvm specifically

### DIFF
--- a/scripts/check-node-version.sh
+++ b/scripts/check-node-version.sh
@@ -5,34 +5,18 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 red='\x1B[0;31m'
-plain='\x1b[0m'
-
-fileExists() {
-  test -e "$1"
-}
-
-changeNodeVersion() {
-    if [[ -z "${NVM_DIR}" ]]; then
-        echo -e "${red}NVM not found. NVM is required to run this project"
-        echo -e "Install it from https://github.com/creationix/nvm#installation${plain}"
-        exit 1
-    else
-        [ -s "$NVM_DIR/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh"
-        # nvm will need to be sourced
-        nvm install
-    fi
-}
 
 checkNodeMatchesNvm() {
     NODE_MAJOR_VERSION=$(node -v | cut -d "." -f 1)
     DESIRED_NODE_VERSION=$(cat "${DIR}/../.nvmrc")
 
     if [[ "v${DESIRED_NODE_VERSION}" != "${NODE_MAJOR_VERSION}"* ]]; then
-        echo -e "${red}Your node version ${NODE_MAJOR_VERSION}" does not match "${DESIRED_NODE_VERSION}"
-        echo -e "Please run 'nvm use' to get the desired node version${plain}"
+        echo -e "${red}Your node version ${NODE_MAJOR_VERSION} does not match the version the project expects (v${DESIRED_NODE_VERSION})."
+        echo -e "${red}Please ensure it matches before starting the project."
+        echo -e "${red}If you are using nvm, for example, run \`nvm use\`."
+        echo -e "${red}https://github.com/creationix/nvm"
         exit 1
     fi
 }
 
-changeNodeVersion
-checkNodeMatchesNvm # Just in case something didn't work in the nvm switch
+checkNodeMatchesNvm

--- a/scripts/check-node-version.sh
+++ b/scripts/check-node-version.sh
@@ -5,6 +5,7 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 red='\x1B[0;31m'
+plain='\033[0m'
 
 checkNodeMatchesNvm() {
     NODE_MAJOR_VERSION=$(node -v | cut -d "." -f 1)
@@ -12,9 +13,9 @@ checkNodeMatchesNvm() {
 
     if [[ "v${DESIRED_NODE_VERSION}" != "${NODE_MAJOR_VERSION}"* ]]; then
         echo -e "${red}Your node version ${NODE_MAJOR_VERSION} does not match the version the project expects (v${DESIRED_NODE_VERSION})."
-        echo -e "${red}Please ensure it matches before starting the project."
-        echo -e "${red}If you are using nvm, for example, run \`nvm use\`."
-        echo -e "${red}https://github.com/creationix/nvm"
+        echo -e "Please ensure it matches before starting the project."
+        echo -e "If you are using nvm, for example, run \`nvm use\`."
+        echo -e "https://github.com/creationix/nvm${plain}"
         exit 1
     fi
 }


### PR DESCRIPTION
Shamelessly borrowed from https://github.com/guardian/flexible-content/pull/3813

The `nvm` script makes running the project difficult when using e.g. `fnm` (which some of us are now doing due to command line slowness caused by `nvm`). This PR changes the scripts to warn users with the wrong version of node, without forcing the use of `nvm`.