### PR TITLE
Bump `Serial` in cloudformation

### DIFF
--- a/cloudformation/media-atom-maker-dev.yml
+++ b/cloudformation/media-atom-maker-dev.yml
@@ -96,7 +96,7 @@ Resources:
     Type: "AWS::IAM::AccessKey"
     Properties:
       UserName: {"Ref": "MediaAtomUser"}
-      Serial: 3
+      Serial: 4
   MediaAtomsDynamoTable:
     Type: "AWS::DynamoDB::Table"
     Properties:


### PR DESCRIPTION
## What does this change?

Bumps `Serial` in `cloudformation/media-atom-maker-dev.yml`. 

This will magically rotate the IAM key, as per these instructions:

https://github.com/guardian/media-atom-maker/blob/main/docs/01-dev-setup.md#local-setup

This is needed because the key was last rotated a year ago:

https://security-hq.gutools.co.uk/iam