### PR TITLE
Add CI via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Media Atom Maker CI
+name: CI
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,9 @@ jobs:
         with:
           java-version: "8"
           distribution: "corretto"
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
       - name: Build Pluto lambda
         run: |
           ./scripts/pluto-ci.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,10 @@ jobs:
         with:
           java-version: "8"
           distribution: "corretto"
-      - uses: actions/setup-node@v3
+      - name: Setup Node
+        uses: guardian/actions-setup-node@v2.4.1
         with:
-          node-version: 14
+          cache: "yarn"
       - name: Build Pluto lambda
         run: |
           ./scripts/pluto-ci.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,9 @@ jobs:
         with:
           java-version: "8"
           distribution: "corretto"
-      - name: Setup Node
-        uses: guardian/actions-setup-node@v2.4.1
+      - uses: actions/setup-node@v3
         with:
-          cache: "yarn"
+          node-version-file: '.nvmrc'
       - name: Build Pluto lambda
         run: |
           ./scripts/pluto-ci.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+name: Media Atom Maker CI
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+      - uses: actions/setup-java@v3
+        with:
+          java-version: "8"
+          distribution: "corretto"
+      - name: Build Pluto lambda
+        run: |
+          ./scripts/pluto-ci.sh
+      - name: Build Media Atom Maker
+        run: |
+          ./scripts/app-ci.sh
+      - name: Compile Scala and upload artifacts to RiffRaff
+        run: |
+          ./scripts/scala-ci.sh
+
+

--- a/scripts/scala-ci.sh
+++ b/scripts/scala-ci.sh
@@ -2,6 +2,6 @@
 
 set -e
  # Ensure we don't overwrite existing (Teamcity) builds.
-  LAST_TEAMCITY_BUILD=1280
+  LAST_TEAMCITY_BUILD=4800
   export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
   sbt clean compile test riffRaffUpload

--- a/scripts/scala-ci.sh
+++ b/scripts/scala-ci.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-
+ # Ensure we don't overwrite existing (Teamcity) builds.
+  LAST_TEAMCITY_BUILD=1280
+  export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
   sbt clean compile test riffRaffUpload


### PR DESCRIPTION
## What does this change?

This adds CI via GitHub Actions. This will allow us to deprecate TeamCity (which is happening across the department by September).

The `ci.yaml` file added by this PR replicates the existing build steps from TeamCity. Build numbers will start from `4800` so as not to overlap with TeamCity's existing builds (currently with a margin of 70 TeamCity builds to spare).

## How to test

Took at the build in RiffRaff under the project `media-service:media-atom-maker`. Can you deploy it to CODE? Does it work as expected?

Once this branch is merged:
- We will be able to deploy the CI workflow manually in the Actions tab.
- We can turn off builds for media-atom-maker in TeamCity