### PR TITLE
Increase padding around logo

### DIFF
--- a/app/util/ThumbnailGenerator.scala
+++ b/app/util/ThumbnailGenerator.scala
@@ -32,7 +32,7 @@ case class ThumbnailGenerator(logoFile: File) extends Logging {
     val logoHeight: Double = logo.getHeight() / (logo.getWidth() / logoWidth)
 
     // amount of padding (px) on left and bottom of logo
-    val PADDING = (logoHeight/8).toInt
+    val PADDING = (logoHeight/4).toInt
     val logoX = PADDING
     val logoY = bgImage.getHeight() - logoHeight.toInt - PADDING
 

--- a/app/util/ThumbnailGenerator.scala
+++ b/app/util/ThumbnailGenerator.scala
@@ -32,7 +32,7 @@ case class ThumbnailGenerator(logoFile: File) extends Logging {
     val logoHeight: Double = logo.getHeight() / (logo.getWidth() / logoWidth)
 
     // amount of padding (px) on left and bottom of logo
-    val PADDING = (logoHeight/4).toInt
+    val PADDING = (bgImage.getHeight() / 18.0).toInt
     val logoX = PADDING
     val logoY = bgImage.getHeight() - logoHeight.toInt - PADDING
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR increase the padding around the Guardian logo in video thumbnails.

The logo is currently a bit too close to the edge of the thumbnails. If a video has been watched, a red bar obscures the logo in smaller video thumbnails on YouTube.

![image](https://user-images.githubusercontent.com/34686302/227488340-621cbabe-815f-4115-9cc9-7c644bb86bc7.png)

---

The video team have shared their preferred spacing: 

![image](https://user-images.githubusercontent.com/34686302/227488579-54b0ecbc-fc52-4779-a680-cc9d9def68b0.png)

---

The padding is now set to 1/18th of the video height (formerly it was a quarter of the logo height).

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/34686302/227493377-20479a1a-3f71-4b86-9cdf-776bead66422.png) | ![image](https://user-images.githubusercontent.com/34686302/227493392-972a2da3-0da9-4a22-a2b5-6290836c3914.png) |

## How to test

1. Deploy this branch to CODE.
2. Upload a video and set the video thumbnail - or change this thumbnail: https://video.code.dev-gutools.co.uk/videos/9ddf5ac9-5adf-46de-a6d8-c0b14a25ff4d
3. Does the logo padding match the intended spacing?