### PR TITLE
Add headline validation error message if it reaches the maximum length

### DIFF
--- a/public/video-ui/src/components/FormFields/RichTextField.tsx
+++ b/public/video-ui/src/components/FormFields/RichTextField.tsx
@@ -12,8 +12,7 @@ type EditorProps = {
   fieldValue: string;
   derivedFrom: string;
   onUpdateField: (string: string) => any;
-  maxLength: number;
-  maxCharLength: number;
+  maxWordLength: number;
   editable: boolean;
   fieldLocation: string;
   fieldName: string;
@@ -46,7 +45,7 @@ export default class RichTextField extends React.Component<EditorProps, EditorSt
   };
 
   updateFieldValue = (value: string) => {
-    if (!isTooLong(value, this.props.maxLength, this.props.maxCharLength)) {
+    if (!isTooLong(value, this.props.maxWordLength)) {
       this.setState({
         isTooLong: false
       });

--- a/public/video-ui/src/components/FormFields/richtext/utils/richTextHelpers.ts
+++ b/public/video-ui/src/components/FormFields/richtext/utils/richTextHelpers.ts
@@ -21,13 +21,12 @@ export const getWords = (text: string): string[] => {
     .filter(_ => _.length !== 0);
 };
 
-export const isTooLong = (value: string, maxLength: number, maxCharLength: number): boolean => {
+export const isTooLong = (value: string, maxWordLength: number): boolean => {
   const wordLength = getWords(value).reduce((length, word) => {
     length += word.length;
     return length;
   }, 0);
   return (
-    wordLength > maxLength ||
-    value.length > maxCharLength
+    wordLength > maxWordLength
   );
 };

--- a/public/video-ui/src/components/ManagedForm/ManagedField.js
+++ b/public/video-ui/src/components/ManagedForm/ManagedField.js
@@ -62,7 +62,6 @@ export class ManagedField extends React.Component {
       this.props.customValidation,
       composerValidation,
       this.props.maxLength,
-      this.props.name
     );
 
     if (this.props.updateFormErrors) {
@@ -161,7 +160,7 @@ export class ManagedField extends React.Component {
         hasWarning: this.hasWarning,
         displayPlaceholder: this.displayPlaceholder,
         derivedFrom: this.props.derivedFrom,
-        maxCharLength: this.props.maxCharLength,
+        maxWordLength: this.props.maxWordLength,
         tagType: this.props.tagType,
         inputPlaceholder: this.props.inputPlaceholder,
         tooltip: this.props.tooltip,

--- a/public/video-ui/src/components/ManagedForm/ManagedField.js
+++ b/public/video-ui/src/components/ManagedForm/ManagedField.js
@@ -60,7 +60,9 @@ export class ManagedField extends React.Component {
       this.props.isRequired,
       this.props.isDesired,
       this.props.customValidation,
-      composerValidation
+      composerValidation,
+      this.props.maxLength,
+      this.props.name
     );
 
     if (this.props.updateFormErrors) {

--- a/public/video-ui/src/components/VideoData/VideoData.js
+++ b/public/video-ui/src/components/VideoData/VideoData.js
@@ -82,8 +82,8 @@ export default class VideoData extends React.Component {
         <ManagedField
           fieldLocation="description"
           name="Standfirst"
-          maxCharLength={fieldLengths.description.charMax}
-          maxLength={fieldLengths.description.max}
+          maxLength={fieldLengths.description.charMax}
+          maxWordLength={fieldLengths.description.max}
         >
           <RichTextField
             config={standfirstConfig}
@@ -93,8 +93,8 @@ export default class VideoData extends React.Component {
           fieldLocation="trailText"
           derivedFrom={video.description}
           name="Trail Text"
-          maxCharLength={fieldLengths.description.charMax}
-          maxLength={fieldLengths.description.max}
+          maxLength={fieldLengths.description.charMax}
+          maxWordLength={fieldLengths.description.max}
           isDesired={!canonicalVideoPageExists}
           isRequired={canonicalVideoPageExists}
         >

--- a/public/video-ui/src/components/YoutubeFurniture/index.js
+++ b/public/video-ui/src/components/YoutubeFurniture/index.js
@@ -134,7 +134,7 @@ class YoutubeFurniture extends React.Component {
         <ManagedField
           fieldLocation="youtubeDescription"
           name="Description"
-          maxCharLength={fieldLengths.youtubeDescription.charMax}
+          maxWordLength={fieldLengths.youtubeDescription.charMax}
           maxLength={fieldLengths.youtubeDescription.charMax}
           isRequired={false}
           customValidation={this.validateYouTubeDescription}

--- a/public/video-ui/src/test/richTextInput.spec.ts
+++ b/public/video-ui/src/test/richTextInput.spec.ts
@@ -24,29 +24,17 @@ describe("isTooLong", () => {
   it('Should return false for phrases less than the character and word limit', () => {
     const tooLongString = "So it goes";
     const maxWords = 100;
-    const maxChars = 10;
 
-    const isTooLongResult = isTooLong(tooLongString, maxWords, maxChars);
+    const isTooLongResult = isTooLong(tooLongString, maxWords);
 
     expect(isTooLongResult).toBe(false);
-  });
-
-  it('Should return true for phrases over the character limit', () => {
-    const stringWithTooManyCharacters = "abcdefghijklmnop";
-    const maxWords = 100;
-    const maxChars = 10;
-
-    const isTooLongResult = isTooLong(stringWithTooManyCharacters, maxWords, maxChars);
-
-    expect(isTooLongResult).toBe(true);
   });
 
   it('Should return true for phrases over the word limit', () => {
     const stringWithTooManyWords = " All statements are true in some sense, false in some sense, meaningless in some sense, true and false in some sense, true and meaningless in some sense, false and meaningless in some sense, and true and false and meaningless in some sense.";
     const maxWords = 5;
-    const maxChars = 10000;
 
-    const isTooLongResult = isTooLong(stringWithTooManyWords, maxWords, maxChars);
+    const isTooLongResult = isTooLong(stringWithTooManyWords, maxWords);
 
     expect(isTooLongResult).toBe(true);
   });

--- a/public/video-ui/src/util/validateField.js
+++ b/public/video-ui/src/util/validateField.js
@@ -7,7 +7,7 @@ const validateField = (
   isDesired = false,
   customValidation = null,
   composerValidation = false,
-  maxLength,
+  maxLength
 ) => {
   if (customValidation) {
     return customValidation(fieldValue);

--- a/public/video-ui/src/util/validateField.js
+++ b/public/video-ui/src/util/validateField.js
@@ -6,7 +6,9 @@ const validateField = (
   isRequired = false,
   isDesired = false,
   customValidation = null,
-  composerValidation = false
+  composerValidation = false,
+  maxLength,
+  name
 ) => {
   if (customValidation) {
     return customValidation(fieldValue);
@@ -38,6 +40,22 @@ const validateField = (
         ? RequiredForComposer.warning
         : 'This field is desired',
       FieldNotification.warning
+    );
+  }
+
+  function fieldValueTooLong() {
+    if (fieldValue && fieldValue.length === maxLength) {
+      return true;
+    }
+
+    return false;
+  }
+
+  if (name === "Headline" && fieldValueTooLong()) {
+    return new FieldNotification(
+      'too long',
+      'You have reached the maximum character length',
+      FieldNotification.error
     );
   }
 

--- a/public/video-ui/src/util/validateField.js
+++ b/public/video-ui/src/util/validateField.js
@@ -8,7 +8,6 @@ const validateField = (
   customValidation = null,
   composerValidation = false,
   maxLength,
-  name
 ) => {
   if (customValidation) {
     return customValidation(fieldValue);
@@ -51,7 +50,7 @@ const validateField = (
     return false;
   }
 
-  if (name === "Headline" && fieldValueTooLong()) {
+  if (maxLength && fieldValueTooLong()) {
     return new FieldNotification(
       'too long',
       'You have reached the maximum character length',


### PR DESCRIPTION
Co-authored-by: Samantha Gottlieb <samantha.gottlieb@guardian.co.uk>

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a validation message to the headline field alerting users when they've reached the maximum number of characters. Due to youtube content rules, there is currently a limit of 100, but until now this wouldn't have been clear to users if they reached it.  

Just to note, other fields such as the standfirst have their own erroring logic; wary of this clashing with the changes from this PR, we've restricted this validation to the `Headline` field. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Running MAM and entering 100 characters (or trying to enter more) in the headline field should now show an error stating `You have reached the maximum character length`

## Images

<img width="612" alt="image" src="https://github.com/guardian/media-atom-maker/assets/102960844/a0327df5-d634-451e-84a1-177959c0db29">


