### PR TITLE
Update cloudformation docs

### DIFF
--- a/docs/07-deploying.md
+++ b/docs/07-deploying.md
@@ -1,7 +1,7 @@
 # Deploying
 
 ## Infrastructure
-The infrastructure is managed in [Cloud Formation templates](../cloudformation) which are deployed manually.
+The infrastructure is managed in a Cloud Formation template stored in the Editorial tools platform repository. This is deployed using the riff-raff project `media-service:media-atom-maker::cloudformation`.
 
 ## App
 The app is deployed with RiffRaff under `media-service:media-atom-maker`.


### PR DESCRIPTION
## What does this change?

Cloudformation files moved to editorial tools platform repo a while ago, and are now deployed via riff-raff rather than manually

(playing with AI to automatically generate a README for the repo surfaced this error)