### PR TITLE
Replace elk-kinesis-logger with console log/error

### DIFF
--- a/pluto-message-ingestion/hmac-request.js
+++ b/pluto-message-ingestion/hmac-request.js
@@ -3,10 +3,9 @@ const reqwest = require('reqwest');
 const url = require('url');
 
 class HMACRequest {
-  constructor({ serviceName, secret, logger }) {
+  constructor({ serviceName, secret }) {
     this.serviceName = serviceName;
     this.secret = secret;
-    this.logger = logger;
   }
 
   _getToken(remoteUrl, date) {
@@ -38,7 +37,7 @@ class HMACRequest {
       requestBody.data = JSON.stringify(data);
     }
 
-    this.logger.log(`Making ${method} request to ${remoteUrl}`, data);
+    console.log({message: `Making ${method} request to ${remoteUrl}`, data});
 
     return reqwest(requestBody);
   }

--- a/pluto-message-ingestion/hmac-request.js
+++ b/pluto-message-ingestion/hmac-request.js
@@ -37,7 +37,8 @@ class HMACRequest {
       requestBody.data = JSON.stringify(data);
     }
 
-    console.log({message: `Making ${method} request to ${remoteUrl}`, data});
+    // eslint-disable-next-line no-console
+    console.log({ message: `Making ${method} request to ${remoteUrl}`, data });
 
     return reqwest(requestBody);
   }

--- a/pluto-message-ingestion/index.js
+++ b/pluto-message-ingestion/index.js
@@ -23,7 +23,11 @@ exports.handler = (event, context, callback) => {
           const jsonPayload = JSON.parse(payload);
           kinesisMessageProcessor.process(jsonPayload);
         } catch (e) {
-          callback(`Failed to parse kinesis message as JSON: ${payload}`);
+          // eslint-disable-next-line no-console
+          console.error(
+            `Failed to parse kinesis message as JSON: ${payload}. Removing from the stream.`
+          );
+          callback(null, 'Message removed from stream due to invalid data.');
         }
       });
 

--- a/pluto-message-ingestion/index.js
+++ b/pluto-message-ingestion/index.js
@@ -8,13 +8,17 @@ exports.handler = (event, context, callback) => {
   kinesisMessageProcessor
     .open()
     .then(() => {
+      // eslint-disable-next-line no-console
+      console.log({ records: event.Records, count: event.Records.length });
       event.Records.forEach(record => {
         // Kinesis data is base64 encoded so decode here
         const payload = new Buffer(record.kinesis.data, 'base64').toString(
           'utf8'
         );
-        console.log({record})
-        console.log({payload})
+        // eslint-disable-next-line no-console
+        console.log({ record });
+        // eslint-disable-next-line no-console
+        console.log({ payload });
         try {
           const jsonPayload = JSON.parse(payload);
           kinesisMessageProcessor.process(jsonPayload);

--- a/pluto-message-ingestion/index.js
+++ b/pluto-message-ingestion/index.js
@@ -8,17 +8,11 @@ exports.handler = (event, context, callback) => {
   kinesisMessageProcessor
     .open()
     .then(() => {
-      // eslint-disable-next-line no-console
-      console.log({ records: event.Records, count: event.Records.length });
       event.Records.forEach(record => {
         // Kinesis data is base64 encoded so decode here
         const payload = new Buffer(record.kinesis.data, 'base64').toString(
           'utf8'
         );
-        // eslint-disable-next-line no-console
-        console.log({ record });
-        // eslint-disable-next-line no-console
-        console.log({ payload });
         try {
           const jsonPayload = JSON.parse(payload);
           kinesisMessageProcessor.process(jsonPayload);

--- a/pluto-message-ingestion/index.js
+++ b/pluto-message-ingestion/index.js
@@ -13,7 +13,8 @@ exports.handler = (event, context, callback) => {
         const payload = new Buffer(record.kinesis.data, 'base64').toString(
           'utf8'
         );
-
+        console.log({record})
+        console.log({payload})
         try {
           const jsonPayload = JSON.parse(payload);
           kinesisMessageProcessor.process(jsonPayload);

--- a/pluto-message-ingestion/kinesis-message-processor.js
+++ b/pluto-message-ingestion/kinesis-message-processor.js
@@ -31,6 +31,8 @@ class KinesisMessageProcessor {
             hostname: `https://${config.host}`,
             hmacRequest: this.hmacRequest
           });
+
+          resolve();
         })
         .catch(err => {
           reject(`Failed to read config file. ${err}`);

--- a/pluto-message-ingestion/kinesis-message-processor.js
+++ b/pluto-message-ingestion/kinesis-message-processor.js
@@ -24,12 +24,12 @@ class KinesisMessageProcessor {
         .then(config => {
           this.hmacRequest = new HMACRequest({
             serviceName: EnvironmentConfig.app,
-            secret: config.secret,
+            secret: config.secret
           });
 
           this.plutoMessageProcessor = new PlutoMessageProcessor({
             hostname: `https://${config.host}`,
-            hmacRequest: this.hmacRequest,
+            hmacRequest: this.hmacRequest
           });
         })
         .catch(err => {
@@ -41,7 +41,7 @@ class KinesisMessageProcessor {
   close() {
     return new Promise((resolve, reject) => {
       Promise.all(this._messages)
-        .then(() =>  resolve('done'))
+        .then(() => resolve('done'))
         .catch(err => reject(err));
     });
   }

--- a/pluto-message-ingestion/kinesis-message-processor.js
+++ b/pluto-message-ingestion/kinesis-message-processor.js
@@ -1,6 +1,5 @@
 const AWS = require('aws-sdk');
 const FileConfig = require('./file-config');
-const ELKKinesisLogger = require('@guardian/elk-kinesis-logger');
 const EnvironmentConfig = require('./environment-config');
 const HMACRequest = require('./hmac-request');
 const PlutoMessageProcessor = require('./pluto-message-processor');
@@ -23,32 +22,15 @@ class KinesisMessageProcessor {
     return new Promise((resolve, reject) => {
       FileConfig.read()
         .then(config => {
-          this.logger = new ELKKinesisLogger({
-            stage: EnvironmentConfig.stage,
-            stack: EnvironmentConfig.stack,
-            app: EnvironmentConfig.app,
-            roleArn: config.aws.kinesis.stsLoggingRoleToAssume,
-            streamName: config.aws.kinesis.logging
+          this.hmacRequest = new HMACRequest({
+            serviceName: EnvironmentConfig.app,
+            secret: config.secret,
           });
 
-          this.logger
-            .open()
-            .then(() => {
-              this.hmacRequest = new HMACRequest({
-                serviceName: EnvironmentConfig.app,
-                secret: config.secret,
-                logger: this.logger
-              });
-
-              this.plutoMessageProcessor = new PlutoMessageProcessor({
-                hostname: `https://${config.host}`,
-                hmacRequest: this.hmacRequest,
-                logger: this.logger
-              });
-
-              resolve();
-            })
-            .catch(err => reject(`Failed to open logger. ${err}`));
+          this.plutoMessageProcessor = new PlutoMessageProcessor({
+            hostname: `https://${config.host}`,
+            hmacRequest: this.hmacRequest,
+          });
         })
         .catch(err => {
           reject(`Failed to read config file. ${err}`);
@@ -59,12 +41,8 @@ class KinesisMessageProcessor {
   close() {
     return new Promise((resolve, reject) => {
       Promise.all(this._messages)
-        .then(() => {
-          this.logger.close().then(() => resolve('done'));
-        })
-        .catch(err => {
-          this.logger.close().then(() => reject(err));
-        });
+        .then(() =>  resolve('done'))
+        .catch(err => reject(err));
     });
   }
 

--- a/pluto-message-ingestion/package.json
+++ b/pluto-message-ingestion/package.json
@@ -12,7 +12,6 @@
     "build": "yarn lint && mkdir -p target && ncc-zip build -m -e aws-sdk -o ./target/pluto-message-ingestion.zip"
   },
   "dependencies": {
-    "@guardian/elk-kinesis-logger": "0.1.0",
     "crypto": "0.0.3",
     "hocon-parser": "^1.0.1",
     "reqwest": "^2.0.5",

--- a/pluto-message-ingestion/pluto-message-processor.js
+++ b/pluto-message-ingestion/pluto-message-processor.js
@@ -1,10 +1,9 @@
 const DELETE_KEY = '(DELETE)';
 
 class PlutoMessageProcessor {
-  constructor({ hostname, hmacRequest, logger }) {
+  constructor({ hostname, hmacRequest }) {
     this.hostname = hostname;
     this.hmacRequest = hmacRequest;
-    this.logger = logger;
   }
 
   process(message) {
@@ -49,8 +48,11 @@ class PlutoMessageProcessor {
   _upsertProject(message) {
     return new Promise((resolve, reject) => {
       if (!PlutoMessageProcessor._isValidMessage(message)) {
-        this.logger.log('invalid message, props missing', {
-          message: message
+        console.error({
+          error: 'invalid message, props missing', 
+          data: {
+            message
+          }
         });
 
         // `resolve` to remove message from Kinesis
@@ -64,7 +66,8 @@ class PlutoMessageProcessor {
       this.hmacRequest
         .put(remoteUrl, project)
         .then(resp => {
-          this.logger.log('successfully upserted project', {
+          console.log({
+            message: 'successfully upserted project', 
             response: resp
           });
           resolve(resp);
@@ -76,7 +79,7 @@ class PlutoMessageProcessor {
             project: project
           };
 
-          this.logger.error('failed to upsert project', logDetail);
+          console.error({message: 'failed to upsert project', extraDetail: logDetail});
           reject(err);
         });
     });

--- a/pluto-message-ingestion/pluto-message-processor.js
+++ b/pluto-message-ingestion/pluto-message-processor.js
@@ -48,8 +48,9 @@ class PlutoMessageProcessor {
   _upsertProject(message) {
     return new Promise((resolve, reject) => {
       if (!PlutoMessageProcessor._isValidMessage(message)) {
+        // eslint-disable-next-line no-console
         console.error({
-          error: 'invalid message, props missing', 
+          error: 'invalid message, props missing',
           data: {
             message
           }
@@ -66,8 +67,9 @@ class PlutoMessageProcessor {
       this.hmacRequest
         .put(remoteUrl, project)
         .then(resp => {
+          // eslint-disable-next-line no-console
           console.log({
-            message: 'successfully upserted project', 
+            message: 'successfully upserted project',
             response: resp
           });
           resolve(resp);
@@ -78,8 +80,11 @@ class PlutoMessageProcessor {
             response: err.response,
             project: project
           };
-
-          console.error({message: 'failed to upsert project', extraDetail: logDetail});
+          // eslint-disable-next-line no-console
+          console.error({
+            message: 'failed to upsert project',
+            extraDetail: logDetail
+          });
           reject(err);
         });
     });

--- a/pluto-message-ingestion/yarn.lock
+++ b/pluto-message-ingestion/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@guardian/elk-kinesis-logger@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/elk-kinesis-logger/-/elk-kinesis-logger-0.1.0.tgz#93fa667ec7a53a4630c96495ae6413ccbc27d282"
-  integrity sha1-k/pmfselOkYwyWSVrmQTzLwn0oI=
-  dependencies:
-    aws-sdk "^2.38.0"
-
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -169,7 +162,7 @@ async@^3.2.0:
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
   integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
 
-aws-sdk@^2.35.0, aws-sdk@^2.38.0:
+aws-sdk@^2.35.0:
   version "2.730.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.730.0.tgz#5b2775bb0c3cd7764031a17a9bcac3f1aafc385e"
   integrity sha512-hYHplsbgUDP0XuaVJaHx2L/nC0E1i+4dGlkAQpkJz3qQ4NDfLnrbUFsA2g3AyWAsrnjrBNCkexPvwnV82Qng1g==


### PR DESCRIPTION
## What does this change?

This replaces the `elk-kinesis-logger` with standard node `console.log`/`console.error`, since we now get Lambda log-shipping for free from [guardian/cloudwatch-logs-management](https://github.com/guardian/cloudwatch-logs-management. Removing the `elk-kinesis-logger` dependency will sort two vulnerabilities in the Lambda.

This PR also fixes an issue with non-JSON payloads reaching the Lambda. Formerly, the Lambda would return an error response in these circumstances - the faulty record would remain in the Kinesis stream, and subsequent additions to the stream would not invoke the Lambda until the faulty record had expired after (I think) 24 hours, while the Lambda would be continually invoked for the faulty payload.

Payloads that aren't now parsed will log an error, but the Lambda will still complete, allowing subsequent messages to be invoked (after all, repeated attempts to parse the non-JSON would also fail).

## How to test

Pluto CODE is down since the incident in December, but we can still deploy the CODE lambda and manually insert our own data into the Kinesis stream, in order to do so:

1. Create a directory with an `example.json` file in it. This should contain data along the lines of:
```{"type":"project-updated","id":"foo","title":"bar","status":"New","commissionId":"baz","commissionTitle":"baz","productionOffice":"UK","created":"2017-04-24T17:20:11.503Z"}```
2. Set a base-64 encoded version of that text to a bash variable, e.g: `EXAMPLE=$(cat ./example.json | base64)`
3. Deploy this branch to CODE (you can click 'Preview' in RiffRaff to deploy only the `pluto-message-ingestion` `updateLambda` and `uploadLambda` steps, which deploy very quickly). 
4. Add the message to the stream via the following bash command, where CodeStreamName is your name. The partition key can be anything:
```
aws kinesis put-record --stream-name CodeStreamName --data $EXAMPLE --partition-key foobar --profile media-service --region eu-west-1
```
5. Monitor the logs [here](https://logs.gutools.co.uk/s/editorial-tools/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-10m,to:now))&_a=(columns:!(),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'67604290-baa6-11e9-bea2-633437abb232',key:stage,negate:!f,params:(query:CODE),type:phrase),query:(match_phrase:(stage:CODE)))),index:'67604290-baa6-11e9-bea2-633437abb232',interval:auto,query:(language:lucene,query:'app:%22pluto%22'),sort:!(!('@timestamp',desc)))). Do you see a PUT command logged for your JSON payload?

You may also want to try sending something that isn't JSON as your payload to see if that functionality is working as expected.

I've tested both these paths on CODE and they worked as expected.

## How can we measure success?

Valid JSON payloads lead to a PUT command and faulty JSON don't clog up the Kinesis stream.

## Have we considered potential risks?

Pluto CODE isn't running currently so we can't end-to-end testing before deployment, though Pluto PROD is. If something goes wrong and we disrupt `media-atom-maker`'s commission system, we will need to roll back this PR.
