### PR TITLE
Use standard color space in order to prevent png colour-space related thumbnail issues

### DIFF
--- a/app/util/ThumbnailGenerator.scala
+++ b/app/util/ThumbnailGenerator.scala
@@ -1,7 +1,7 @@
 package util
 
 import java.awt.RenderingHints
-import java.awt.image.BufferedImage
+import java.awt.image.{BufferedImage, ColorConvertOp}
 import java.io._
 import java.net.URL
 import com.google.api.client.http.InputStreamContent
@@ -24,8 +24,11 @@ case class ThumbnailGenerator(logoFile: File) extends Logging {
       .maxBy(_.size.get)
   }
 
-  private def imageAssetToBufferedImage(imageAsset: ImageAsset): BufferedImage =
-    ImageIO.read(new URL(imageAsset.file))
+  private def imageAssetToBufferedImage(imageAsset: ImageAsset): BufferedImage = {
+    val image = ImageIO.read(new URL(imageAsset.file))
+    val rgbImage = new BufferedImage(image.getWidth, image.getHeight, BufferedImage.TYPE_3BYTE_BGR)
+    new ColorConvertOp(null).filter(image, rgbImage)
+  }
 
   private def overlayImages(bgImage: BufferedImage, bgImageMimeType: String, atomId: String): ByteArrayInputStream = {
     val logoWidth: Double = List(bgImage.getWidth() / 3.0, logo.getWidth()).min


### PR DESCRIPTION
Occasionally, images used for the thumbnail in `media-atom-maker` clash with the logo - the transparency doesn't render properly (appearing as a grid behind the logo), and the overall colours look wrong (see below). 

<img width="848" alt="image" src="https://github.com/guardian/media-atom-maker/assets/34686302/b4be1359-0093-4584-bbf9-c0a721eb31bd"> 

(Troublesome png: https://media.test.dev-gutools.co.uk/images/7865a525047ebf55e5bb4dccbdd85e369f342ccb)

This seems to be caused by our image composition function not playing well with the colour space used by some png files. 

This PR converts images to use a standard RGB colour space before adding the logo.

| Before | After |
| --- | --- |
| ![image](https://github.com/guardian/media-atom-maker/assets/34686302/1366983d-31a3-42c7-9115-5aa365e06228) | ![image](https://github.com/guardian/media-atom-maker/assets/34686302/3fb169b5-bfce-4647-9c07-397fb5e523ea) |


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

1. Deploy to CODE.
2. Update the thumbnail to use the [troublesome image above](https://media.test.dev-gutools.co.uk/images/7865a525047ebf55e5bb4dccbdd85e369f342ccb).
3. Save and launch to update the video on YouTube.
4. Does the thumbnail render properly on youtube? 

N.B Annoyingly it can take ages for the thumbnail to update in various places. The first place that it updates for me is the 'Watch after ad' button in the bottom right hand of a video when an advert is playing (see below). The preview in MAM CODE takes an especially long time to update.

![image](https://github.com/guardian/media-atom-maker/assets/34686302/7ff5e2da-8a62-4b41-a7e2-c20aa83e0e6a)

