### PR TITLE
Drop unmaintained `diff` library for logging `MediaAtom` changes

### DIFF
--- a/app/model/commands/UpdateAtomCommand.scala
+++ b/app/model/commands/UpdateAtomCommand.scala
@@ -11,6 +11,7 @@ import com.gu.media.util.MediaAtomImplicits
 import com.gu.pandomainauth.model.{User => PandaUser}
 import data.DataStores
 import model.commands.CommandExceptions._
+import model.commands.UpdateAtomCommand.createDiffString
 import org.joda.time.DateTime
 import util.AWSConfig
 
@@ -120,7 +121,9 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom, override val stores: D
     val message = AtomAssignedProjectMessage.build(newAtom)
     plutoActions.sendToPluto(message)
   }
+}
 
+object UpdateAtomCommand {
   private val interestingFields = List("title", "category", "description", "duration", "source", "youtubeCategoryId", "license", "commentsEnabled", "channelId", "legallySensitive")
 
   // We don't use HTTP patch so diffing has to be done manually

--- a/app/model/commands/UpdateAtomCommand.scala
+++ b/app/model/commands/UpdateAtomCommand.scala
@@ -1,7 +1,6 @@
 package model.commands
 
 import java.util.Date
-import ai.x.diff.DiffShow
 import com.gu.atom.data.{AtomSerializer, VersionConflictError}
 import com.gu.contentatom.thrift.{Atom, ContentAtomEvent, EventType, ChangeRecord => ThriftChangeRecord}
 import com.gu.media.logging.Logging
@@ -124,22 +123,29 @@ case class UpdateAtomCommand(id: String, atom: MediaAtom, override val stores: D
 }
 
 object UpdateAtomCommand {
-  private val interestingFields = List("title", "category", "description", "duration", "source", "youtubeCategoryId", "license", "commentsEnabled", "channelId", "legallySensitive")
+  private val interestingFields = Seq[(String, MediaAtom => Option[Any])](
+    ("title", a => Some(a.title)),
+    ("category", a => Some(a.category)),
+    ("description", _.description),
+    ("duration", _.duration),
+    ("source", _.source),
+    ("youtubeCategoryId", _.youtubeCategoryId),
+    ("license", _.license),
+    ("commentsEnabled", _.composerCommentsEnabled),
+    ("channelId", _.channelId),
+    ("legallySensitive", _.legallySensitive)
+  )
 
   // We don't use HTTP patch so diffing has to be done manually
   def createDiffString(before: MediaAtom, after: MediaAtom): String = {
-    val fieldDiffs = DiffShow.diff[MediaAtom](before, after).string
-      .replaceAll("\\[*[0-9]+m", "") // Clean out the silly console coloring stuff
-      .split('\n')
-      .map(_.trim())
-      .filter(line => !line.contains("ERROR")) // More silly stuff from diffing library
-      .filter(line => interestingFields.exists(line.contains))
-      .mkString(", ")
+    val changedFields = for {
+      (name, extractor) <- interestingFields
+      distinctValues = Seq(extractor(before), extractor(after)).distinct
+      if distinctValues.size > 1
+    } yield s"$name: ${distinctValues.map(_.getOrElse("[NONE]")).mkString(" -> ")}"
 
-    if (fieldDiffs == "") { // There's a change, but in some field we're not interested in (or rather, unable to format nicely)
+    if (changedFields.isEmpty) { // There's a change, but in some field we're not interested in (or rather, unable to format nicely)
       "Updated atom fields"
-    } else {
-      s"Updated atom fields ($fieldDiffs)"
-    }
+    } else s"Updated atom fields (${changedFields.mkString(", ")})"
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,6 @@ val scanamoVersion = "1.0.0-M9"
 
 val playJsonExtensionsVersion = "0.40.2"
 val okHttpVersion = "2.4.0"
-val diffVersion = "2.0.1"
-
 val capiAwsVersion = "0.5"
 
 val scalaTestVersion = "3.0.8"
@@ -135,7 +133,6 @@ lazy val app = (project in file("."))
     libraryDependencies ++= Seq(
       ehcache,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
-      "ai.x" %% "diff" % diffVersion,
       "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
       "org.scalatestplus.play" %% "scalatestplus-play" % scalaTestPlusPlayVersion % "test",

--- a/test/model/commands/UpdateAtomCommandTest.scala
+++ b/test/model/commands/UpdateAtomCommandTest.scala
@@ -1,0 +1,57 @@
+package model.commands
+
+import com.gu.media.model.{Category, ContentChangeDetails, MediaAtom}
+import model.commands.UpdateAtomCommand.createDiffString
+import org.scalatest.{FunSuite, MustMatchers}
+
+class UpdateAtomCommandTest extends FunSuite with MustMatchers {
+  val mediaAtomFixture: MediaAtom = MediaAtom(
+    id = "123",
+    labels = List.empty,
+    assets = List.empty,
+    activeVersion = Some(1),
+    title = "title",
+    category = Category.News,
+    description = Some("Example description"),
+    duration = Some(1),
+    source = Some("source"),
+    posterImage = None,
+    trailText = None,
+    youtubeTitle = "title",
+    youtubeDescription = None,
+    trailImage = None,
+    tags = List.empty,
+    byline = List.empty,
+    commissioningDesks = List.empty,
+    contentChangeDetails = ContentChangeDetails(None, None, None, 1L, None, None, None),
+    privacyStatus = None,
+    channelId = None,
+    youtubeCategoryId = None,
+    youtubeOverrideImage = None,
+    keywords = List.empty,
+    license = None,
+    plutoData = None,
+    expiryDate = None,
+    legallySensitive = None,
+    sensitive = None,
+    optimisedForWeb = None,
+    composerCommentsEnabled = None,
+    suppressRelatedContent = None
+  )
+
+  test("Diff output when nothing changes") {
+    createDiffString(mediaAtomFixture, mediaAtomFixture) must be("Updated atom fields (category = News$,, channelId = None,, description = Some( \"Example description\" ),, duration = Some( 1 ),, legallySensitive = None,, license = None,, source = Some( \"source\" ),, title = \"title\",, youtubeCategoryId = None,, youtubeTitle = \"title\")")
+  }
+
+  test("Diff output when description changes") {
+    createDiffString(mediaAtomFixture, mediaAtomFixture.copy(description = Some("New description"))) must be(
+      "Updated atom fields (MediaAtom( ..., description = Some( \u001B\"Example description\"\u001B -> \u001B\"New description\"\u001B ) ))"
+    )
+  }
+
+  test("Diff output when description is removed") {
+    createDiffString(mediaAtomFixture, mediaAtomFixture.copy(description = None)) must be(
+      "Updated atom fields (MediaAtom( ..., description = \u001BSome( \"Example description\" )\u001B -> \u001BNone\u001B ))"
+    )
+  }
+}

--- a/test/model/commands/UpdateAtomCommandTest.scala
+++ b/test/model/commands/UpdateAtomCommandTest.scala
@@ -40,18 +40,18 @@ class UpdateAtomCommandTest extends FunSuite with MustMatchers {
   )
 
   test("Diff output when nothing changes") {
-    createDiffString(mediaAtomFixture, mediaAtomFixture) must be("Updated atom fields (category = News$,, channelId = None,, description = Some( \"Example description\" ),, duration = Some( 1 ),, legallySensitive = None,, license = None,, source = Some( \"source\" ),, title = \"title\",, youtubeCategoryId = None,, youtubeTitle = \"title\")")
+    createDiffString(mediaAtomFixture, mediaAtomFixture) must be("Updated atom fields")
   }
 
   test("Diff output when description changes") {
     createDiffString(mediaAtomFixture, mediaAtomFixture.copy(description = Some("New description"))) must be(
-      "Updated atom fields (MediaAtom( ..., description = Some( \u001B\"Example description\"\u001B -> \u001B\"New description\"\u001B ) ))"
+      "Updated atom fields (description: Example description -> New description)"
     )
   }
 
   test("Diff output when description is removed") {
     createDiffString(mediaAtomFixture, mediaAtomFixture.copy(description = None)) must be(
-      "Updated atom fields (MediaAtom( ..., description = \u001BSome( \"Example description\" )\u001B -> \u001BNone\u001B ))"
+      "Updated atom fields (description: Example description -> [NONE])"
     )
   }
 }


### PR DESCRIPTION
This removes the unmaintained [bizzabo/diff](https://github.com/bizzabo/diff) library ([`"ai.x" %% "diff"`](https://index.scala-lang.org/bizzabo/diff/artifacts/diff)) from media-atom-maker, as a prelude to the Scala 2.13 upgrade in https://github.com/guardian/media-atom-maker/pull/1140 (the `diff` library is only available for Scala 2.11 & 2.12).

The library is _only_ used for the media-atom-maker audit log, logging a diff when certain fields on `MediaAtom` entities change. The diff text _only_ goes to [the ELK logs](https://logs.gutools.co.uk/s/editorial-tools/goto/ecc536c0-c023-11ee-87d0-13c8789b7f4e) in the free-format message & description fields:

![image](https://github.com/guardian/media-atom-maker/assets/52038/40d1dc1b-0647-4841-bb31-e3e29e5ae5d7)

### Precise format of the Audit Log diff is not crucial

Originally, there was some functionality in the media-atom-maker UI involving an audit button, but this was removed with https://github.com/guardian/media-atom-maker/pull/759 in February 2018, and the ELK became the place this information was sent to (the _only_ place) with https://github.com/guardian/media-atom-maker/pull/767. See also https://github.com/guardian/media-atom-maker/pull/868#issuecomment-480065134 for a bit of additional context.

All this means that **the exact format of the diff logged to the ELK is not that important** - right now, the information could only really be used by a developer as an informative diagnostic - there is no process that cares if the diff format changes. This is probably a good thing, as 060adabbb8390cf1b0677edaba2bd0488437f83e in this PR (which captures the behaviour of the old diff by adding a unit test) shows that the format of the diff was not perfect!

### Replacement

To replace the old `diff` library, we looked at using alternative diffing libraries ([`diffx`](https://diffx-scala.readthedocs.io/en/latest/) or [`difflicious`](https://github.com/jatcwang/difflicious)) to produce the diff, but getting them to produce the format we wanted (a one-line diff with only _changed_ fields taken from an accept-list, and no colouring) looked like it would take a bit of work - @JamieB-gu pointed out that, given that there were only a few fields to look at, we could write our own diffing logic with little effort! The new logic produces output that is aesthetically better, I think - see [the updated unit test](https://github.com/guardian/media-atom-maker/pull/1141/commits/f60f0b77980b99ec35592d376c178ad1593d044c#diff-064da8baf7dc8bc5eddc4d9d23fddc171ca02aa1d16e756d1bc0ae68ed748b11) for some examples of how the audit log message changes.
