### PR TITLE
Use the updated vertical video tag

### DIFF
--- a/public/video-ui/src/components/VideoImages/VideoImages.js
+++ b/public/video-ui/src/components/VideoImages/VideoImages.js
@@ -38,7 +38,7 @@ export default class VideoImages extends React.Component {
 
   hasVerticalVideoTag() {
     const tags = this.props.video.keywords || [];
-    return tags.includes('media/series/vertical-video');
+    return tags.includes('tone/vertical-video');
   }
 
   render() {

--- a/public/video-ui/src/components/VideoPreview/VideoPreview.js
+++ b/public/video-ui/src/components/VideoPreview/VideoPreview.js
@@ -40,7 +40,7 @@ export default class VideoPreview extends React.Component {
 
   hasVerticalVideoTag() {
     const tags = this.props.video.keywords || [];
-    return tags.includes('media/series/vertical-video');
+    return tags.includes('tone/vertical-video');
   }
 
   render() {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Previously we were using a series tag to identify vertical video, but its better to use a tone tag

<img width="1507" alt="image" src="https://github.com/guardian/media-atom-maker/assets/26366706/5d771e54-033a-40e8-b782-881284523e4e">
Note the vertical-video tag, and the vertical media player and thumbnail
