### PR TITLE
Fix-up various sbt errors & problems

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,5 +1,4 @@
 -J-Xms512M
 -J-Xmx1536M
 -J-Xss4M
--J-XX:+CMSClassUnloadingEnabled
 -J-Dhttp.port=9001

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
-# blocked at this version until play 2.8
-sbt.version=1.8.0
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,4 @@
-// The Typesafe repository
-resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/maven-releases/"
-
-// a, faster, alternative dependancy resolver to ivy
-// https://github.com/coursier/coursier#sbt-plugin
+// This early version of coursier needs to be removed, but right now doing so exposes dependency conflicts...
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC12")
 
 // Use the Play sbt plugin for Play projects
@@ -12,7 +8,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.17")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
 // for creating test cases that use a local dynamodb
 
@@ -26,12 +22,11 @@ libraryDependencies += "org.vafer" % "jdeb" % "1.6" artifacts (Artifact("jdeb", 
 addDependencyTreePlugin
 
 /*
-   Because scala-xml has not be updated to 2.x in sbt yet but has in sbt-native-packager
+   scala-xml has been updated to 2.x in sbt, but not in other sbt plugins like sbt-native-packager
    See: https://github.com/scala/bug/issues/12632
-
-   This effectively overrides the safeguards (early-semver) put in place by the library authors ensuring binary compatibility.
-   We consider this a safe operation because it only affects the compilation of build.sbt, not of the application build itself
+   This is effectively overrides the safeguards (early-semver) put in place by the library authors ensuring binary compatibility.
+   We consider this a safe operation because when set under `projects/` (ie *not* in `build.sbt` itself) it only affects the
+   compilation of build.sbt, not of the application build itself.
+   Once the build has succeeded, there is no further risk (ie of a runtime exception due to clashing versions of `scala-xml`).
  */
-libraryDependencySchemes ++= Seq(
-  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
-)
+libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always


### PR DESCRIPTION
Here's a few tweaks for sbt config that I came across while trying out the project. This sits upon @rebecca-thompson's awesome work in #1085 !

* Update `sbt-riffraff-artifact` plugin to v1.1.18 to fix the noisy AWS SDK "Unable to retrieve the requested metadata" error that occurs on starting sbt - see https://github.com/guardian/sbt-riffraff-artifact/pull/68 . Without the fix, we see a big noisy non-fatal error like this: https://gist.github.com/rtyley/13dae25b0531cd644c36626d36d4aa6a
* Remove the `-XX:+CMSClassUnloadingEnabled` flag from `.sbtopts`. This option is [enabled by default in Java 8](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html#:~:text=%2DXX%3A%2B-,CMSClassUnloadingEnabled,-Enables%20class%20unloading) onwards (so there's no point in setting it!) and it may be removed in later versions of Java. See also https://stackoverflow.com/q/3334911/438886
* Remove the [obsolete](https://discuss.lightbend.com/t/typesaferepo-https-repo-typesafe-com-typesafe-releases-is-returning-a-404-error/8156) and broken https://repo.typesafe.com/ resolver 
* Tweak `scala-xml` library scheme declaration (to make it more compact) and associated comment (fixing inverted statement)

Not included in this update:

 * Removing the superfluous `sbt-coursier` plugin from plugins.sbt - sbt v1.3 and above ship with coursier support out-of-the-box (https://get-coursier.io/docs/sbt-coursier), so we shouldn't be specifying an older version. However, removing it, and using the newer embedded version of coursier, exposes existing version conflicts in library dependencies that I'm not ready to deal with right now:
   * https://github.com/guardian/media-atom-maker/actions/runs/7729320064/job/21072198692
   * https://gist.github.com/rtyley/2802ea4235f5f9018aac4f273dc10975