### PR TITLE
Allow user to override the image for the YouTube thumbnail

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val scroogeVersion = "4.12.0"
 val awsVersion = "1.11.678"
 val pandaVersion = "1.2.0"
 val pandaHmacVersion = "2.1.0"
-val atomMakerVersion = "1.3.2"
+val atomMakerVersion = "1.3.4"
 val typesafeConfigVersion = "1.4.0" // to match what we get from Play transitively
 val scanamoVersion = "1.0.0-M9"
 

--- a/common/src/main/scala/com/gu/media/model/MediaAtom.scala
+++ b/common/src/main/scala/com/gu/media/model/MediaAtom.scala
@@ -26,6 +26,7 @@ abstract class MediaAtomBase {
   val expiryDate: Option[Long]
   val youtubeTitle: String
   val youtubeDescription: Option[String]
+  val youtubeOverrideImage: Option[Image]
 
   //composer metadata
   val trailImage: Option[Image]
@@ -61,6 +62,7 @@ case class MediaAtomBeforeCreation(
   license: Option[String],
   blockAds: Boolean,
   expiryDate: Option[Long],
+  youtubeOverrideImage: Option[Image],
 
   trailImage: Option[Image],
   trailText: Option[String],
@@ -87,6 +89,7 @@ case class MediaAtomBeforeCreation(
       trailText = trailText,
       posterImage = posterImage.map(_.asThrift),
       trailImage = trailImage.map(_.asThrift),
+      youtubeOverrideImage = youtubeOverrideImage.map(_.asThrift),
       byline = Some(byline),
       commissioningDesks = Some(commissioningDesks),
       keywords = Some(keywords),
@@ -148,6 +151,7 @@ case class MediaAtom(
   trailText: Option[String],
   posterImage: Option[Image],
   trailImage: Option[Image],
+  youtubeOverrideImage: Option[Image],
   // metadata
   tags: List[String],
   byline: List[String],
@@ -181,6 +185,7 @@ case class MediaAtom(
       trailText = trailText,
       posterImage = posterImage.map(_.asThrift),
       trailImage = trailImage.map(_.asThrift),
+      youtubeOverrideImage = youtubeOverrideImage.map(_.asThrift),
       byline = Some(byline),
       commissioningDesks = Some(commissioningDesks),
       keywords = Some(keywords),
@@ -246,6 +251,7 @@ object MediaAtom extends MediaAtomImplicits {
       source = data.source,
       posterImage = data.posterImage.map(Image.fromThrift),
       trailImage = data.trailImage.map(Image.fromThrift),
+      youtubeOverrideImage = data.youtubeOverrideImage.map(Image.fromThrift),
       description = data.description,
       trailText = data.trailText,
       tags = data.metadata.flatMap(_.tags.map(_.toList)).getOrElse(Nil),

--- a/common/src/test/scala/com/gu/media/model/AdSettingsTest.scala
+++ b/common/src/test/scala/com/gu/media/model/AdSettingsTest.scala
@@ -26,6 +26,7 @@ class AdSettingsTest extends FunSuite with MustMatchers {
     trailText = None,
     posterImage = None,
     trailImage = None,
+    youtubeOverrideImage = None,
     tags = List.empty,
     byline = List.empty,
     commissioningDesks = List.empty,

--- a/common/src/test/scala/com/gu/media/model/MediaAtomTest.scala
+++ b/common/src/test/scala/com/gu/media/model/MediaAtomTest.scala
@@ -32,6 +32,7 @@ class MediaAtomTest extends FunSuite with MustMatchers {
     channelId = None,
     privacyStatus = None,
     youtubeCategoryId = None,
+    youtubeOverrideImage = None,
     keywords = List.empty,
     license = None,
     blockAds = false,

--- a/public/video-ui/src/components/VideoImages/VideoImages.js
+++ b/public/video-ui/src/components/VideoImages/VideoImages.js
@@ -38,10 +38,10 @@ export default class VideoImages extends React.Component {
 
     return (
       <div className="video__imagebox">
-        <div className="video__detailbox">
+        <div className="video__images">
           <div className="video__detailbox__header__container">
             <header className="video__detailbox__header">
-              Main Image (YouTube poster)
+              Main Image
             </header>
             <GridImageSelect
               image={this.props.video.posterImage}
@@ -49,12 +49,12 @@ export default class VideoImages extends React.Component {
               gridDomain={this.props.gridDomain}
               disabled={this.props.videoEditOpen}
               updateVideo={this.saveAndUpdateVideoImage}
-              fieldLocation="posterImage" 
+              fieldLocation="posterImage"
             />
           </div>
           <GridImage image={this.props.video.posterImage} />
         </div>
-        <div className="video__detailbox">
+        <div className="video__images">
           <div className="video__detailbox__header__container">
             <header className="video__detailbox__header">
               Composer Trail Image
@@ -65,15 +65,15 @@ export default class VideoImages extends React.Component {
               gridDomain={this.props.gridDomain}
               disabled={trailImageDisabled}
               updateVideo={this.saveAndUpdateVideoImage}
-              fieldLocation="trailImage" 
+              fieldLocation="trailImage"
             />
           </div>
           <GridImage image={this.props.video.trailImage} />
         </div>
-        <div className="video__detailbox">
+        <div className="video__images">
           <div className="video__detailbox__header__container">
             <header className="video__detailbox__header">
-              Youtube Thumbnail Image Override
+              Youtube Thumbnail Image
             </header>
             <GridImageSelect
               image={this.props.video.youtubeOverrideImage}
@@ -81,7 +81,7 @@ export default class VideoImages extends React.Component {
               gridDomain={this.props.gridDomain}
               disabled={this.props.videoEditOpen}
               updateVideo={this.saveAndUpdateVideoImage}
-              fieldLocation="youtubeOverrideImage" 
+              fieldLocation="youtubeOverrideImage"
             />
           </div>
           <GridImage image={this.props.video.youtubeOverrideImage} />

--- a/public/video-ui/src/components/VideoImages/VideoImages.js
+++ b/public/video-ui/src/components/VideoImages/VideoImages.js
@@ -41,7 +41,7 @@ export default class VideoImages extends React.Component {
         <div className="video__images">
           <div className="video__detailbox__header__container">
             <header className="video__detailbox__header">
-              Main Image
+              Guardian Video Thumbnail Image
             </header>
             <GridImageSelect
               image={this.props.video.posterImage}
@@ -73,7 +73,7 @@ export default class VideoImages extends React.Component {
         <div className="video__images">
           <div className="video__detailbox__header__container">
             <header className="video__detailbox__header">
-              Youtube Thumbnail Image
+              Youtube Video Thumbnail Image
             </header>
             <GridImageSelect
               image={this.props.video.youtubeOverrideImage}

--- a/public/video-ui/src/components/VideoImages/VideoImages.js
+++ b/public/video-ui/src/components/VideoImages/VideoImages.js
@@ -49,7 +49,7 @@ export default class VideoImages extends React.Component {
               gridDomain={this.props.gridDomain}
               disabled={this.props.videoEditOpen}
               updateVideo={this.saveAndUpdateVideoImage}
-              fieldLocation="posterImage"
+              fieldLocation="posterImage" 
             />
           </div>
           <GridImage image={this.props.video.posterImage} />
@@ -65,10 +65,26 @@ export default class VideoImages extends React.Component {
               gridDomain={this.props.gridDomain}
               disabled={trailImageDisabled}
               updateVideo={this.saveAndUpdateVideoImage}
-              fieldLocation="trailImage"
+              fieldLocation="trailImage" 
             />
           </div>
           <GridImage image={this.props.video.trailImage} />
+        </div>
+        <div className="video__detailbox">
+          <div className="video__detailbox__header__container">
+            <header className="video__detailbox__header">
+              Youtube Thumbnail Image Override
+            </header>
+            <GridImageSelect
+              image={this.props.video.youtubeOverrideImage}
+              gridUrl={this.getGridUrl('video')}
+              gridDomain={this.props.gridDomain}
+              disabled={this.props.videoEditOpen}
+              updateVideo={this.saveAndUpdateVideoImage}
+              fieldLocation="youtubeOverrideImage" 
+            />
+          </div>
+          <GridImage image={this.props.video.youtubeOverrideImage} />
         </div>
       </div>
     );

--- a/public/video-ui/src/components/utils/GridImageSelect.js
+++ b/public/video-ui/src/components/utils/GridImageSelect.js
@@ -12,7 +12,7 @@ export default class GridImageSelect extends React.Component {
     gridDomain: PropTypes.string.isRequired,
     disabled: PropTypes.bool.isRequired,
     updateVideo: PropTypes.func.isRequired,
-    fieldLocation: PropTypes.oneOf(['posterImage', 'trailImage'])
+    fieldLocation: PropTypes.oneOf(['posterImage', 'trailImage', 'youtubeOverrideImage'])
   };
 
   state = {

--- a/public/video-ui/src/constants/blankVideoData.js
+++ b/public/video-ui/src/constants/blankVideoData.js
@@ -22,5 +22,8 @@ export const blankVideoData = {
   },
   trailImage: {
     assets: []
+  },
+  youtubeOverrideImage: {
+    assets: []
   }
 };

--- a/public/video-ui/src/constants/imageFields.js
+++ b/public/video-ui/src/constants/imageFields.js
@@ -1,1 +1,1 @@
-export const imageFields = ['posterImage', 'trailImage'];
+export const imageFields = ['posterImage', 'trailImage', 'youtubeOverrideImage'];

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -117,7 +117,11 @@ class VideoDisplay extends React.Component {
               <tr>
                 <td>Used as the preview image for a video in articles and on video pages.</td>
                 <td>Used as an article trail image when specified. (Otherwise Main Image is used).</td>
-                <td>Used on YouTube when specified. (Otherwise Main Image is used).</td>
+                <td>
+                  Used on YouTube when specified. (Otherwise Main Image is used).
+                  <br/>
+                  The atom must be published for the override to take effect. Changes can take up to fifteen minutes to apply.
+                </td>
               </tr>
             </tbody>
           </table>

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -100,6 +100,32 @@ class VideoDisplay extends React.Component {
     );
   }
 
+  renderDescription(){
+    return (
+      <div>
+        <p className="video__images_heading">How are these fields used?</p>
+        <div>
+          <table class="video__images_description_table">
+            <thead>
+              <tr>
+                <th scope="row">Main Image</th>
+                <th scope="row">Composer Trail Image</th>
+                <th scope="row">Youtube Image Override</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Used as the preview image for a video in articles and on video pages.</td>
+                <td>Used as an article trail image when specified. (Otherwise Main Image is used).</td>
+                <td>Used on YouTube when specified. (Otherwise Main Image is used).</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    )
+  }
+
   renderPreviewAndImages() {
     const isYoutube = VideoUtils.isYoutube(this.props.video);
     const activeAsset = VideoUtils.getActiveAsset(this.props.video);
@@ -124,6 +150,7 @@ class VideoDisplay extends React.Component {
         <div className="video-preview">
           {this.renderPreview()}
           {this.renderImages()}
+          {this.renderDescription()}
         </div>
       </div>
     );

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -103,7 +103,7 @@ class VideoDisplay extends React.Component {
   renderDescription(){
     return (
       <div>
-        <p className="video__images_heading">How are these fields used?</p>
+        <p className="video__images_heading">How are these images used?</p>
         <div>
           <table class="video__images_description_table">
             <thead>

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -108,9 +108,9 @@ class VideoDisplay extends React.Component {
           <table class="video__images_description_table">
             <thead>
               <tr>
-                <th scope="row">Main Image</th>
+                <th scope="row">Guardian Video Thumbnail Image</th>
                 <th scope="row">Composer Trail Image</th>
-                <th scope="row">Youtube Image Override</th>
+                <th scope="row">Youtube Video Thumbnail Image</th>
               </tr>
             </thead>
             <tbody>

--- a/public/video-ui/src/util/cleanVideoData.js
+++ b/public/video-ui/src/util/cleanVideoData.js
@@ -7,7 +7,7 @@ export function cleanVideoData(data) {
     }
   });
 
-  ['posterImage', 'trailImage'].forEach(image => {
+  ['posterImage', 'trailImage', 'youtubeOverrideImage'].forEach(image => {
     if (
       cleanedData[image] &&
       cleanedData[image].assets &&

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -54,12 +54,14 @@
 
 .video__imagebox {
   display: flex;
+  gap: 10px;
 }
 
 .video__detailbox__header__container {
   display: flex;
   justify-content: space-between;
   padding: 10px;
+  margin-right: 4px;
 }
 
 .video__detailbox {
@@ -104,4 +106,42 @@
 
 .video-player {
   max-width: 100%;
+}
+
+.video__images {
+  width: 33%;
+  flex: 1 0 20%;
+  margin-top: 10px;
+  background-color: #393939;
+  border-top: 1px solid #666666;
+}
+
+.video__images_description_table {
+  border-spacing: 0px;
+}
+
+.video__images_description_table th, .video__images_description_table td {
+  padding: 0px 8px 8px 0px;
+  width: 33%;
+  vertical-align: top;
+}
+
+.video__images_description_table th:last-of-type, .video__images_description_table td:last-of-type {
+  padding: 0px;
+}
+
+.video__images_description_table td {
+  color: $cWhite;
+}
+
+.video__images_heading {
+  font-weight: 700;
+  margin: 0 0 5px;
+  padding: 8px 0 0;
+  border-top: 1px solid #3e3e3e;
+  text-align: left;
+}
+
+.video__images_description {
+  color: $color500Grey;
 }

--- a/test/ThriftUtilSpec.scala
+++ b/test/ThriftUtilSpec.scala
@@ -34,19 +34,19 @@ class ThriftUtilSpec extends FunSpec
     it("should correctly generate media atom data") {
       inside(parseMediaAtom(makeParams("uri" -> youtubeUrl))) {
         case Right(MediaAtom(assets, Some(1L), "unknown", Category.News, None, None, None, None, None, None, None, None,
-        None, None, None, None, None, None, None)) =>
+        None, None, None, None, None, None, None, None)) =>
           assets should have length 1
           assets.head should equal(Asset(AssetType.Video, 1L, youtubeId, Platform.Youtube))
       }
     }
 
     it("should create empty assets without uri") {
-      parseMediaAtom(Map.empty) should matchPattern { case Right(MediaAtom(Nil, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _)) => }
+      parseMediaAtom(Map.empty) should matchPattern { case Right(MediaAtom(Nil, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _)) => }
     }
 
     it("should create multiple assets with multiple uri params") {
       inside(parseMediaAtom(Map("uri" -> List(youtubeUrl, youtubeUrl)))) {
-        case Right(MediaAtom(assets, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _)) =>
+        case Right(MediaAtom(assets, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _)) =>
           assets should have length 2
       }
     }
@@ -71,7 +71,7 @@ class ThriftUtilSpec extends FunSpec
 
       inside(parseMediaAtom(makeParams("uri" -> youtubeUrl, "metadata" -> meta))) {
         case Right(MediaAtom(assets, Some(1L), "unknown", Category.News, None, None, None, None, None, metadata, None,
-        None, None, None, None, None, None, None, None)) =>
+        None, None, None, None, None, None, None, None, None)) =>
           metadata should matchPattern { case Some(Metadata(_, _, _, Some(true), Some("channelId"), Some(PrivacyStatus.Private), Some(1), _, _)) => }
       }
     }


### PR DESCRIPTION
## What does this change?

This PR allows the user to override the image for the YouTube thumbnail, to be used instead of the poster image if specified. 

The videos team occasionally want to create a specific YouTube thumbnail that will improve video performance on that platform, but we wouldn't necessarily want to use on our site. They currently do this manually on YouTube, but updates to the Media Atom overwrite the thumbnails updated on YouTube itself.

I've modified the layout slightly to make a better use of the space, and I've also provided a description of what the images are used for as I don't think it's especially clear, especially now that we have a third option.

Some examples of custom thumbnails set in YouTube:
<img width="326" alt="image" src="https://user-images.githubusercontent.com/34686302/204012100-ca255615-5040-4433-b972-48a9edfdc401.png">

## Dependencies - all now merged
Because content atoms are stored in CAPI, this PR required a change to the thrift model and elasticsearch mappings enabled by these PRs:
- https://github.com/guardian/content-atom/pull/155 - (update the thrift definition for content atoms)
- https://github.com/guardian/content-api/pull/2721 - (update the elastic search mapping to include the youtubeOverride field and specify its shape)
- https://github.com/guardian/content-api/pull/2730 - (update capi porter to reflect the updated thrift model)
- https://github.com/guardian/content-api-models/pull/219 - (update content-api-models to reflect the change to the content atom)
- https://github.com/guardian/content-api/pull/2732 - (update comtent-api-models version used by capi concierge)
- https://github.com/guardian/atom-maker/pull/86 - (update atom-maker's content-api-models version because media-atom-maker accesses the model indirectly via atom-maker

This is a lot of PRs for a data change that won't be manifested anywhere other than YouTube - and which therefore doesn't really need to be in CAPI. If we are to support the videos team with future changes specific to YouTube, it might make sense to provide a separate database for YouTube specific information, e.g. a DynamoDB table keyed against the video id in CAPI.

(For example, the videos team would ideally like to be auto-populate channel-specific branding for channels like Guardian Sport from media-atom-maker).

## Before and after:

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/34686302/228498143-a8dea91b-dd9e-4381-a26a-4656e4456c96.png) | ![image](https://user-images.githubusercontent.com/34686302/228498668-ec9cd711-75ff-46ef-a3d9-118b52076609.png) |

## Testing
The easiest way to test this change is probably deploying to our CODE environment via RiffRaff, where media-atom-maker shows as `media-service:media-atom-maker`.

1. Add a video to YouTube via [media atom maker](https://video.code.dev-gutools.co.uk/). I've observed that thumbnails for videos with small dimensions don't tend to work properly so use a landscape video with a decent resolution.
  i. There are required fields in the 'Furniture' and 'YouTube Furniture Tab' which must be completed 
  ii. After the above, a video can be updated from the pencil icon in the top right corner of the 'Video Preview' panel (shows the tooltip 'Add Assets' on hover). 
  iii. Choose 'Upload to YouTube', upload an video you have locally on your machine and activate it
2. Back on the main video page, add a YouTube Thumbnail Image from the Grid, in addition to a Main Image.
3. Publish the video
4. Is the YouTube Thumbnail Image used as the video thumbnail rather than the Main Image?

How does the user experience feel to you? I've experienced thumbnail update delays of 10-15 minutes from YouTube which can make it feel like media-atom-maker isn't doing its job. It also doesn't feel obvious that you need to publish the video in order to apply the thumbnail.