### PR TITLE
Fix Snyk Java version to 8

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -14,5 +14,6 @@ jobs:
       DEBUG: true
       ORG: guardian
       SKIP_NODE: false
+      JAVA_VERSION: 8
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist
 metals.sbt
 .bloop
 .bsp/
+.java-version


### PR DESCRIPTION
## What does this change?

Fixes the Java version for the Snyk integration to 8, to match the project's

## How to test

Snyk integration runs successfully for this branch
