### PR TITLE
Add more styling fixes

### DIFF
--- a/public/video-ui/src/components/ContentChangeDetails/index.js
+++ b/public/video-ui/src/components/ContentChangeDetails/index.js
@@ -11,13 +11,13 @@ class ContentChangeDetails extends React.Component {
   };
 
   getTextField = (path, caption) => (
-    <ManagedField fieldLocation={path} name={caption} disabled={true}>
+    <ManagedField fieldLocation={path} name={caption}>
       <TextInput />
     </ManagedField>
   );
 
   getDateField = (path, caption) => (
-    <ManagedField fieldLocation={path} name={caption} disabled={true}>
+    <ManagedField fieldLocation={path} name={caption} className="unhide">
       <DatePicker />
     </ManagedField>
   );

--- a/public/video-ui/src/components/FormFields/CheckBox.js
+++ b/public/video-ui/src/components/FormFields/CheckBox.js
@@ -15,6 +15,7 @@ export default class CheckBox extends React.Component {
           onChange={e => {
             this.props.onUpdateField(e.target.checked);
           }}
+          className='form-checkbox'
         />
       </div>
     );

--- a/public/video-ui/src/components/FormFields/RichTextField.tsx
+++ b/public/video-ui/src/components/FormFields/RichTextField.tsx
@@ -69,12 +69,12 @@ export default class RichTextField extends React.Component<EditorProps, EditorSt
         <button
           type="button"
           disabled={!this.props.derivedFrom}
-          className="btn form__label__button"
+          className="btn form__label__button form__label__copy-button"
           onClick={this.updateValueFromCopy}
           data-tip="Copy trail text from description"
           data-place="top"
         >
-          <i className="icon">edit</i>
+          Copy from standfirst
         </button>
         );
   };
@@ -141,7 +141,7 @@ export default class RichTextField extends React.Component<EditorProps, EditorSt
   render() {
     return (
       <div className="form__row">
-        <div className="form__label__layout">
+        <div className="form__label__layout form__label__layout__rich-text">
           <label className="form__label">{this.props.fieldName}</label>
           {this.renderCopyButton()}
         </div>

--- a/public/video-ui/src/components/PACUpload/PACUpload.js
+++ b/public/video-ui/src/components/PACUpload/PACUpload.js
@@ -90,23 +90,26 @@ export default class PACUpload extends React.Component {
   render() {
     return (
       <section className="video__detailbox">
-        <header className="video__detailbox__header">
-          Upload PAC Form XML
-        </header>
         <div className="form__group">
-          <input type="file"
-                 accept=".xml"
-                 disabled={this.state.uploading}
-                 onChange={e => this.validate(e.target.files)}/>
-          <button type="button"
-                  className={this.getButtonClassName()}
-                  disabled={this.state.uploading || !this.state.isValid || this.state.uploaded}
-                  onClick={() => this.uploadFile()}
-          >
-            <Icon icon={this.getButtonIcon()}>
-              {this.getUploadButtonText()}
-            </Icon>
-          </button>
+          <header className="video__detailbox__header video__detailbox__header-with-border">
+            Upload PAC Form XML
+          </header>
+          <div className="form__row">
+            <input type="file"
+                  className="form__field__file"
+                  accept=".xml"
+                  disabled={this.state.uploading}
+                  onChange={e => this.validate(e.target.files)}/>
+            <button type="button"
+                    className={this.getButtonClassName()}
+                    disabled={this.state.uploading || !this.state.isValid || this.state.uploaded}
+                    onClick={() => this.uploadFile()}
+            >
+              <Icon icon={this.getButtonIcon()}>
+                {this.getUploadButtonText()}
+              </Icon>
+            </button>
+          </div>
         </div>
       </section>
     );

--- a/public/video-ui/src/components/Pluto/PlutoProjectPicker.js
+++ b/public/video-ui/src/components/Pluto/PlutoProjectPicker.js
@@ -43,6 +43,9 @@ class PlutoProjectPicker extends React.Component {
         editable={true}
         formName="Pluto"
       >
+        <header className="video__detailbox__header">
+          Pluto
+        </header>
         <ManagedField
           fieldLocation="plutoData.commissionId"
           name="Commission"

--- a/public/video-ui/src/components/VideoUpload/AddAssetFromURL.js
+++ b/public/video-ui/src/components/VideoUpload/AddAssetFromURL.js
@@ -21,10 +21,8 @@ export default class AddAssetFromURL extends React.Component {
 
     return (
       <div className="video__detailbox video__detailbox__assets">
-        <div className="video__detailbox__header__container">
-          <header className="video__detailbox__header">Asset URL</header>
-        </div>
         <div className="form__group">
+          <header className="video__detailbox__header video__detailbox__header-with-border">Asset URL</header>
           <div className="form__row">
             <div>
               <input

--- a/public/video-ui/src/components/VideoUpload/AddSelfHostedAsset.js
+++ b/public/video-ui/src/components/VideoUpload/AddSelfHostedAsset.js
@@ -25,34 +25,34 @@ export default class AddSelfHostedAsset extends React.Component {
 
     return (
       <div className="video__detailbox video__detailbox__assets">
-        <div className="video__detailbox__header__container">
-          <header className="video__detailbox__header">
+        <div className="form__group">
+          <header className="video__detailbox__header video__detailbox__header-with-border">
             Self-Hosted Video
           </header>
-        </div>
-        <div className="form__group">
-          <input
-            className="form__field"
-            type="file"
-            onChange={this.setFile}
-            disabled={uploading}
-            accept="video/*,.mxf"
-          />
-          <button
-            type="button"
-            className="btn button__secondary__assets"
-            disabled={!this.state.file || uploading}
-            onClick={() =>
-              startUpload({
-                id: video.id,
-                file: this.state.file,
-                selfHost: true
-              })}
-          >
-            <Icon icon="backup">
-              Upload
-            </Icon>
-          </button>
+          <div className="form__row">
+            <input
+              className="form__field__file"
+              type="file"
+              onChange={this.setFile}
+              disabled={uploading}
+              accept="video/*,.mxf"
+            />
+            <button
+              type="button"
+              className="btn button__secondary__assets"
+              disabled={!this.state.file || uploading}
+              onClick={() =>
+                startUpload({
+                  id: video.id,
+                  file: this.state.file,
+                  selfHost: true
+                })}
+            >
+              <Icon icon="backup">
+                Upload
+              </Icon>
+            </button>
+          </div>
         </div>
       </div>
     );

--- a/public/video-ui/src/components/VideoUpload/YoutubeUpload.js
+++ b/public/video-ui/src/components/VideoUpload/YoutubeUpload.js
@@ -19,9 +19,9 @@ export default class YoutubeUpload extends React.Component {
 
   renderWarning() {
     return (
-      <span className="form__message form__message--warning">
+      <p className="form__message form__message--warning">
         A YouTube channel, category and privacy status are needed before uploading a video
-      </span>
+      </p>
     );
   }
 
@@ -31,36 +31,35 @@ export default class YoutubeUpload extends React.Component {
     const canUploadToYouTube = VideoUtils.canUploadToYouTube(video);
 
     return (
-      <div className="video__detailbox video__detailbox__assets">
-        <div className="video__detailbox__header__container">
-          <header className="video__detailbox__header">
+      <div className="video__detailbox video__detailbox__assets">   
+        <div className="form__group">
+          <header className="video__detailbox__header video__detailbox__header-with-border">
             Upload to YouTube
           </header>
-        </div>
-        <div className="form__group">
-          {!canUploadToYouTube ? this.renderWarning() : ''}
-          <input
-            className="form__field"
-            type="file"
-            onChange={this.setFile}
-            disabled={!canUploadToYouTube || this.props.uploading}
-            accept="video/*,.mxf"
-          />
-          <button
-            type="button"
-            className="btn button__secondary__assets"
-            disabled={!canUploadToYouTube || this.props.uploading || !this.state.file}
-            onClick={() =>
-              startUpload({
-                id: video.id,
-                file: this.state.file,
-                selfHost: false
-              })}
-          >
-            <Icon icon="backup">
-              Upload To YouTube
-            </Icon>
-          </button>
+          <div className="form__row">
+            <input
+              className="form__field__file"
+              type="file"
+              onChange={this.setFile}
+              disabled={!canUploadToYouTube || this.props.uploading}
+              accept="video/*,.mxf"
+            />
+            <button
+              type="button"
+              className="btn button__secondary__assets"
+              disabled={!canUploadToYouTube || this.props.uploading || !this.state.file}
+              onClick={() =>
+                startUpload({
+                  id: video.id,
+                  file: this.state.file,
+                  selfHost: false
+                })}
+            >
+              <Icon icon="backup">
+                Upload To YouTube
+              </Icon>
+            </button>
+          </div>
         </div>
       </div>
     );

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.js
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.js
@@ -77,9 +77,9 @@ export default class VideoUsages extends React.Component {
 
       return (
         <div key={`${state}-usages`}>
-          <h4>{`${state.charAt(0).toUpperCase() + state.slice(1)} (Total: ${totalUsages})`}</h4>
+          <p className='details-list__title'>{`${state.charAt(0).toUpperCase() + state.slice(1)} (Total: ${totalUsages})`}</p>
           {totalUsages === 0
-            ? <div className="usage--none">{`No ${state} usages found`}</div>
+            ? <p className="usage--none details-list__field">{`No ${state} usages found`}</p>
             : <ul className="detail__list">
                 {usages[state].video.map(usage => this.renderUsage({usage, state}))}
                 {usages[state].other.map(usage => this.renderUsage({usage, state}))}

--- a/public/video-ui/src/pages/Upload/index.js
+++ b/public/video-ui/src/pages/Upload/index.js
@@ -38,11 +38,6 @@ class VideoUpload extends React.Component {
           <div className="video__main__header">
             <div className="video__detailbox">
               <div>
-                <div className="video__detailbox__header__container">
-                  <header className="video__detailbox__header">
-                    Pluto
-                  </header>
-                </div>
                 <div className="form__group">
                   { projectId && <PlutoProjectLink projectId={projectId}/> }
                   <PlutoProjectPicker

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -148,7 +148,7 @@ class VideoDisplay extends React.Component {
             onClick={e => this.handleAssetClick(e)}
             data-tip="Edit Assets"
           >
-            <Icon className="icon__edit" icon="edit" />
+            <Icon className={"icon__edit"  + (this.props.videoEditOpen ? ' icon__edit__disabled' : '')} icon="edit" />
           </Link>
         </div>
         <div className="video-preview">

--- a/public/video-ui/styles/abstracts/_variables.scss
+++ b/public/video-ui/styles/abstracts/_variables.scss
@@ -25,7 +25,7 @@ $color300Grey: #DCDCDC; // hsl(59,0%,86%)
 $color400Grey: #BDBDBD; // hsl(59,0%,74%)
 $color500Grey: #898984; // hsl(59,3%,53%)
 $color600Grey: #666666; // hsl(59,0%,46%)
-$color625Grey: #3e3e3e; // hsl(59,0%,20%)
+$color625Grey: #444444; // hsl(59,0%,20%)
 $color650Grey: #393939; // hsl(59,0%,20%)
 $color700Grey: #333333; // hsl(59,0%,20%)
 $color800Grey: #252525;

--- a/public/video-ui/styles/components/_buttons.scss
+++ b/public/video-ui/styles/components/_buttons.scss
@@ -51,9 +51,6 @@ button {
 .button__secondary {
   @include buttonClass($color800Grey, $color500Grey, $color300Grey, $color800Grey);
 
-  &__assets {
-    margin: 5px;
-  }
   &--confirm {
     @include buttonClass($cGreen33, $color500Grey, $cWhite, $color800Grey);
   }

--- a/public/video-ui/styles/components/_details-list.scss
+++ b/public/video-ui/styles/components/_details-list.scss
@@ -36,5 +36,8 @@
 
 .details-list__big {
   padding-right: 10px;
+}
 
+.detail__list {
+  margin: 0 0 10px;
 }

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -87,8 +87,21 @@
     outline: none;
   }
 
-  &[type="file"] {
+  &__file {
     border: none;
+    display: block;
+    margin: 0 0 10px;
+    font-family: $text-font-stack;
+
+    &::file-selector-button {
+      padding: 5px 7px;
+      margin-right: 8px;
+      border: none;
+      &:hover{
+        background-color: $color300Grey;
+        cursor: pointer;
+      }
+    }
   }
 
   // Placeholder styling, separated because if one selector is invalid, the browser will ignore the rest

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -114,6 +114,10 @@
     border-radius: 0;
     text-indent: .01px;
     text-overflow: '';
+    &:hover {
+      cursor: pointer;
+      background-color: $color625Grey;
+    }
   }
 
   &--error {
@@ -189,7 +193,7 @@
 .form__image {
   padding: 10px;
   text-align: center;
-  background-color: $color700Grey;
+  background-color: inherit;
 }
 
 

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -215,61 +215,10 @@
   max-height: 250px;
 }
 
-.form-checkbox {
-  padding: 12px 35px;
-  font-size: 13px;
-  position: relative;
-  display: inline-block;
-  border: 1px solid $greyBorderColor;
-
-  &:after, &:before {
-    color: $cWhite;
-    width: 50%;
-    height: 100%;
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    z-index: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
-
-  &:after {
-    content: 'No';
-    right: 0;
-    background: $color600Grey;
-  }
-
-  &:before {
-    content: 'Yes';
-    left: 0;
-    background: #47af37;
-  }
-
-  &__toggle {
-    display: block;
-    width: 50%;
-    height: 100%;
+.form-checkbox{
+  &:hover {
+    filter: brightness(90%);
     cursor: pointer;
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    left: 0;
-    z-index: 1;
-    background: $cWhite;
-
-    &:hover {
-      background-color: $color200Grey;
-    }
-  }
-
-  &__input {
-    visibility: hidden;
-    &:checked + .form-checkbox__toggle {
-      right: 0;
-      left: auto;
-    }
   }
 }
 

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -176,6 +176,18 @@
   padding: 5px;
 }
 
+.form__label__copy-button {
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.form__label__layout__rich-text {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
 .form__message {
   font-size: 13px;
   margin-top: 10px;

--- a/public/video-ui/styles/components/_presence.scss
+++ b/public/video-ui/styles/components/_presence.scss
@@ -1,5 +1,6 @@
 .presence-section {
   display: inline-block;
+  margin-left: 10px;
 }
 
 .presence-list {

--- a/public/video-ui/styles/layout/_grid.scss
+++ b/public/video-ui/styles/layout/_grid.scss
@@ -11,7 +11,7 @@
 
 .grid__list {
   list-style: none;
-  padding: 0 20px;
+  padding: 0 0 0 20px;
   text-align: center;
 
   &__trail {

--- a/public/video-ui/styles/layout/_icons.scss
+++ b/public/video-ui/styles/layout/_icons.scss
@@ -67,6 +67,13 @@
   &.disabled {
     @include disabled;
   }
+  &__disabled {
+    @include disabled;
+    &:hover {
+      background-color: $color600Grey;
+      cursor: not-allowed;
+    }
+  }
 }
 
 

--- a/public/video-ui/styles/layout/_tabs.scss
+++ b/public/video-ui/styles/layout/_tabs.scss
@@ -7,7 +7,7 @@
 .react-tabs__tab {
   display: inline-block;
   border: 1px solid $color600Grey;
-  border-bottom: 4px solid transparent;
+  border-top: 0px;
   position: relative;
   list-style: none;
   padding: 10px 20px;
@@ -27,7 +27,8 @@
 
   &--selected {
     background-color: $color600Grey;
-    border-bottom: 4px solid $brandColor;
+    box-shadow: inset 0px -4px 0px 0px $brandColor;
+    border-bottom-color: $brandColor;
     color: $brandColor;
 
     &:hover {

--- a/public/video-ui/styles/layout/_tabs.scss
+++ b/public/video-ui/styles/layout/_tabs.scss
@@ -38,7 +38,11 @@
 
   &--disabled {
     color: $color600Grey;
-    cursor: default;
+    &:hover {
+      color: $color600Grey;
+      background-color: $color650Grey;
+      cursor: not-allowed;
+    }
   }
 }
 

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -72,10 +72,16 @@
   border-top: 1px solid $color600Grey;
 
   &__header {
-    color: $color500Grey;
+    color: $color400Grey;
     font-weight: bold;
     display: block;
     font-size: $fontsize__detailbox;
+    margin-bottom: 8px;
+    &-with-border {
+      margin-bottom: 10px;
+      padding-bottom: 6px;
+      border-bottom: 1px solid #444;
+    }
   }
 
   &__assets {

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -8,6 +8,7 @@
 .video__main {
   flex-grow: 1;
   background-color: $color800Grey;
+  padding: 10px;
 
   &__header {
     display: flex;
@@ -17,6 +18,7 @@
 
 .video__row {
   display: flex;
+  gap: 10px;
 }
 
 .video-preview {
@@ -66,7 +68,6 @@
 
 .video__detailbox {
   flex: 1 0 20%;
-  margin: 10px;
   background-color: $color650Grey;
   border-top: 1px solid $color600Grey;
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds a few styling fixes:
1. Make the 'copy from standfirst' button clearer

| Before | After |
| --- | --- |
| ![before-copy-button](https://github.com/guardian/media-atom-maker/assets/34686302/60b716bb-c6cb-485b-8a00-ed3c5d6265b3) | ![image](https://github.com/guardian/media-atom-maker/assets/34686302/db319794-999e-4f89-b6f7-e0400ef6bbe4) |

2. Add hover state to checkboxes

| Before | After |
| --- | --- |
| ![checkbox-before](https://github.com/guardian/media-atom-maker/assets/34686302/5611bc53-91be-42f2-8264-f644cb99e154) | ![checkbox-after](https://github.com/guardian/media-atom-maker/assets/34686302/5e5bdf3c-71d3-4d77-9306-fd62b07aea45) |

3. Tidy up typography on the Usages tab

| Before | After |
| --- | --- |
| ![image](https://github.com/guardian/media-atom-maker/assets/34686302/13f38e39-d5aa-48a6-ba6b-84a1598c869a) | ![image](https://github.com/guardian/media-atom-maker/assets/34686302/27138866-f83c-4d33-a946-ca10948c77c7) |

4. Tidy the upload page (more regular padding and margins & restyle upload buttons)

| Before | After |
| --- | --- |
| ![image](https://github.com/guardian/media-atom-maker/assets/34686302/6d4cc41e-9527-4286-afa5-91d5f8e1fa61) | ![image](https://github.com/guardian/media-atom-maker/assets/34686302/39d2b86b-c465-465d-8f8e-cfcba61b3cf6) |

5. Un-fade content details

| Before | After |
| --- | --- |
| ![image](https://github.com/guardian/media-atom-maker/assets/34686302/654d97fd-8bcf-492a-bad6-681e28f33291) | ![image](https://github.com/guardian/media-atom-maker/assets/34686302/e4d3bdbc-f3a6-4a5e-9eeb-6a7c07984816) |



## How to test

Run the application locally according to the instructions in the readme, or deploy to CODE. Do the styling change work as expected? Are there any unintended style changes?

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
