### PR TITLE
Update DEV setup instructions

### DIFF
--- a/docs/01-dev-setup.md
+++ b/docs/01-dev-setup.md
@@ -5,7 +5,7 @@ Ensure you have the following installed:
 - awscli
 - Java 8
 - nginx
-- node v10+
+- node v14.18.1
 - npm
 - yarn
 - nvm
@@ -13,12 +13,12 @@ Ensure you have the following installed:
 
 You'll also need Janus credentials to the `media-service` account.
 
-## Local setup 
+## Local setup
 
 We use a shared DEV stack, with a shared config. Fetch it by running:
 
 ```bash
-./scripts/fetch-dev-config.sh
+sudo ./scripts/fetch-dev-config.sh
 ```
 
 There is a chance that the IAM key used for local development (media-atom-maker-DEV) has been disabled if it has not been rotated in a while. If this is the case, and you need the key, you will need to rotate the IAM key. To do this, increment the [Serial property](https://github.com/guardian/media-atom-maker/blob/ba9f87b4b3d3f3446affabc4410ea598ae130e36/cloudformation/media-atom-maker-dev.yml#L99) in the CloudFormation template, and update the stack with the new template. This will generate the new IAM key (found in the CloudFormation `Outputs` tab, under `AwsId` and `AwsSecret`), which you should update in the dev config file in S3 (under the settings `upload.accessKey` and `upload.secretKey`).


### PR DESCRIPTION
_co-authored-by @Georges-GNM_
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This updates the DEV setup instructions.

Running the `./scripts/fetch-dev-config.sh` script gave me the error `mkdir: /etc/gu: Permission denied`, so this PR adds `sudo` to the command. It also updates the node version required.

## How to test

Follow the instructions to get Media Atom Maker set up and running locally.