### PR TITLE
Fix invalid embargoed state

### DIFF
--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -39,6 +39,7 @@ object CommandExceptions extends Results {
   def commandExceptionAsResult: PartialFunction[Throwable, Result] = {
     case CommandException(msg, 400) => BadRequest(msg)
     case CommandException(msg, 404) => NotFound(msg)
+    case CommandException(msg, 409) => Conflict(msg)
     case CommandException(msg, 500) => InternalServerError(msg)
     case YouTubeError(msg, true) => InternalServerError(msg)
     case YouTubeError(msg, false) => InternalServerError(msg).withHeaders("X-No-Alerts" -> "true")

--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -25,6 +25,7 @@ object CommandExceptions extends Results {
   def AssetNotFound(assetId: String) = throw new CommandException(s"Asset with id $assetId not found", 404)
   def YoutubeException(err: String) = throw new CommandException(s"Exception when trying to reach YouTube: $err", 400)
   def AtomUpdateFailed(err: String) = throw new CommandException(s"Failed to update atom: $err", 500)
+  def AtomUpdateConflictError(err: String) = throw new CommandException(s"Failed to update atom: $err", 409)
   def AtomPublishFailed(err: String) = throw new CommandException(s"Failed to publish atom: $err", 500)
 
   def AtomMissingYouTubeChannel = throw new CommandException("Atom is missing YouTube channel", 400)

--- a/app/model/commands/UpdateAtomCommand.scala
+++ b/app/model/commands/UpdateAtomCommand.scala
@@ -1,9 +1,8 @@
 package model.commands
 
 import java.util.Date
-
 import ai.x.diff.DiffShow
-import com.gu.atom.data.AtomSerializer
+import com.gu.atom.data.{AtomSerializer, VersionConflictError}
 import com.gu.contentatom.thrift.{Atom, ContentAtomEvent, EventType, ChangeRecord => ThriftChangeRecord}
 import com.gu.media.logging.Logging
 import com.gu.media.model.{AtomAssignedProjectMessage, AuditMessage, ChangeRecord, MediaAtom}
@@ -66,9 +65,13 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom, override val stores: D
     log.info(s"Attempting to update atom ${atom.id} in ${awsConfig.dynamoTableName} to new atom: $newAtomAsJson")
 
     previewDataStore.updateAtom(thrift).fold(
-      err => {
-        log.error(s"Unable to update atom with id ${atom.id} in ${awsConfig.dynamoTableName} table to new content: $newAtomAsJson", err)
-        AtomUpdateFailed(err.msg)
+      {
+        case err: VersionConflictError =>
+          log.warn(s"Unable to update atom due to version conflict with id ${atom.id} in ${awsConfig.dynamoTableName} table to new content: $newAtomAsJson", err)
+          AtomUpdateConflictError(err.msg)
+        case err =>
+          log.error(s"Unable to update atom with id ${atom.id} in ${awsConfig.dynamoTableName} table to new content: $newAtomAsJson", err)
+          AtomUpdateFailed(err.msg)
       },
       _ => {
         val event = ContentAtomEvent(thrift, EventType.Update, new Date().getTime)

--- a/app/model/commands/UpdateAtomCommand.scala
+++ b/app/model/commands/UpdateAtomCommand.scala
@@ -52,7 +52,7 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom, override val stores: D
     val expiry: Option[DateTime] = atom.expiryDate.map(expiry => new DateTime(expiry))
 
     val details = atom.contentChangeDetails.copy(
-      revision = existingAtom.contentChangeDetails.revision + 1,
+      revision = atom.contentChangeDetails.revision + 1,
       lastModified = Some(changeRecord),
       scheduledLaunch = scheduledLaunchDate.map(ChangeRecord.build(_, user)),
       embargo = embargo.map(ChangeRecord.build(_, user)),

--- a/public/video-ui/src/actions/VideoActions/saveVideo.js
+++ b/public/video-ui/src/actions/VideoActions/saveVideo.js
@@ -32,10 +32,10 @@ function receiveVideoUsages(usages) {
   };
 }
 
-function errorVideoSave(error) {
+function errorVideoSave(error, message) {
   return {
     type: 'SHOW_ERROR',
-    message: 'Could not save video',
+    message,
     error: error,
     receivedAt: Date.now()
   };
@@ -58,6 +58,11 @@ export function saveVideo(video) {
       )
       .then(() => dispatch(receiveVideoPageUpdate(video.title)))
     })
-    .catch(error => dispatch(errorVideoSave(error)));
+    .catch(error => {
+      const defaultError = 'Could not save video';
+      const conflictError = 'Could not save video as another user (or tab) is currently editing this video';
+      const message = error.status === 409 ? conflictError : defaultError;
+      dispatch(errorVideoSave(error, message));
+    });
   };
 }

--- a/public/video-ui/src/reducers/videoReducer.js
+++ b/public/video-ui/src/reducers/videoReducer.js
@@ -18,6 +18,9 @@ export default function video(state = null, action) {
     case 'VIDEO_SAVE_REQUEST':
       return Object.assign({}, blankVideoData, action.video);
 
+    case 'VIDEO_SAVE_RECEIVE':
+      return Object.assign({}, blankVideoData, action.video);
+
     case 'VIDEO_POPULATE_BLANK':
       return Object.assign({}, blankVideoData, {
         type: 'media'

--- a/webpack-dev-server.js
+++ b/webpack-dev-server.js
@@ -13,9 +13,11 @@ var wpConfig         = require('./build_config/webpack.devserver.conf.js');
 var wpServer = new WebpackDevServer(webpack(wpConfig), {
   contentBase:  wpConfig.output.path,
   publicPath:   '/assets/video-ui/build/',
+  public: "video-assets.local.dev-gutools.co.uk",
   hot:          true,
   progress:     true,
   noInfo:       true,
+  disableHostCheck: true,
   clientLogLevel: "info",
   watchOptions: {
     aggregateTimeout: 300,


### PR DESCRIPTION
## What does this change?

Should make it impossible for someone to modify an atom without having visibility of the previous most-recent version.  This should avoid the issue we've seen before:

* Video is embargoed
* User A and B open video in MAM
* User A removes embargo
* User A publishes the video
* User B edits the headline [which unintentionally re-adds the embargo]
* Content is now Published but also has an embargo so cannot be re-published. Embargo cannot be removed because UI hides this feature on published content.

The change sets revision ID based on what the client has sent, not what we've just fetched from dynamodb. This way, if the user has edited an old version of the atom, atom-publisher-lib will refuse to update the db. Atom-publisher-lib will only publish if the new revision is higher than the current revision.

## How to test

### Test 1

Edit a video in MAM - check that new revision is exactly 1 higher than the old revision

### Test 2

* Open the same video in 2 tabs.
* Make a change in one tab.
* Attempt to make a change in another tab - change should fail and an informative error message displayed

### Test 3

* Open the same video
* Make a change
* Make a change
* No error should be seen

This test was added because I noticed a bug with the first attempt where subsequent edits were rejected because the local revision was not updated.