### PR TITLE
Allow a vertical video player (when the vertical-video tag is added)

### DIFF
--- a/public/video-ui/src/components/VideoPreview/VideoPreview.js
+++ b/public/video-ui/src/components/VideoPreview/VideoPreview.js
@@ -38,9 +38,14 @@ export default class VideoPreview extends React.Component {
     return <VideoEmbed sources={sources}/>;
   }
 
+  hasVerticalVideoTag() {
+    const tags = this.props.video.keywords || [];
+    return tags.includes('media/series/vertical-video');
+  }
+
   render() {
     return (
-      <div className="sixteen-by-nine">
+      <div className={this.hasVerticalVideoTag() ? "nine-by-sixteen" : "sixteen-by-nine"}>
         {this.renderPreview()}
       </div>
     );

--- a/public/video-ui/styles/layout/_common.scss
+++ b/public/video-ui/styles/layout/_common.scss
@@ -15,6 +15,25 @@
     height: 100%;
   }
 }
+.nine-by-sixteen {
+  // https://www.w3schools.com/howto/howto_css_aspect_ratio.asp
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-top: 71.11%; // 9:16 ratio (16/9)*0.4 so that it doesn't take up the whole screen
+
+
+  :first-child {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    width: 40%; // So it doesn't take up the whole screen (as above)
+    height: 100%;
+    margin: auto;
+  }
+}
 
 .responsive {
   &--primary {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This updates the video player to allow a 9:16 player when the vertical video tag is added.
In future, we hope to use the youtube video response to determine the aspect ratio rather than relying on a manually added tag.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
1. Upload a video
2. Observe it is 16:9 format by default
3. Add the vertical-video keyword
4. Observe the player is now in the 9:16 aspect ratio


## Images
| Horizontal video | vertical video |
|--------|--------|
|<img width="1502" alt="image" src="https://github.com/guardian/media-atom-maker/assets/26366706/fd9676b1-39d5-4f27-997b-6547dc8381d4">|This looks a bit weird as its not _actually_ a vertical video <img width="1502" alt="image" src="https://github.com/guardian/media-atom-maker/assets/26366706/c35f1012-82f8-41de-b256-e92e364f4fa4"> |

**Video demo**
https://github.com/guardian/media-atom-maker/assets/26366706/494d24a9-ca2f-4dc3-a94b-02e3c10f7eb4
