### PR TITLE
📌 pinboard integration

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -50,10 +50,14 @@ class Api(
     Ok(Json.toJson(atoms))
   }
 
-  def getMediaAtom(id: String) = APIAuthAction {
+  def getMediaAtom(id: String) = APIAuthAction {req =>
     try {
+      val maybeCorsValue = req.headers.get("Origin").filter(_.endsWith("gutools.co.uk"))
       val atom = getPreviewAtom(id)
-      Ok(Json.toJson(MediaAtom.fromThrift(atom)))
+      Ok(Json.toJson(MediaAtom.fromThrift(atom))).withHeaders(
+        "Access-Control-Allow-Origin" -> maybeCorsValue.getOrElse(""),
+        "Access-Control-Allow-Credentials" -> maybeCorsValue.isDefined.toString
+      )
     } catch {
       commandExceptionAsResult
     }

--- a/app/controllers/VideoUIApp.scala
+++ b/app/controllers/VideoUIApp.scala
@@ -1,6 +1,7 @@
 package controllers
 
 
+import com.gu.editorial.permissions.client.{Permission, PermissionDenied, PermissionsUser}
 import com.gu.media.MediaAtomMakerPermissionsProvider
 import com.gu.media.logging.Logging
 import com.gu.media.youtube.YouTubeAccess
@@ -66,6 +67,7 @@ class VideoUIApp(val authActions: HMACAuthActions, conf: Configuration, awsConfi
         title = "Media Atom Maker",
         jsLocation,
         presenceJsLocation = clientConfig.presence.map(_.jsLocation),
+        pinboardJsLocation = if(permissions.pinboard) awsConfig.pinboardLoaderUrl else None,
         Json.toJson(clientConfig).toString(),
         isHotReloading,
         CSRF.getToken.value

--- a/app/util/AWS.scala
+++ b/app/util/AWS.scala
@@ -29,6 +29,7 @@ class AWSConfig(override val config: Config, override val credentials: AwsCreden
     .withCredentials(credentials.instance)
     .build()
 
+  lazy val pinboardLoaderUrl = getString("panda.domain").map(domain => s"https://pinboard.$domain/pinboard.loader.js")
   lazy val composerUrl = getMandatoryString("flexible.url")
   lazy val workflowUrl = getMandatoryString("workflow.url")
   lazy val viewerUrl = getMandatoryString("viewer.url")

--- a/app/views/VideoUIApp/app.scala.html
+++ b/app/views/VideoUIApp/app.scala.html
@@ -2,6 +2,7 @@
   title: String,
   jsFileLocation: String,
   presenceJsLocation: Option[String],
+  pinboardJsLocation: Option[String],
   clientConfigJson: String,
   isHotReloading: Boolean,
   csrf: String
@@ -22,5 +23,8 @@
 
     <script src="@jsFileLocation"></script>
 
+    @pinboardJsLocation.map { pinboardJs =>
+      <script async src="@pinboardJs" ></script>
+    }
 
 }

--- a/common/src/main/scala/com/gu/media/Permissions.scala
+++ b/common/src/main/scala/com/gu/media/Permissions.scala
@@ -7,7 +7,12 @@ import play.api.libs.json.Format
 import com.gu.pandomainauth.model.{User => PandaUser}
 import scala.concurrent.Future
 
-case class Permissions(deleteAtom: Boolean, addSelfHostedAsset: Boolean, setVideosOnAllChannelsPublic: Boolean)
+case class Permissions(
+  deleteAtom: Boolean,
+  addSelfHostedAsset: Boolean,
+  setVideosOnAllChannelsPublic: Boolean,
+  pinboard: Boolean
+)
 object Permissions {
   implicit val format: Format[Permissions] = Jsonx.formatCaseClass[Permissions]
 
@@ -15,17 +20,15 @@ object Permissions {
   val deleteAtom = Permission("delete_atom", app, defaultVal = PermissionDenied)
   val addSelfHostedAsset = Permission("add_self_hosted_asset", app, defaultVal = PermissionDenied)
   val setVideosOnAllChannelsPublic = Permission("set_videos_on_all_channels_public", app, defaultVal = PermissionDenied)
+  val pinboard = Permission("pinboard", "pinboard", defaultVal = PermissionDenied)
 }
 
 class MediaAtomMakerPermissionsProvider(stage: String, credsProvider: AWSCredentialsProvider) extends PermissionsProvider {
   import Permissions._
 
-  val all = Seq(deleteAtom, addSelfHostedAsset, setVideosOnAllChannelsPublic)
-  val none = Permissions(deleteAtom = false, addSelfHostedAsset = false, setVideosOnAllChannelsPublic = false )
-
   implicit def config = PermissionsConfig(
     app = "media-atom-maker",
-    all = Seq(deleteAtom, addSelfHostedAsset, setVideosOnAllChannelsPublic),
+    all = Seq(deleteAtom, addSelfHostedAsset, setVideosOnAllChannelsPublic, pinboard),
     s3BucketPrefix = if(stage == "PROD") "PROD" else "CODE",
     awsCredentials = credsProvider
   )
@@ -34,19 +37,13 @@ class MediaAtomMakerPermissionsProvider(stage: String, credsProvider: AWSCredent
     deleteAtom <- hasPermission(deleteAtom, user)
     selfHostedMediaAtom <- hasPermission(addSelfHostedAsset, user)
     publicStatusPermissions <- hasPermission(setVideosOnAllChannelsPublic, user)
-  } yield Permissions(deleteAtom, selfHostedMediaAtom, publicStatusPermissions)
-
-
-  def getUploadPermissions(user: PandaUser): Future[Permissions] = for {
-    selfHostedMediaAtom <- hasPermission(addSelfHostedAsset, user)
-  } yield {
-    Permissions(deleteAtom = false, selfHostedMediaAtom, setVideosOnAllChannelsPublic = false)
-  }
+    pinboard <- hasPermission(pinboard, user)
+  } yield Permissions(deleteAtom, selfHostedMediaAtom, publicStatusPermissions, pinboard)
 
   def getStatusPermissions(user: PandaUser): Future[Permissions] = for {
     publicStatus <- hasPermission(setVideosOnAllChannelsPublic, user)
   } yield {
-    Permissions(deleteAtom = false, addSelfHostedAsset = false, publicStatus)
+    Permissions(deleteAtom = false, addSelfHostedAsset = false, publicStatus, pinboard = false)
   }
 
   private def hasPermission(permission: Permission, user: PandaUser): Future[Boolean] = {

--- a/public/video-ui/src/components/utils/YouTubeEmbed.js
+++ b/public/video-ui/src/components/utils/YouTubeEmbed.js
@@ -1,15 +1,17 @@
 import React from 'react';
 import { getStore } from '../../util/storeAccessor';
 
-export function YouTubeEmbed({ id, className }) {
-  const embedUrl = getStore().getState().config.youtubeEmbedUrl;
-  const src = `${embedUrl}${id}?showinfo=0&rel=0`;
 
+export const getYouTubeEmbedUrl = (id) => {
+  const embedUrl = getStore().getState().config.youtubeEmbedUrl;
+  return `${embedUrl}${id}?showinfo=0&rel=0`;
+}
+export function YouTubeEmbed({ id, className }) {
   return (
     <iframe
       type="text/html"
       className={className}
-      src={src}
+      src={getYouTubeEmbedUrl(id)}
       allowFullScreen
       frameBorder="0"
     />

--- a/public/video-ui/src/pages/Video/index.js
+++ b/public/video-ui/src/pages/Video/index.js
@@ -105,7 +105,7 @@ class VideoDisplay extends React.Component {
       <div>
         <p className="video__images_heading">How are these images used?</p>
         <div>
-          <table class="video__images_description_table">
+          <table className="video__images_description_table">
             <thead>
               <tr>
                 <th scope="row">Guardian Video Thumbnail Image</th>
@@ -142,6 +142,12 @@ class VideoDisplay extends React.Component {
             Video Preview
             {youtubeAsset ? ` (${youtubeAsset.id})` : ``}
           </header>
+          <asset-handle data-source="mam"
+                        data-source-type="video"
+                        data-thumbnail={this.props.video?.posterImage?.assets?.[0]?.file}
+                        data-external-url={VideoUtils.isYoutube(this.props.video) && getYouTubeEmbedUrl(VideoUtils.getActiveAsset(this.props.video)?.id)}
+                        data-embeddable-url={window.location.href}>
+          </asset-handle>
           <Link
             className={'button ' + (this.props.videoEditOpen ? 'disabled' : '')}
             to={`/videos/${this.props.video.id}/upload`}
@@ -391,6 +397,7 @@ import * as trackInWorkflow
   from '../../actions/WorkflowActions/trackInWorkflow';
 import * as updateWorkflowData
   from '../../actions/WorkflowActions/updateWorkflowData';
+import {getYouTubeEmbedUrl} from "../../components/utils/YouTubeEmbed";
 
 function mapStateToProps(state) {
   return {

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -64,6 +64,8 @@
   justify-content: space-between;
   padding: 10px;
   margin-right: 4px;
+  gap: 10px;
+  align-items: center;
 }
 
 .video__detailbox {
@@ -72,6 +74,7 @@
   border-top: 1px solid $color600Grey;
 
   &__header {
+    flex-grow: 1;
     color: $color400Grey;
     font-weight: bold;
     display: block;


### PR DESCRIPTION
https://trello.com/c/SiW7WLsL/1513-pinboard-mam-videos-support

related: https://github.com/guardian/pinboard/pull/283

This PR does three main things...
- loads the pinboard loader script (if the user has pinboard permission) - this gets the pinboard floaty on the screen etc.
- adds an innocuous `<asset-handle>` to the DOM of the video page (following Pinboard's 'lightweight integration' approach, similar to https://github.com/guardian/grid/pull/3190, https://github.com/guardian/grid/pull/3704, https://github.com/guardian/grid/pull/3740), which pinboard can detect and extract some data attributes...
  - `data-source` : `mam` and `data-source-type` : `video` together form the `type` for the pinboard message
  - `data-thumbnail`: the url of the poster image thumbnail
  - `data-external-url`: the Youtube embed url
  - `data-embeddable-url`: the url of the current atom (since composer already has drag'n'drop embed support for these URLs)
- adds `Access-Control-Allow-Origin` & `Access-Control-Allow-Credentials` response headers to the `GET /api/atoms/:id` endpoint to allow and ed tools to load it AJAX (so long as they have panda auth of course) to facilitate https://github.com/guardian/pinboard/pull/284

![mam-videos-in-pinboard](https://github.com/guardian/pinboard/assets/19289579/30e5c5cc-f492-4f1c-b55e-3472128145af)

EDIT: since the GIF was made the `Add to 📌` button has been moved to be on the `Video Preview` heading line
<img width="878" alt="image" src="https://github.com/guardian/media-atom-maker/assets/19289579/4358c87b-6fdf-4e6b-8d4b-8214704f6e8f">