### PR TITLE
temporary: Accept thumbnail update failure

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -176,7 +176,13 @@ case class PublishAtomCommand(
           createOrUpdateYoutubeClaim(publishedAtom, previewAtom, asset)
         }
         updateYoutubeMetadata(previewAtom, asset)
-        updateYoutubeThumbnail(previewAtom, asset)
+        try {
+          updateYoutubeThumbnail(previewAtom, asset)
+        } catch {
+          case e: Throwable =>
+            log.error("failed to update thumbnail; skipping", e)
+            Future.successful(previewAtom)
+        }
 
       case Some(_) =>
         // third party YouTube video that we do not have permission to edit

--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -176,12 +176,10 @@ case class PublishAtomCommand(
           createOrUpdateYoutubeClaim(publishedAtom, previewAtom, asset)
         }
         updateYoutubeMetadata(previewAtom, asset)
-        try {
-          updateYoutubeThumbnail(previewAtom, asset)
-        } catch {
+        updateYoutubeThumbnail(previewAtom, asset).recover {
           case e: Throwable =>
             log.error("failed to update thumbnail; skipping", e)
-            Future.successful(previewAtom)
+            previewAtom
         }
 
       case Some(_) =>


### PR DESCRIPTION
## What does this change?

Bringing back #1014 
the youtube thumbnail api is currently timing out, we think thumbnails are generally getting published but users can ensure that is the case out-of-band as required

## How to test

Try publishing a video (with a youtube poster) on CODE

