### PR TITLE
Increase the overhead available to the thumbnail generator when picking images from grid

### DIFF
--- a/app/util/ThumbnailGenerator.scala
+++ b/app/util/ThumbnailGenerator.scala
@@ -14,7 +14,7 @@ case class ThumbnailGenerator(logoFile: File) extends Logging {
   // YouTube have a file size limit of 2MB
   // see https://developers.google.com/youtube/v3/docs/thumbnails/set
   // use a slightly smaller file from Grid so we can add a branding overlay
-  private val MAX_SIZE = 1.8 * 1000 * 1000
+  private val MAX_SIZE = 1.7 * 1000 * 1000
 
   private lazy val logo = ImageIO.read(logoFile)
 


### PR DESCRIPTION
youtube requires thumbnails to be < 2MB. when picking which grid crop resize to use, we pick those under 1.8MB, so that we have 200kb available for the addition of the branding logo.
today we've encountered an image with a 1.75MB crop that is > 2MB after logo has been added, so dropping that limit by another 100kb to unblock that image.
(we could/should test what the limit really should be, rather than guess and trial & error, but that's a problem for another day)