### PR TITLE
Also comma-separate launched youtube keywords

### DIFF
--- a/public/video-ui/src/components/FormFields/TagPicker.js
+++ b/public/video-ui/src/components/FormFields/TagPicker.js
@@ -318,7 +318,10 @@ class TagPicker extends React.Component {
       if (this.props.tagType === TagTypes.contributor ||
           this.props.tagType === TagTypes.youtube) {
         return (
-          <TagFieldValue tagValue={this.state.tagValue}/>
+          <TagFieldValue 
+            tagValue={this.state.tagValue}
+            tagType={this.props.tagType}
+          />
         );
 
       }
@@ -389,7 +392,7 @@ class TagPicker extends React.Component {
           <p className="details-list__title">{this.props.fieldName}</p>
           <CapiUnavailable capiUnavailable={this.state.capiUnavailable} />
           <p className="details-list__field ">
-            <TagFieldValue tagValue={this.state.tagValue}/>
+            <TagFieldValue tagValue={this.state.tagValue} tagType={this.props.tagType}/>
           </p>
         </div>
       );

--- a/public/video-ui/src/components/Tags/TagFieldValue.js
+++ b/public/video-ui/src/components/Tags/TagFieldValue.js
@@ -1,18 +1,24 @@
 import React from 'react';
 
 export default class TagFieldValue extends React.Component {
-  renderFieldValue(value, index) {
+  
+  renderFieldValue(value, index, array) {
+    // Add a trailing comma if it's a youtube keyword field and it's not the last keyword in the array
+    const shouldAddComma = (this?.props?.tagType === "youtube" && index !== array.length - 1);
     if (value.detailedTitle) {
       return (
         <span key={`${value.id}-${index}`}>
           <span className="form__field__tag__display">
             {value.detailedTitle}
-          </span>{' '}
+          </span>
+          {shouldAddComma ? ',' : ' '}
         </span>
       );
     } else if (value.webTitle) {
-      // In YouTube Furniture tab, the `keyword` field passes an object with webTitle to this component
-      return value.webTitle;
+      // In a  YouTube Furniture tab with non-launched changes, the `keyword` field 
+      //passes an object with webTitle to this component
+      const titleToRender = value.webTitle.concat(shouldAddComma ? ',' : '');
+      return titleToRender;
     }
 
     if (index === 0 || value === ',') {
@@ -22,11 +28,7 @@ export default class TagFieldValue extends React.Component {
     return ` ${value}`;
   }
   getRenderedValues(){
-    const values = this.props.tagValue.map(this.renderFieldValue);
-    if (values.every(value => typeof value === "string" && !value.includes(','))){
-      // E.g. a list of YouTube keywords
-      return values.join(',');
-    } else return values;
+    return this.props.tagValue.map((tagValue, index, array) => this.renderFieldValue(tagValue, index, array));
   }
 
   render() {


### PR DESCRIPTION
## What does this change?

The [previous PR](https://github.com/guardian/media-atom-maker/pull/1072) aimed to comma-separate YouTube keywords. It works for non-launched YouTube keywords, but not launched keywords, which are rendered as JSX rather than plain strings.

This PR styles launched keyword lists as comma-separated. It also explicitly checks that the field is for YouTube keywords and is not the Byline field.

## How to test

1. Run locally (I've found only the `/scripts/start.sh` script works currently, not `client-dev.sh`) or deploy to CODE.
2. Add keywords to a video. Try copying the bottom list of keywords into another video's keyword field, then hit enter. Does it populate the video with the same keywords, comma separated? 
3. Launch the video (or look at an already launched video). Do the keywords still appear comma-separated?
4. Make sure other fields based on multiple tags (e.g. the byline field) are not broken

## Images

| Before | After |
| --- | --- |
|  <img width="254" alt="Screenshot 2022-11-14 at 10 43 05" src="https://user-images.githubusercontent.com/34686302/201640876-c75afdce-9367-4349-ba4b-6274b6d50224.png"> | <img width="424" alt="Screenshot 2022-11-14 at 10 43 15" src="https://user-images.githubusercontent.com/34686302/201641022-fb5a773c-b678-4336-beda-696a678edc64.png"> |