### PR TITLE
Revert "Upgrade to panda v1.3.0"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scala.sys.process._
 
 val scroogeVersion = "4.12.0"
 val awsVersion = "1.11.678"
-val pandaVersion = "1.3.0"
+val pandaVersion = "1.2.0"
 val pandaHmacVersion = "2.1.0"
 val atomMakerVersion = "1.3.4"
 val typesafeConfigVersion = "1.4.0" // to match what we get from Play transitively


### PR DESCRIPTION
Reverts guardian/media-atom-maker#1123 which appears to have led to some issues in the tool, with 'could not get uploads' and 'could not get youtube categories' error messages in the UI and some `500` status network errors showing up.