### PR TITLE
Check for presence client on window before attempting to access it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,35 @@
+name: CI
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+      - uses: actions/setup-java@v3
+        with:
+          java-version: "8"
+          distribution: "corretto"
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+      - name: Build Pluto lambda
+        run: |
+          ./scripts/pluto-ci.sh
+      - name: Build Media Atom Maker
+        run: |
+          ./scripts/app-ci.sh
+      - name: Compile Scala and upload artifacts to RiffRaff
+        run: |
+          ./scripts/scala-ci.sh
+
+

--- a/public/video-ui/src/components/Presence.js
+++ b/public/video-ui/src/components/Presence.js
@@ -27,7 +27,7 @@ export class Presence extends React.Component {
         );
       }
 
-      if (current) {
+      if (current && window.presenceClient) {
         this.startPresence(current, this.props.config);
       }
     }

--- a/scripts/scala-ci.sh
+++ b/scripts/scala-ci.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-
+ # Ensure we don't overwrite existing (Teamcity) builds.
+  LAST_TEAMCITY_BUILD=4800
+  export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
   sbt clean compile test riffRaffUpload


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR checks for the presence client on the window object before attempting to access it.

Currently video pages are in an error state locally when the presence client is not on the window object - this is usually the case locally because the presence config is missing from the default local config files and most local users will not be running presence.

## How to test

Run locally according to the instructions in the readme and visit a video page. Is there an error that prevents the page from rendering?