### PR TITLE
use vertical crop for vertical video

### DIFF
--- a/public/video-ui/src/components/VideoImages/VideoImages.js
+++ b/public/video-ui/src/components/VideoImages/VideoImages.js
@@ -74,7 +74,7 @@ export default class VideoImages extends React.Component {
             </header>
             <GridImageSelect
               image={this.props.video.trailImage}
-              gridUrl={this.hasVerticalVideoTag() ? this.getGridUrl('verticalvideo'): this.getGridUrl('landscape')}
+              gridUrl={this.getGridUrl('landscape')}
               gridDomain={this.props.gridDomain}
               disabled={trailImageDisabled}
               updateVideo={this.saveAndUpdateVideoImage}

--- a/public/video-ui/src/components/VideoImages/VideoImages.js
+++ b/public/video-ui/src/components/VideoImages/VideoImages.js
@@ -24,7 +24,7 @@ export default class VideoImages extends React.Component {
     const posterImage = this.props.video.posterImage;
 
     const queryParam = cropType == "verticalvideo" ?
-      'cropType=verticalvideo&customRatio=verticalvideo,9,16' :
+      `cropType=landscape,${cropType}&customRatio=${cropType},9,16` :
       `cropType=${cropType}`;
 
     if (posterImage.assets.length > 0) {

--- a/public/video-ui/src/components/VideoImages/VideoImages.js
+++ b/public/video-ui/src/components/VideoImages/VideoImages.js
@@ -24,7 +24,7 @@ export default class VideoImages extends React.Component {
     const posterImage = this.props.video.posterImage;
 
     const queryParam = cropType == "verticalvideo" ?
-      `cropType=landscape,${cropType}&customRatio=${cropType},9,16` :
+      `cropType=${cropType}&customRatio=${cropType},9,16` :
       `cropType=${cropType}`;
 
     if (posterImage.assets.length > 0) {

--- a/public/video-ui/src/components/VideoImages/VideoImages.js
+++ b/public/video-ui/src/components/VideoImages/VideoImages.js
@@ -23,7 +23,7 @@ export default class VideoImages extends React.Component {
   getGridUrl(cropType) {
     const posterImage = this.props.video.posterImage;
 
-    const queryParam = cropType == "verticalvideo" ?
+    const queryParam = cropType == "verticalVideo" ?
       `cropType=${cropType}&customRatio=${cropType},9,16` :
       `cropType=${cropType}`;
 
@@ -55,7 +55,7 @@ export default class VideoImages extends React.Component {
             </header>
             <GridImageSelect
               image={this.props.video.posterImage}
-              gridUrl={this.hasVerticalVideoTag() ? this.getGridUrl('verticalvideo'): this.getGridUrl('video')}
+              gridUrl={this.hasVerticalVideoTag() ? this.getGridUrl('verticalVideo'): this.getGridUrl('video')}
               gridDomain={this.props.gridDomain}
               disabled={this.props.videoEditOpen}
               updateVideo={this.saveAndUpdateVideoImage}
@@ -87,7 +87,7 @@ export default class VideoImages extends React.Component {
             </header>
             <GridImageSelect
               image={this.props.video.youtubeOverrideImage}
-              gridUrl={this.hasVerticalVideoTag() ? this.getGridUrl('verticalvideo'): this.getGridUrl('video')}
+              gridUrl={this.hasVerticalVideoTag() ? this.getGridUrl('verticalVideo'): this.getGridUrl('video')}
               gridDomain={this.props.gridDomain}
               disabled={this.props.videoEditOpen}
               updateVideo={this.saveAndUpdateVideoImage}

--- a/public/video-ui/src/components/VideoImages/VideoImages.js
+++ b/public/video-ui/src/components/VideoImages/VideoImages.js
@@ -37,10 +37,7 @@ export default class VideoImages extends React.Component {
   }
 
   hasVerticalVideoTag() {
-
     const tags = this.props.video.keywords || [];
-    console.log("tags:");
-    console.log(tags.includes('media/series/vertical-video'));
     return tags.includes('media/series/vertical-video');
   }
 

--- a/public/video-ui/src/components/VideoImages/VideoImages.js
+++ b/public/video-ui/src/components/VideoImages/VideoImages.js
@@ -23,12 +23,25 @@ export default class VideoImages extends React.Component {
   getGridUrl(cropType) {
     const posterImage = this.props.video.posterImage;
 
+    const queryParam = cropType == "verticalvideo" ?
+      'cropType=verticalvideo&customRatio=verticalvideo,9,16' :
+      `cropType=${cropType}`;
+
     if (posterImage.assets.length > 0) {
       const imageGridId = getGridMediaId(posterImage);
-      return `${this.props.gridDomain}/images/${imageGridId}?cropType=${cropType}`;
+
+      return `${this.props.gridDomain}/images/${imageGridId}?${queryParam}`;
     }
 
-    return `${this.props.gridDomain}?cropType=${cropType}`;
+    return `${this.props.gridDomain}?${queryParam}`;
+  }
+
+  hasVerticalVideoTag() {
+
+    const tags = this.props.video.keywords || [];
+    console.log("tags:");
+    console.log(tags.includes('media/series/vertical-video'));
+    return tags.includes('media/series/vertical-video');
   }
 
   render() {
@@ -45,7 +58,7 @@ export default class VideoImages extends React.Component {
             </header>
             <GridImageSelect
               image={this.props.video.posterImage}
-              gridUrl={this.getGridUrl('video')}
+              gridUrl={this.hasVerticalVideoTag() ? this.getGridUrl('verticalvideo'): this.getGridUrl('video')}
               gridDomain={this.props.gridDomain}
               disabled={this.props.videoEditOpen}
               updateVideo={this.saveAndUpdateVideoImage}
@@ -61,7 +74,7 @@ export default class VideoImages extends React.Component {
             </header>
             <GridImageSelect
               image={this.props.video.trailImage}
-              gridUrl={this.getGridUrl('landscape')}
+              gridUrl={this.hasVerticalVideoTag() ? this.getGridUrl('verticalvideo'): this.getGridUrl('landscape')}
               gridDomain={this.props.gridDomain}
               disabled={trailImageDisabled}
               updateVideo={this.saveAndUpdateVideoImage}
@@ -77,7 +90,7 @@ export default class VideoImages extends React.Component {
             </header>
             <GridImageSelect
               image={this.props.video.youtubeOverrideImage}
-              gridUrl={this.getGridUrl('video')}
+              gridUrl={this.hasVerticalVideoTag() ? this.getGridUrl('verticalvideo'): this.getGridUrl('video')}
               gridDomain={this.props.gridDomain}
               disabled={this.props.videoEditOpen}
               updateVideo={this.saveAndUpdateVideoImage}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->


## What does this change?
This PR is using 9:16 crop for thumbnail images if the video page has a `vertical-video` series tag.

![image](https://github.com/guardian/media-atom-maker/assets/15894063/da1f2d79-b5b4-4d1d-b65c-d4fd066f2de8)

In the upcoming PRs (In the near future) we will be using the youtube video response that gives us the aspect ratio, and pass that data through the CAPI data, in order to avoid relying on the tag. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- Upload a vertical video
- add the `vertical-video` series tag
- add thumbnail image
- crop thumbnail image - there should only be 9:16 crop available
