### PR TITLE
Do not bump `revision` twice when content is published

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -134,16 +134,15 @@ case class PublishAtomCommand(
       contentChangeDetails = atom.contentChangeDetails.copy(
         published = changeRecord,
         lastModified = changeRecord,
-        revision = atom.contentChangeDetails.revision + 1,
         scheduledLaunch = None,
         embargo = None
       )
     )
 
     AuditMessage(id, "Publish", getUsername(user)).logMessage()
-    UpdateAtomCommand(id, updatedAtom, stores, user, awsConfig).process()
+    val updatedAtomToPublish = UpdateAtomCommand(id, updatedAtom, stores, user, awsConfig).process()
 
-    val publishedAtom = publishAtomToLive(updatedAtom)
+    val publishedAtom = publishAtomToLive(updatedAtomToPublish)
     updateInactiveAssets(publishedAtom)
     publishedAtom
   }


### PR DESCRIPTION
## What does this change?

At the moment, publishing content bumps the revision once for the published content, and _twice_ for the draft content. This is because both the publish and update commands increment the revision number – the publish command passes an atom that's already been incremented into an update command.

This PR has the publish command delegate revision changes to the update action, and uses the output of the update action as the content to publish. As a result

## How to test

- On the `main` branch, running locally or in CODE, open the network tab and publish an atom, noting the revision number that comes back in the response – it's at `contentChangeDetails.revision`. Reload the page, and note that the revision number that comes back for the content is one greater.
- Do the same on this branch. The revision numbers should match.