### PR TITLE
Copyable keywords

### DIFF
--- a/public/video-ui/src/components/Tags/TagFieldValue.js
+++ b/public/video-ui/src/components/Tags/TagFieldValue.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 export default class TagFieldValue extends React.Component {
   renderFieldValue(value, index) {
+    console.log(value);
     if (value.detailedTitle) {
       return (
         <span key={`${value.id}-${index}`}>
@@ -23,7 +24,7 @@ export default class TagFieldValue extends React.Component {
   }
   getRenderedValues(){
     const values = this.props.tagValue.map(this.renderFieldValue);
-    if (values.every(value => typeof value === "string")){
+    if (values.every(value => typeof value === "string" && !value.includes(','))){
       // E.g. a list of YouTube keywords
       return values.join(',');
     } else return values;

--- a/public/video-ui/src/components/Tags/TagFieldValue.js
+++ b/public/video-ui/src/components/Tags/TagFieldValue.js
@@ -21,8 +21,15 @@ export default class TagFieldValue extends React.Component {
 
     return ` ${value}`;
   }
+  getRenderedValues(){
+    const values = this.props.tagValue.map(this.renderFieldValue);
+    if (values.every(value => typeof value === "string")){
+      // E.g. a list of YouTube keywords
+      return values.join(',');
+    } else return values;
+  }
 
   render() {
-    return <span>{this.props.tagValue.map(this.renderFieldValue).join(',')}</span>;
+    return <span>{this.getRenderedValues()}</span>;
   }
 }

--- a/public/video-ui/src/components/Tags/TagFieldValue.js
+++ b/public/video-ui/src/components/Tags/TagFieldValue.js
@@ -2,7 +2,6 @@ import React from 'react';
 
 export default class TagFieldValue extends React.Component {
   renderFieldValue(value, index) {
-    console.log(value);
     if (value.detailedTitle) {
       return (
         <span key={`${value.id}-${index}`}>

--- a/public/video-ui/src/components/Tags/TagFieldValue.js
+++ b/public/video-ui/src/components/Tags/TagFieldValue.js
@@ -23,6 +23,6 @@ export default class TagFieldValue extends React.Component {
   }
 
   render() {
-    return <span>{this.props.tagValue.map(this.renderFieldValue)}</span>;
+    return <span>{this.props.tagValue.map(this.renderFieldValue).join(',')}</span>;
   }
 }

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -58,6 +58,9 @@
   cursor: pointer;
   flex-wrap: wrap;
   min-height: 36px;
+  .form__field__tag--container, .form__field__tag--container input {
+    flex-grow: 1;
+  }
 }
 
 .form__field {


### PR DESCRIPTION
## What does this change?

This PR renders the keywords as a comma-separated string list, which will allow users to copy and paste keyword lists between different videos. 

When a series of videos reference the same new event (e.g. US Midterms), video editors will want to use many shared keywords. The field already supports pasting a comma-separated list. This PR will render a comma-separated list of the keywords in a video so that a user can also copy a parseable keyword list.

It also restyles the field as previously only about 100 pixels of width were selectable.

## How to test

1. Run locally (I've found only the `/scripts/start.sh` script works currently, not `client-dev.sh`) or deploy to CODE.
2. Add keywords to a video. Try copying the bottom list of keywords into another video's keyword field, then hit enter. Does it populate the video with the same keywords?
3. Make sure other fields based on multiple tags (e.g. the byline field) are not broken

## Images

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/34686302/201341034-8254242e-2388-491f-a746-bc85f033ad57.png) | ![image](https://user-images.githubusercontent.com/34686302/201342499-bb01b5c9-9c9d-4935-90c0-dedf05240d1e.png) |