### PR TITLE
Upgrade `play-json-extensions` library

### DIFF
--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import ai.x.play.json.Encoders._
 import com.amazonaws.services.stepfunctions.model.{ExecutionAlreadyExistsException, ExecutionListItem}
 import com.gu.media.MediaAtomMakerPermissionsProvider
 import com.gu.media.logging.Logging

--- a/app/model/ClientConfig.scala
+++ b/app/model/ClientConfig.scala
@@ -1,5 +1,6 @@
 package model
 
+import ai.x.play.json.Encoders._
 import com.gu.media.Permissions
 import ai.x.play.json.Jsonx
 import play.api.libs.json.Format

--- a/app/model/MediaAtomSummary.scala
+++ b/app/model/MediaAtomSummary.scala
@@ -1,6 +1,7 @@
 package model
 
 import com.gu.media.model.{Image, ContentChangeDetails}
+import ai.x.play.json.Encoders._
 import ai.x.play.json.Jsonx
 import play.api.libs.json.Format
 

--- a/app/model/WorkflowMediaAtom.scala
+++ b/app/model/WorkflowMediaAtom.scala
@@ -1,5 +1,6 @@
 package model
 
+import ai.x.play.json.Encoders._
 import ai.x.play.json.Jsonx
 import play.api.libs.json.Format
 

--- a/app/model/transcoder/JobStatus.scala
+++ b/app/model/transcoder/JobStatus.scala
@@ -1,5 +1,6 @@
 package model.transcoder
 
+import ai.x.play.json.Encoders._
 import ai.x.play.json.Jsonx
 
 case class JobStatus(key: String, status: String, statusDetail: Option[String])

--- a/app/util/ActivateAssetRequest.scala
+++ b/app/util/ActivateAssetRequest.scala
@@ -1,5 +1,6 @@
 package util
 
+import ai.x.play.json.Encoders._
 import ai.x.play.json.Jsonx
 import play.api.libs.json._
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val atomMakerVersion = "1.3.4"
 val typesafeConfigVersion = "1.4.0" // to match what we get from Play transitively
 val scanamoVersion = "1.0.0-M9"
 
-val playJsonExtensionsVersion = "0.40.2"
+val playJsonExtensionsVersion = "0.42.0"
 val okHttpVersion = "2.4.0"
 val capiAwsVersion = "0.5"
 

--- a/common/src/main/scala/com/gu/media/Permissions.scala
+++ b/common/src/main/scala/com/gu/media/Permissions.scala
@@ -3,6 +3,7 @@ package com.gu.media
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.gu.editorial.permissions.client._
 import ai.x.play.json.Jsonx
+import ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 import com.gu.pandomainauth.model.{User => PandaUser}
 import scala.concurrent.Future

--- a/common/src/main/scala/com/gu/media/model/Asset.scala
+++ b/common/src/main/scala/com/gu/media/model/Asset.scala
@@ -1,6 +1,7 @@
 package com.gu.media.model
 
 import com.gu.contentatom.thrift.atom.media.{Asset => ThriftAsset}
+import ai.x.play.json.Encoders._
 import ai.x.play.json.Jsonx
 
 case class Asset(assetType: AssetType,

--- a/common/src/main/scala/com/gu/media/model/ChangeRecord.scala
+++ b/common/src/main/scala/com/gu/media/model/ChangeRecord.scala
@@ -1,5 +1,6 @@
 package com.gu.media.model
 
+import ai.x.play.json.Encoders._
 import com.gu.contentatom.thrift.{ChangeRecord => ThriftChangeRecord}
 import com.gu.pandomainauth.model.{User => PandaUser}
 import ai.x.play.json.Jsonx

--- a/common/src/main/scala/com/gu/media/model/ClientAsset.scala
+++ b/common/src/main/scala/com/gu/media/model/ClientAsset.scala
@@ -1,5 +1,6 @@
 package com.gu.media.model
 
+import ai.x.play.json.Encoders._
 import com.gu.media.upload.model.Upload
 import com.gu.media.youtube.YouTubeProcessingStatus
 import ai.x.play.json.Jsonx

--- a/common/src/main/scala/com/gu/media/model/ContentChangeDetails.scala
+++ b/common/src/main/scala/com/gu/media/model/ContentChangeDetails.scala
@@ -1,6 +1,7 @@
 package com.gu.media.model
 
 import com.gu.contentatom.thrift.{ContentChangeDetails => ThriftContentChangeDetails}
+import ai.x.play.json.Encoders._
 import ai.x.play.json.Jsonx
 
 case class ContentChangeDetails(

--- a/common/src/main/scala/com/gu/media/model/Image.scala
+++ b/common/src/main/scala/com/gu/media/model/Image.scala
@@ -1,6 +1,7 @@
 package com.gu.media.model
 
 import com.gu.contentatom.thrift.{Image => ThriftImage, ImageAsset => ThriftImageAsset, ImageAssetDimensions => ThriftImageAssetDimensions}
+import ai.x.play.json.Encoders._
 import ai.x.play.json.Jsonx
 
 case class ImageAssetDimensions(height: Int, width: Int) {

--- a/common/src/main/scala/com/gu/media/model/MediaAtom.scala
+++ b/common/src/main/scala/com/gu/media/model/MediaAtom.scala
@@ -1,11 +1,12 @@
 package com.gu.media.model
 
+import ai.x.play.json.Encoders._
+import ai.x.play.json.Jsonx
 import com.gu.contentatom.thrift.atom.media.{MediaAtom => ThriftMediaAtom, Metadata => ThriftMetadata, YoutubeData => ThriftYoutubeData}
 import play.api.libs.json.Format
 import com.gu.contentatom.thrift.{AtomData, Atom => ThriftAtom, AtomType => ThriftAtomType, Flags => ThriftFlags}
 import com.gu.media.util.MediaAtomImplicits
 import com.gu.media.youtube.{MediaAtomYoutubeDescriptionHandler, YoutubeDescription}
-import ai.x.play.json.Jsonx
 
 abstract class MediaAtomBase {
   //generic metadata

--- a/common/src/main/scala/com/gu/media/model/PlutoData.scala
+++ b/common/src/main/scala/com/gu/media/model/PlutoData.scala
@@ -1,5 +1,6 @@
 package com.gu.media.model
 
+import ai.x.play.json.Encoders._
 import com.gu.contentatom.thrift.atom.media.{PlutoData => ThriftPlutoData}
 import ai.x.play.json.Jsonx
 import play.api.libs.json.Format

--- a/common/src/main/scala/com/gu/media/model/PlutoIntegrationData.scala
+++ b/common/src/main/scala/com/gu/media/model/PlutoIntegrationData.scala
@@ -4,6 +4,7 @@ import com.amazonaws.services.s3.model.PutObjectRequest
 import com.gu.media.aws.{AwsAccess, UploadAccess}
 import com.gu.media.upload.CompleteUploadKey
 import ai.x.play.json.Jsonx
+import ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 
 sealed trait PlutoIntegrationMessage {

--- a/common/src/main/scala/com/gu/media/model/User.scala
+++ b/common/src/main/scala/com/gu/media/model/User.scala
@@ -1,5 +1,6 @@
 package com.gu.media.model
 
+import ai.x.play.json.Encoders._
 import com.gu.contentatom.thrift.{User => ThriftUser}
 import ai.x.play.json.Jsonx
 import play.api.libs.json.Format

--- a/common/src/main/scala/com/gu/media/model/VideoAsset.scala
+++ b/common/src/main/scala/com/gu/media/model/VideoAsset.scala
@@ -1,5 +1,6 @@
 package com.gu.media.model
 
+import ai.x.play.json.Encoders._
 import ai.x.play.json.Jsonx
 import play.api.libs.json.Format
 

--- a/common/src/main/scala/com/gu/media/pluto/PlutoProject.scala
+++ b/common/src/main/scala/com/gu/media/pluto/PlutoProject.scala
@@ -1,5 +1,6 @@
 package com.gu.media.pluto
 
+import ai.x.play.json.Encoders._
 import ai.x.play.json.Jsonx
 import org.joda.time.DateTime
 import play.api.libs.json._

--- a/common/src/main/scala/com/gu/media/upload/model/Upload.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/Upload.scala
@@ -1,6 +1,7 @@
 package com.gu.media.upload.model
 
 import ai.x.play.json.Jsonx
+import ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 
 // All data is conceptually immutable except UploadProgress

--- a/common/src/main/scala/com/gu/media/upload/model/UploadCredentials.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadCredentials.scala
@@ -1,6 +1,7 @@
 package com.gu.media.upload.model
 
 import ai.x.play.json.Jsonx
+import ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 
 case class UploadCredentials(temporaryAccessId: String, temporarySecretKey: String, sessionToken: String)

--- a/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
@@ -1,6 +1,7 @@
 package com.gu.media.upload.model
 
 import ai.x.play.json.Jsonx
+import ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 import com.gu.media.model.{PlutoSyncMetadataMessage, VideoAsset}
 

--- a/common/src/main/scala/com/gu/media/upload/model/UploadPart.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadPart.scala
@@ -1,6 +1,7 @@
 package com.gu.media.upload.model
 
 import ai.x.play.json.Jsonx
+import ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 
 case class UploadPart(key: String, start: Long, end: Long)

--- a/common/src/main/scala/com/gu/media/upload/model/UploadProgress.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadProgress.scala
@@ -1,6 +1,7 @@
 package com.gu.media.upload.model
 
 import ai.x.play.json.Jsonx
+import ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 
 case class UploadProgress(chunksInS3: Int, chunksInYouTube: Int, fullyUploaded: Boolean, fullyTranscoded: Boolean,

--- a/common/src/main/scala/com/gu/media/upload/model/UploadRequest.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadRequest.scala
@@ -1,6 +1,7 @@
 package com.gu.media.upload.model
 
 import ai.x.play.json.Jsonx
+import ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 
 case class UploadRequest(

--- a/common/src/main/scala/com/gu/media/upload/model/UploadStatus.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadStatus.scala
@@ -3,6 +3,7 @@ package com.gu.media.upload.model
 import com.gu.media.model.VideoAsset
 import ai.x.play.json.Jsonx
 import play.api.libs.json.Format
+import ai.x.play.json.Encoders._
 
 case class UploadStatus(id: String, status: String, asset: Option[VideoAsset], current: Option[Int], total: Option[Int], failed: Boolean)
 

--- a/common/src/main/scala/com/gu/media/youtube/MediaAtomYoutubeDescriptionHandler.scala
+++ b/common/src/main/scala/com/gu/media/youtube/MediaAtomYoutubeDescriptionHandler.scala
@@ -4,7 +4,7 @@ import com.gu.contentatom.thrift.atom.media.{MediaAtom => ThriftMediaAtom}
 import com.gu.media.model.MediaAtom
 import com.gu.media.util.MediaAtomImplicits
 import ai.x.play.json.Jsonx
-
+import ai.x.play.json.Encoders._
 
 object MediaAtomYoutubeDescriptionHandler extends MediaAtomImplicits {
 


### PR DESCRIPTION
This is the latest version of the "ai.x" %% "play-json-extensions" library:

* https://github.com/bizzabo/play-json-extensions
* https://index.scala-lang.org/bizzabo/play-json-extensions/artifacts/play-json-extensions?binary-versions=_2.13#

I originally assumed it was necessary to make this upgrade to get Scala 2.13 support to allow https://github.com/guardian/media-atom-maker/pull/1140 to proceed, but it did turn out that the library _already_ had Scala 2.13 support as of v0.40.2 - so this upgrade isn't essential, but probably still a good idea.

Although many files are changed, all that's required is an additional import!
