### PR TITLE
Fix bug in word limit

### DIFF
--- a/public/video-ui/src/components/FormFields/richtext/utils/richTextHelpers.ts
+++ b/public/video-ui/src/components/FormFields/richtext/utils/richTextHelpers.ts
@@ -22,10 +22,7 @@ export const getWords = (text: string): string[] => {
 };
 
 export const isTooLong = (value: string, maxWordLength: number): boolean => {
-  const wordLength = getWords(value).reduce((length, word) => {
-    length += word.length;
-    return length;
-  }, 0);
+  const wordLength = getWords(value).length;
   return (
     wordLength > maxWordLength
   );

--- a/public/video-ui/src/test/richTextInput.spec.ts
+++ b/public/video-ui/src/test/richTextInput.spec.ts
@@ -21,9 +21,9 @@ describe("getWords", () => {
 });
 
 describe("isTooLong", () => {
-  it('Should return false for phrases less than the character and word limit', () => {
+  it('Should return false for phrases less than the word limit', () => {
     const tooLongString = "So it goes";
-    const maxWords = 100;
+    const maxWords = 3;
 
     const isTooLongResult = isTooLong(tooLongString, maxWords);
 


### PR DESCRIPTION
## What does this change?

The `tooLong` function currently limits the number of non-whitespace characters rather than the number of words. We think word limit is what was intended. This PR updates the tests so the existing implementation fails, and then fixes the function.

It also removes reference to character limit in the test, since this feature was removed by https://github.com/guardian/media-atom-maker/pull/1127

## How to test

Tricky to test without tweaking the word limits in `videoEditValidation.js`, since the word limit is currently half the character limit. If you were to change the word limit to 13 words, you should see that on `main` the text "I would like, if I may, to take you on a strange journey." is deemed too long, but with on this branch, it is acceptable.

But there is a unit test, so might be okay to just merge as is?

## How can we measure success?

No one notices. Main benefit is that when this code is copy and pasted (e.g. into prosemirror-editor) it does what developers expect.

## Have we considered potential risks?

This reduces the limit (if anything it increases the limit), and editorial cannot write the content they want. We would just roll back.