### PR TITLE
Fix bug with isEdToolsDomain

### DIFF
--- a/public/video-ui/src/components/FormFields/richtext/utils/linkValidator.ts
+++ b/public/video-ui/src/components/FormFields/richtext/utils/linkValidator.ts
@@ -62,7 +62,7 @@ const isEdToolsDomain = (rawLink: string) => {
 };
 
 export const linkValidator = (rawLink: string) => {
-  if (rawLink === ""){
+  if (!rawLink){
     return {valid: false, message: "Empty URL provided", link: rawLink};
   }
   if (isEdToolsDomain(rawLink)) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fixes bug introduced by https://github.com/guardian/media-atom-maker/pull/1096

`isEdToolsDomain` was being called with values other than a string, so the `.includes` call was failing.

This PR only calls `isEdToolsDomain` if the value of `rawString` is truthy - so it won't ever be called with `null` (as is happening currently).

I've tested it locally.
