### PR TITLE
Upgrade Editorial permissions library to latest version

### DIFF
--- a/app/di.scala
+++ b/app/di.scala
@@ -73,7 +73,7 @@ class MediaAtomMaker(context: Context)
   private val capi = new Capi(config)
 
   private val stores = new DataStores(aws, capi)
-  private val permissions = new MediaAtomMakerPermissionsProvider(aws.stage, aws.credentials.instance.awsV1Creds)
+  private val permissions = new MediaAtomMakerPermissionsProvider(aws.stage, aws.region.getName, aws.credentials.instance.awsV1Creds)
 
   private val reindexer = buildReindexer()
 

--- a/build.sbt
+++ b/build.sbt
@@ -27,8 +27,6 @@ val awsLambdaEventsVersion = "1.3.0"
 val logbackClassicVersion = "1.2.3"
 val logstashLogbackEncoderVersion = "4.8"
 
-val permissionsClientVersion = "0.8"
-
 val guavaVersion = "31.1-jre"
 val googleOauthVersion = "1.33.3"
 val googleHttpJacksonVersion = "1.41.7"
@@ -117,7 +115,7 @@ lazy val common = (project in file("common"))
       "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test", // to match ScalaTest version
       "com.amazonaws" % "aws-java-sdk-sns" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion,
-      "com.gu" %% "editorial-permissions-client" % permissionsClientVersion,
+      "com.gu" %% "editorial-permissions-client" % "2.15",
       "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ses" % awsVersion,
       "com.gu" %% "content-api-client-aws" % capiAwsVersion,


### PR DESCRIPTION
This upgrades the Media Atom Maker to use the latest version of the client for the Guardian's Editorial Permissions service - we need the latest version of the client to support the upgrade to Scala 2.13 in https://github.com/guardian/media-atom-maker/pull/1140

## Permissions library versions

* **Before**: [guardian/editorial-permissions-client v0.8](https://github.com/guardian/editorial-permissions-client/tree/v0.8) - supporting Scala 2.11 & 2.12
* **After**: [guardian/permissions v2.15](https://github.com/guardian/permissions/tree/v2.15/client) - supporting Scala 2.12 & 2.13

As you can see, the permissions client has moved repositories, to the main `permissions` repo - this happened in July 2018 with PR https://github.com/guardian/permissions/pull/103. This PR is also important because it removed use of `Future` from the permissions client API - as Michael Barton explained, permission lookups should be mostly instantaneous because they now come from an in-memory cache.

The removal of `Future` means that _this_ PR, upgrading Media Atom Maker, needs to remove several for-comprehensions/map-statements. The diff on these can look quite big, but they look smaller if whitespace
changes are ignored. I've taken the opportunity to do small refactors to improve code clarity and remove repetition.

## Permission to modify Privacy Status of a published Media Atom

In particular, the code around modifying Privacy Status of a Media Atom _had_ to be changed because it involved removing `Future`, but I also included refactoring to make the code clearer. When reviewing this, you may want to look at the original PRs that introduced this logic:

* https://github.com/guardian/media-atom-maker/pull/607 - introduced the concept of each of our YouTube channels having a different set of available PrivacyStatus (Private, Unlisted, Public) values.
* https://github.com/guardian/media-atom-maker/pull/694 - allow everyone to upload as Public unless the channel is in the `youtube.channels.unlisted` config, in which case you need permission. This means we can give general users the ability to upload as Public on the culture channel and grant specific people access to make a public video on the main channel.
* https://github.com/guardian/media-atom-maker/pull/789 - public video should *stay* public when a metadata change is made by someone who does not have permission to *make* a video public on that channel.
* https://github.com/guardian/media-atom-maker/pull/791 - code shouldn't fail if the atom has not been published yet!