### PR TITLE
Convert expiry from string to number, like scheduledLaunchDates

### DIFF
--- a/public/video-ui/src/actions/VideoActions/getVideo.js
+++ b/public/video-ui/src/actions/VideoActions/getVideo.js
@@ -42,6 +42,10 @@ export function getVideo(id) {
         if (embargo) {
           res.contentChangeDetails.embargo.date = moment(embargo).valueOf();
         }
+        const expiry = res?.contentChangeDetails?.expiry?.date;
+        if (expiry) {
+          res.contentChangeDetails.expiry.date = moment(expiry).valueOf();
+        }
         dispatch(receiveVideo(res));
       })
       .catch(error => dispatch(errorReceivingVideo(error)));


### PR DESCRIPTION
## What does this change?

Need to test this connects correctly on CODE.

Currently, MAM sends the expiry date as a string, but composer expects to see a number. On old versions of lift-json I think this means the field gets silently ignored - on the recent upgrade attempting to parse throws.

## How to test

Deploy to CODE along with the relevant versions of composer. Do video pages get created with expiry dates?

 - [x] Tested on CODE


## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
