### PR TITLE
Enable nightly backups for media-atom-pipeline's DynamoDB table

### DIFF
--- a/uploader/src/main/resources/cfn-template.yaml
+++ b/uploader/src/main/resources/cfn-template.yaml
@@ -196,6 +196,9 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: '5'
         WriteCapacityUnits: '5'
+      Tags:
+        - Key: devx-backup-enabled
+          Value: true
 
   VideoPipelinePROD:
     Type: "AWS::StepFunctions::StateMachine"


### PR DESCRIPTION
## What does this change?

This PR allows us to start backing up `media-atom-pipeline`'s DynamoDB table using https://github.com/guardian/aws-backup. For more details on this project see [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit) and this [audit](https://docs.google.com/spreadsheets/d/1gNh_yQ3GVo_dVAemgZfRZM_MaQxep6_x-hzrhvVBGHY/edit#gid=1523470588) that @guardian/devx-reliability have been working on with Heads of Engineering & EMs.

## How to test

I've [deployed this project to `CODE`](https://riffraff.gutools.co.uk/deployment/view/23b28b48-59e7-489c-b2d6-d5c20c2a5439) to confirm that it works as expected.

I will also double check that backups are taken as expected (this should happen the night after this CFN change is applied).

## How can we measure success?

We will be able to recover (most) data stored in this table in the unlikely event that it is ever deleted.

## Have we considered potential risks?

Yes, a number of risks related to performance, cost and privacy were considered. See [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit#heading=h.vwt7syo8ng40) for more details.

## Deployment

[Riff-Raff deploys this template](https://github.com/guardian/media-atom-maker/blob/e339eea3eb95873186be57177177caf3e3f5fdc6/conf/riff-raff.yaml#L40-L46)[^1] and [CD is enabled](https://riffraff.gutools.co.uk/deployment/continuous/49b91d73-3c89-4c19-a557-b45a01199b19/edit), so merging this PR should be sufficient.

[^1]: Although it's getting renamed somewhere along the line!