### PR TITLE
Make logo padding a function of the video height

### DIFF
--- a/app/util/ThumbnailGenerator.scala
+++ b/app/util/ThumbnailGenerator.scala
@@ -16,9 +16,6 @@ case class ThumbnailGenerator(logoFile: File) {
   // use a slightly smaller file from Grid so we can add a branding overlay
   private val MAX_SIZE = 1.8 * 1000 * 1000
 
-  // amount of padding (px) on left and bottom of logo
-  private val PADDING = 80
-
   private lazy val logo = ImageIO.read(logoFile)
 
   private def getGridImageAsset(image: Image): ImageAsset = {
@@ -34,6 +31,7 @@ case class ThumbnailGenerator(logoFile: File) {
     val logoWidth: Double = List(bgImage.getWidth() / 3.0, logo.getWidth()).min
     val logoHeight: Double = logo.getHeight() / (logo.getWidth() / logoWidth)
 
+    val PADDING = (logoHeight/8).toInt
     val logoX = PADDING
     val logoY = bgImage.getHeight() - logoHeight.toInt - PADDING
 

--- a/app/util/ThumbnailGenerator.scala
+++ b/app/util/ThumbnailGenerator.scala
@@ -31,6 +31,7 @@ case class ThumbnailGenerator(logoFile: File) {
     val logoWidth: Double = List(bgImage.getWidth() / 3.0, logo.getWidth()).min
     val logoHeight: Double = logo.getHeight() / (logo.getWidth() / logoWidth)
 
+    // amount of padding (px) on left and bottom of logo
     val PADDING = (logoHeight/8).toInt
     val logoX = PADDING
     val logoY = bgImage.getHeight() - logoHeight.toInt - PADDING


### PR DESCRIPTION
## What does this change?

This PR bases the Guardian wordmark bottom/left padding (on YouTube videos) on the chosen image's width, rather than it being hardcoded to 80px.

The padding is now 1/8th of the wordmark's calculated height (a ratio based on some of our thumbnails that looks good on YouTube)

| Before | After | 
| --- | --- |
| ![image](https://user-images.githubusercontent.com/34686302/201370418-32dd94e6-0deb-44cb-95bc-d279b63c14c0.png) | ![image](https://user-images.githubusercontent.com/34686302/201370393-0565e8fd-07e4-46b5-ab02-b12627ab481d.png) |

## Why?

Placements were coming up inconsistent, most obviously on smaller images, see the right hand thumbnail below:
![image](https://user-images.githubusercontent.com/34686302/201369799-ce3f36d7-b476-4c6b-8810-b3a8fe24d0a3.png)

## How to test

1. Deploy current media-atom-maker `main` to CODE (or check that it's already deployed)
2. Use a very small crop for a video
3. Observe misplaced logo
4. Deploy this branch to CODE
5. Use a very small crop for a video
6. See if logo is now appropriately placed in the bottom left hand corner