### PR TITLE
Revert "temporary: Accept thumbnail update failure"

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -176,11 +176,7 @@ case class PublishAtomCommand(
           createOrUpdateYoutubeClaim(publishedAtom, previewAtom, asset)
         }
         updateYoutubeMetadata(previewAtom, asset)
-        updateYoutubeThumbnail(previewAtom, asset).recover {
-          case e: Throwable =>
-            log.error("failed to update thumbnail; skipping", e)
-            previewAtom
-        }
+        updateYoutubeThumbnail(previewAtom, asset)
 
       case Some(_) =>
         // third party YouTube video that we do not have permission to edit


### PR DESCRIPTION
Reverts guardian/media-atom-maker#1069

Youtube seem to have fixed their side now.

We should in the future allow users to bypass the thumbnail upload if this endpoint falls over again