### PR TITLE
Add various styling fixes

### DIFF
--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -114,6 +114,10 @@
     border-radius: 0;
     text-indent: .01px;
     text-overflow: '';
+    &:hover {
+      cursor: pointer;
+      background-color: $color625Grey;
+    }
   }
 
   &--error {
@@ -189,7 +193,7 @@
 .form__image {
   padding: 10px;
   text-align: center;
-  background-color: $color700Grey;
+  background-color: inherit;
 }
 
 

--- a/public/video-ui/styles/components/_presence.scss
+++ b/public/video-ui/styles/components/_presence.scss
@@ -1,5 +1,6 @@
 .presence-section {
   display: inline-block;
+  margin-left: 10px;
 }
 
 .presence-list {

--- a/public/video-ui/styles/layout/_tabs.scss
+++ b/public/video-ui/styles/layout/_tabs.scss
@@ -7,7 +7,7 @@
 .react-tabs__tab {
   display: inline-block;
   border: 1px solid $color600Grey;
-  border-bottom: 4px solid transparent;
+  border-top: 0px;
   position: relative;
   list-style: none;
   padding: 10px 20px;
@@ -27,7 +27,8 @@
 
   &--selected {
     background-color: $color600Grey;
-    border-bottom: 4px solid $brandColor;
+    box-shadow: inset 0px -4px 0px 0px $brandColor;
+    border-bottom-color: $brandColor;
     color: $brandColor;
 
     &:hover {

--- a/public/video-ui/styles/layout/_tabs.scss
+++ b/public/video-ui/styles/layout/_tabs.scss
@@ -38,7 +38,11 @@
 
   &--disabled {
     color: $color600Grey;
-    cursor: default;
+    &:hover {
+      color: $color600Grey;
+      background-color: $color650Grey;
+      cursor: not-allowed;
+    }
   }
 }
 

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -8,6 +8,7 @@
 .video__main {
   flex-grow: 1;
   background-color: $color800Grey;
+  padding: 10px;
 
   &__header {
     display: flex;
@@ -17,6 +18,7 @@
 
 .video__row {
   display: flex;
+  gap: 10px;
 }
 
 .video-preview {
@@ -66,7 +68,6 @@
 
 .video__detailbox {
   flex: 1 0 20%;
-  margin: 10px;
   background-color: $color650Grey;
   border-top: 1px solid $color600Grey;
 


### PR DESCRIPTION
## What does this change?

This PR adds a few styling fixes:
1. Remove double padding between the two main video panels

| Before | After |
| --- | --- |
| ![double-margin-before](https://user-images.githubusercontent.com/34686302/236508090-b237c576-c5fa-46bc-bf3b-a8dddea59b1a.png) | ![double-margin-after](https://user-images.githubusercontent.com/34686302/236508117-c274002b-5b6b-4cdf-8ac6-e0293d20bc24.png) |

2. Reflow edit panel menu items more elegantly at smaller screen sizes (e.g. maintain border around items, used inner shadow instead of larger yellow bottom border when selected)

| Before | After |
| --- | --- |
| ![menu-collapse-before](https://user-images.githubusercontent.com/34686302/236508204-46f06adc-f038-4db5-a5f5-eaf25412f4a1.png) | ![menu-collapse-after](https://user-images.githubusercontent.com/34686302/236508278-5fd07d40-6877-44c8-97d2-af3eab0c25ae.png) | 


3. Make the disabled state for the edit panel menu items more clear

| Before | After |
| --- | --- |
|  ![menu-item-after](https://github.com/guardian/media-atom-maker/assets/34686302/16bb9e6f-eb86-4477-a112-6db9c673577a) | ![menu-disabled-after](https://github.com/guardian/media-atom-maker/assets/34686302/7a6c60a7-99e3-491d-8571-b0a85b52e4d2) |

4. Add hover state to dropdowns

| Before | After |
| --- | --- |
| ![select-hover-state-before](https://github.com/guardian/media-atom-maker/assets/34686302/a2ba0e34-cd04-4282-b0a3-f15e99bfdb70) | ![select-hover-state-after](https://github.com/guardian/media-atom-maker/assets/34686302/aa2714bc-9d99-4a47-b53c-855b6e5825b2) | 

5. Add margin to the left of the presence indicators section

## How to test

Run the application locally according to the instructions in the readme, or deploy to CODE. Do the styling change work as expected? Are there any unintended style changes?

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
