### PR TITLE
Only update the embargo/expiry/scheduler user on change

### DIFF
--- a/app/model/commands/UpdateAtomCommand.scala
+++ b/app/model/commands/UpdateAtomCommand.scala
@@ -52,7 +52,7 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom, override val stores: D
     val expiry: Option[DateTime] = atom.expiryDate.map(expiry => new DateTime(expiry))
 
     def updateIfChanged(newDate: Option[DateTime], changeRecord: Option[ThriftChangeRecord]): Option[ChangeRecord] = {
-      if (changeRecord.map(_.date) == newDate) {
+      if (changeRecord.map(_.date) == newDate.map(_.getMillis)) {
         changeRecord.map(ChangeRecord.fromThrift)
       } else {
         newDate.map(ChangeRecord.build(_, user))


### PR DESCRIPTION
## What does this change?

Only update the embargo/expiry/scheduler user on change. Current behaviour makes it look like whoever touched the piece last set the expiry/embargo/schedule.  It is probably more useful to know the original setter

## How to test

* Set an embargo on a piece of content
* Ask someone else to make a change to that piece of content
* Check dynamodb (or look in network tab) to verify that the ChangeData still lists you as the embargo-er
