### PR TITLE
add sorting option; 'Last Modified (Default)' or 'Created'

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -45,8 +45,8 @@ class Api(
     }
   }
 
-  def getMediaAtoms(search: Option[String], limit: Option[Int]) = APIAuthAction {
-    val atoms = stores.atomListStore.getAtoms(search, limit)
+  def getMediaAtoms(search: Option[String], limit: Option[Int], shouldUseCreatedDateForSort: Boolean) = APIAuthAction {
+    val atoms = stores.atomListStore.getAtoms(search, limit, shouldUseCreatedDateForSort)
     Ok(Json.toJson(atoms))
   }
 

--- a/conf/routes
+++ b/conf/routes
@@ -1,5 +1,5 @@
 # optional limit
-GET     /api/atoms                     controllers.Api.getMediaAtoms(search: Option[String], limit: Option[Int])
+GET     /api/atoms                     controllers.Api.getMediaAtoms(search: Option[String], limit: Option[Int], shouldUseCreatedDateForSort: Boolean?=false)
 POST    /api/atoms                     controllers.Api.createMediaAtom
 
 GET     /api/atoms/:id                 controllers.Api.getMediaAtom(id)

--- a/public/video-ui/src/actions/SearchActions/updateShouldUseCreatedDateForSort.js
+++ b/public/video-ui/src/actions/SearchActions/updateShouldUseCreatedDateForSort.js
@@ -1,0 +1,7 @@
+export function updateShouldUseCreatedDateForSort(shouldUseCreatedDateForSort) {
+  return {
+    type: 'UPDATE_SHOULD_USE_CREATED_DATE_FOR_SORT',
+    shouldUseCreatedDateForSort,
+    receivedAt: Date.now()
+  };
+}

--- a/public/video-ui/src/actions/VideoActions/getVideos.js
+++ b/public/video-ui/src/actions/VideoActions/getVideos.js
@@ -1,10 +1,11 @@
 import VideosApi from '../../services/VideosApi';
 
-function requestVideos(search, limit) {
+function requestVideos(search, limit, shouldUseCreatedDateForSort) {
   return {
     type: 'VIDEOS_GET_REQUEST',
-    search: search,
-    limit: limit,
+    search,
+    limit,
+    shouldUseCreatedDateForSort,
     receivedAt: Date.now()
   };
 }
@@ -27,10 +28,10 @@ function errorReceivingVideos(error) {
   };
 }
 
-export function getVideos(search, limit) {
+export function getVideos(search, limit, shouldUseCreatedDateForSort) {
   return dispatch => {
-    dispatch(requestVideos(search, limit));
-    return VideosApi.fetchVideos(search, limit)
+    dispatch(requestVideos(search, limit, shouldUseCreatedDateForSort));
+    return VideosApi.fetchVideos(search, limit, shouldUseCreatedDateForSort)
       .then(res => {
         dispatch(receiveVideos(res.total, res.atoms));
       })

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -1,14 +1,15 @@
 import React from 'react';
-import { Link } from 'react-router';
+import {Link} from 'react-router';
 import VideoSearch from './VideoSearch/VideoSearch';
 import VideoPublishBar from './VideoPublishBar/VideoPublishBar';
 import VideoPublishState from './VideoPublishState/VideoPublishState';
 import AdvancedActions from './Videos/AdvancedActions';
 import ComposerPageCreate from './Videos/ComposerPageCreate';
 import Icon from './Icon';
-import { Presence } from './Presence';
-import { canonicalVideoPageExists } from '../util/canonicalVideoPageExists';
+import {Presence} from './Presence';
+import {canonicalVideoPageExists} from '../util/canonicalVideoPageExists';
 import VideoUtils from '../util/video';
+import {QUERY_PARAM_shouldUseCreatedDateForSort} from "../constants/queryParams";
 
 export default class Header extends React.Component {
   state = { presence: null };
@@ -65,13 +66,30 @@ export default class Header extends React.Component {
       <div className="flex-container topbar__global">
         <span>Sort by:&nbsp;</span>
         <select
-          onChange={event => this.props.updateShouldUseCreatedDateForSort(event.target.value === "true")}
+          value={this.props.shouldUseCreatedDateForSort?.toString()}
+          onChange={event => {
+            const shouldUseCreatedDateForSort = event.target.value === "true";
+
+            this.props.updateShouldUseCreatedDateForSort(shouldUseCreatedDateForSort);
+
+            const url = new URL(window.location.href);
+            if (shouldUseCreatedDateForSort) {
+              url.searchParams.set(QUERY_PARAM_shouldUseCreatedDateForSort, "true");
+            } else {
+              url.searchParams.delete(QUERY_PARAM_shouldUseCreatedDateForSort);
+            }
+            window.history.replaceState(
+              window.history.state,
+              document.title,
+              url.toString()
+            );
+          }}
         >
           <option value="false">Last Modified (default)</option>
           <option value="true">Created</option>
         </select>
       </div>
-    )
+    );
   }
 
   renderHeaderBack() {

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -86,7 +86,7 @@ export default class Header extends React.Component {
           }}
         >
           <option value="false">Last Modified (default)</option>
-          <option value="true">Created</option>
+          <option value="true">Created (newest first)</option>
         </select>
       </div>
     );

--- a/public/video-ui/src/components/Header.js
+++ b/public/video-ui/src/components/Header.js
@@ -60,6 +60,20 @@ export default class Header extends React.Component {
     );
   }
 
+  renderSortBy() {
+    return (
+      <div className="flex-container topbar__global">
+        <span>Sort by:&nbsp;</span>
+        <select
+          onChange={event => this.props.updateShouldUseCreatedDateForSort(event.target.value === "true")}
+        >
+          <option value="false">Last Modified (default)</option>
+          <option value="true">Created</option>
+        </select>
+      </div>
+    )
+  }
+
   renderHeaderBack() {
     return (
       <div className="flex-container topbar__global">
@@ -169,6 +183,8 @@ export default class Header extends React.Component {
           {this.renderPresence()}
 
           <div className="flex-spacer" />
+
+          {this.renderSortBy()}
 
           <div className="flex-container">
             {this.renderCreateVideo()}

--- a/public/video-ui/src/components/ReactApp.js
+++ b/public/video-ui/src/components/ReactApp.js
@@ -32,9 +32,9 @@ class ReactApp extends React.Component {
     }
   }
 
-  updateSearchTerm = searchTerm => {
-    this.props.appActions.updateSearchTerm(searchTerm);
-  };
+  updateSearchTerm = this.props.appActions.updateSearchTerm;
+
+  updateShouldUseCreatedDateForSort = this.props.appActions.updateShouldUseCreatedDateForSort;
 
   getEditableFields = () => {
     const allFields = this.props.checkedFormFields;
@@ -53,6 +53,7 @@ class ReactApp extends React.Component {
     return (
       <div className="wrap">
         <Header
+          updateShouldUseCreatedDateForSort={this.updateShouldUseCreatedDateForSort}
           updateSearchTerm={this.updateSearchTerm}
           searchTerm={this.props.searchTerm}
           currentPath={this.props.location.pathname}
@@ -94,6 +95,7 @@ class ReactApp extends React.Component {
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as updateSearchTerm from '../actions/SearchActions/updateSearchTerm';
+import * as updateShouldUseCreatedDateForSort from '../actions/SearchActions/updateShouldUseCreatedDateForSort';
 import * as getVideo from '../actions/VideoActions/getVideo';
 import * as getPublishedVideo from '../actions/VideoActions/getPublishedVideo';
 import * as publishVideo from '../actions/VideoActions/publishVideo';
@@ -108,6 +110,7 @@ import * as updateVideo from '../actions/VideoActions/updateVideo';
 function mapStateToProps(state) {
   return {
     searchTerm: state.searchTerm,
+    shouldUseCreatedDateForSort: state.shouldUseCreatedDateForSort,
     saveState: state.saveState,
     video: state.video,
     publishedVideo: state.publishedVideo,
@@ -128,6 +131,7 @@ function mapDispatchToProps(dispatch) {
       Object.assign(
         {},
         updateSearchTerm,
+        updateShouldUseCreatedDateForSort,
         getVideo,
         getPublishedVideo,
         publishVideo,

--- a/public/video-ui/src/components/ReactApp.js
+++ b/public/video-ui/src/components/ReactApp.js
@@ -32,10 +32,6 @@ class ReactApp extends React.Component {
     }
   }
 
-  updateSearchTerm = this.props.appActions.updateSearchTerm;
-
-  updateShouldUseCreatedDateForSort = this.props.appActions.updateShouldUseCreatedDateForSort;
-
   getEditableFields = () => {
     const allFields = this.props.checkedFormFields;
 
@@ -53,8 +49,9 @@ class ReactApp extends React.Component {
     return (
       <div className="wrap">
         <Header
-          updateShouldUseCreatedDateForSort={this.updateShouldUseCreatedDateForSort}
-          updateSearchTerm={this.updateSearchTerm}
+          shouldUseCreatedDateForSort={this.props.shouldUseCreatedDateForSort}
+          updateShouldUseCreatedDateForSort={this.props.appActions.updateShouldUseCreatedDateForSort}
+          updateSearchTerm={this.props.appActions.updateSearchTerm}
           searchTerm={this.props.searchTerm}
           currentPath={this.props.location.pathname}
           video={this.props.video || {}}

--- a/public/video-ui/src/constants/queryParams.js
+++ b/public/video-ui/src/constants/queryParams.js
@@ -1,0 +1,1 @@
+export const QUERY_PARAM_shouldUseCreatedDateForSort = "shouldUseCreatedDateForSort";

--- a/public/video-ui/src/reducers/rootReducer.js
+++ b/public/video-ui/src/reducers/rootReducer.js
@@ -20,6 +20,7 @@ import path from './pathReducer';
 import pluto from './plutoReducer';
 import workflow from './workflowReducer';
 import targeting from './targetingReducer';
+import shouldUseCreatedDateForSort from "./shouldUseCreatedDateForSortReducer";
 
 export default combineReducers({
   config,
@@ -28,6 +29,7 @@ export default combineReducers({
   videos,
   saveState,
   searchTerm,
+  shouldUseCreatedDateForSort,
   youtube,
   usage,
   pageCreate,

--- a/public/video-ui/src/reducers/shouldUseCreatedDateForSortReducer.js
+++ b/public/video-ui/src/reducers/shouldUseCreatedDateForSortReducer.js
@@ -1,4 +1,7 @@
-export default function shouldUseCreatedDateForSort(state = '', action) {
+import {QUERY_PARAM_shouldUseCreatedDateForSort} from "../constants/queryParams";
+
+const initialState = new URL(window.location.href).searchParams.get(QUERY_PARAM_shouldUseCreatedDateForSort) === "true";
+export default function shouldUseCreatedDateForSort(state = initialState, action) {
   switch (action.type) {
     case 'UPDATE_SHOULD_USE_CREATED_DATE_FOR_SORT':
       return action.shouldUseCreatedDateForSort || false;

--- a/public/video-ui/src/reducers/shouldUseCreatedDateForSortReducer.js
+++ b/public/video-ui/src/reducers/shouldUseCreatedDateForSortReducer.js
@@ -1,0 +1,8 @@
+export default function shouldUseCreatedDateForSort(state = '', action) {
+  switch (action.type) {
+    case 'UPDATE_SHOULD_USE_CREATED_DATE_FOR_SORT':
+      return action.shouldUseCreatedDateForSort || false;
+    default:
+      return state;
+  }
+}

--- a/public/video-ui/src/reducers/videosReducer.js
+++ b/public/video-ui/src/reducers/videosReducer.js
@@ -9,7 +9,8 @@ export default function videos(
       return {
         entries: state.entries,
         total: state.total,
-        limit: action.limit
+        limit: action.limit,
+        shouldUseCreatedDateForSort: action.shouldUseCreatedDateForSort
       };
     case 'VIDEOS_GET_RECEIVE':
       return {

--- a/public/video-ui/src/services/VideosApi.ts
+++ b/public/video-ui/src/services/VideosApi.ts
@@ -102,10 +102,13 @@ function splitUsages({ usages }: {usages: CapiContent[]}) {
 }
 
 export default {
-  fetchVideos: (search: string, limit: number) => {
+  fetchVideos: (search: string, limit: number, shouldUseCreatedDateForSort: boolean) => {
     let url = `/api/atoms?limit=${limit}`;
     if (search) {
       url += `&search=${search}`;
+    }
+    if(shouldUseCreatedDateForSort) {
+      url += '&shouldUseCreatedDateForSort=true';
     }
 
     return pandaReqwest({

--- a/public/video-ui/styles/layout/_topbar.scss
+++ b/public/video-ui/styles/layout/_topbar.scss
@@ -5,6 +5,9 @@ $topbarHeight: 50px;
   top: 0;
   z-index: 1;
 
+  justify-content: right;
+  flex-wrap: wrap;
+
   background: $color700Grey;
   border-bottom: 1px solid $greyBorderColor;
 

--- a/public/video-ui/styles/layout/_topbar.scss
+++ b/public/video-ui/styles/layout/_topbar.scss
@@ -50,6 +50,12 @@ $topbarHeight: 50px;
 .topbar__global {
   margin-right: 10px;
 }
+.topbar__global select {
+  font-family: inherit;
+  background: none;
+  color: inherit;
+  padding: 3px;
+}
 
 .topbar__functional {
   margin-left: 20px;


### PR DESCRIPTION
https://trello.com/c/oQjrL8hW/1558-add-sort-by-to-mam-to-allow-sorting-by-created-date

![mam_sort](https://github.com/guardian/media-atom-maker/assets/19289579/890dd081-0eab-4a17-b105-512eec2da66f)

User request...
![image](https://github.com/guardian/media-atom-maker/assets/19289579/81374ffc-2585-4842-a48a-b5d763bbac97)

Seemed reasonable, so added this feature. The CAPI team advised that sorting by 'created' is curiously done with `order-date: first-published` in CAPI...
![image](https://github.com/guardian/media-atom-maker/assets/19289579/b22c5dab-5ef8-460f-a6c1-53934256897e)

