### PR TITLE
add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+## code changes will send PR to following users. See https://help.github.com/articles/about-codeowners/
+* @guardian/digital-cms


### PR DESCRIPTION
## What does this change?
Add CODEOWNERS file to automatically add digital-cms in the list of required reviewers

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How can we measure success?
New PRs should automatically list digital-cms in the list of reviewers
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
Tested on other repos and this doesn't seem to introduce any breaking changes
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->