### PR TITLE
Add `/live/` urls to youtube url parser

### DIFF
--- a/common/src/main/scala/com/gu/media/youtube/YoutubeUrl.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YoutubeUrl.scala
@@ -1,7 +1,7 @@
 package com.gu.media.youtube
 
 object YoutubeUrl {
-  private val re = "^https://(?:www.youtube(?:\\-nocookie)?.com/(?:watch\\?v=|embed/)|youtu.be/)([a-zA-Z0-9_-]{11}).*$".r
+  private val re = "^https://(?:(?:www\\.)?youtube(?:\\-nocookie)?\\.com/(?:watch\\?v=|embed/|live/)|youtu\\.be/)([a-zA-Z0-9_-]{11}).*$".r
 
   def unapply(url: String): Option[String] = parse(url)
 

--- a/common/src/test/scala/com/gu/media/youtube/YoutubeUrlTest.scala
+++ b/common/src/test/scala/com/gu/media/youtube/YoutubeUrlTest.scala
@@ -31,6 +31,14 @@ class YoutubeUrlTest extends FunSuite with MustMatchers {
     YoutubeUrl.parse("https://www.youtube.com/embed/CqUDO-livlc?rel=0&autoplay=1") must be(Some("CqUDO-livlc"))
   }
 
+  test("Extract video id from YouTube live URL with extra param") {
+    YoutubeUrl.parse("https://www.youtube.com/live/CqUDO-livlc?feature=share") must be(Some("CqUDO-livlc"))
+  }
+
+  test("Extract video id from YouTube live URL missing www.") {
+    YoutubeUrl.parse("https://youtube.com/live/CqUDO-livlc?feature=share") must be(Some("CqUDO-livlc"))
+  }
+
   test("Fail to extract video id from invalid URL") {
     YoutubeUrl.parse("https://www.foo.com/watch?v=CqUDO-livlc") must be(None)
   }


### PR DESCRIPTION
## What does this change?

Looks like a new format added to youtube, this is what you get if you click "share" on a livestream page now

eg. `https://youtube.com/live/abcdefghijk?feature=share`

also handles missing `www.` and tightens `.` in regex to match exactly

we could also think about adding `studio.youtube` links, leaving that for a future think though
