### PR TITLE
Upgrade to Play v2.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val scroogeVersion = "4.12.0"
 val awsVersion = "1.11.678"
 val awsV2Version = "2.21.17"
 val pandaVersion = "3.0.1"
-val atomMakerVersion = "1.3.4"
+val atomMakerVersion = "2.0.0"
 val typesafeConfigVersion = "1.4.0" // to match what we get from Play transitively
 val scanamoVersion = "1.0.0-M28"
 
@@ -85,10 +85,10 @@ lazy val common = (project in file("common"))
       "com.google.api-client" %  "google-api-client" % googleApiClientVersion,
       "com.google.http-client" % "google-http-client-jackson2" % googleHttpJacksonVersion,
       "com.google.apis" % "google-api-services-youtube" % youTubeApiClientVersion,
-      "com.gu" %% "pan-domain-auth-play_2-8" % pandaVersion,
+      "com.gu" %% "pan-domain-auth-play_2-9" % pandaVersion,
       "com.gu" %% "pan-domain-auth-verification" % pandaVersion,
       "com.gu" %% "pan-domain-auth-core" % pandaVersion,
-      "com.gu" %% "panda-hmac-play_2-8" % pandaVersion,
+      "com.gu" %% "panda-hmac-play_2-9" % pandaVersion,
       ws,
       "com.typesafe.play" %% "play-json-joda" % "2.7.4",
       "com.gu" %% "atom-publisher-lib" % atomMakerVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
@@ -19,13 +19,3 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 libraryDependencies += "org.vafer" % "jdeb" % "1.6" artifacts (Artifact("jdeb", "jar", "jar"))
 
 addDependencyTreePlugin
-
-/*
-   scala-xml has been updated to 2.x in sbt, but not in other sbt plugins like sbt-native-packager
-   See: https://github.com/scala/bug/issues/12632
-   This is effectively overrides the safeguards (early-semver) put in place by the library authors ensuring binary compatibility.
-   We consider this a safe operation because when set under `projects/` (ie *not* in `build.sbt` itself) it only affects the
-   compilation of build.sbt, not of the application build itself.
-   Once the build has succeeded, there is no further risk (ie of a runtime exception due to clashing versions of `scala-xml`).
- */
-libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always


### PR DESCRIPTION
This upgrade from Play 2.8 → 2.9 was prompted by https://github.com/guardian/atom-maker/pull/94, but it's a good idea anyway!

Note that this PR is using a preview release of https://github.com/guardian/atom-maker/pull/94 (which updates those libraries to compile against Play 2.9), which should be merged before this PR.

Preparation for this PR included several prior PRs:

* https://github.com/guardian/media-atom-maker/pull/1147 and its [supporting PRs](https://github.com/guardian/media-atom-maker/issues?q=label%3A%22Scala+2.13%22)
* https://github.com/guardian/media-atom-maker/pull/1149 - [Play 2.9 requires Java 11, 17, or 21](https://www.playframework.com/documentation/2.9.x/Requirements#Play-Requirements)
* https://github.com/guardian/media-atom-maker/pull/1145