### PR TITLE
Pre-Play 2.9: Upgrade pan-domain-authentication (Panda) library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,7 @@ import scala.sys.process._
 val scroogeVersion = "4.12.0"
 val awsVersion = "1.11.678"
 val awsV2Version = "2.21.17"
-val pandaVersion = "1.3.0"
-val pandaHmacVersion = "2.1.0"
+val pandaVersion = "3.0.1"
 val atomMakerVersion = "1.3.4"
 val typesafeConfigVersion = "1.4.0" // to match what we get from Play transitively
 val scanamoVersion = "1.0.0-M28"
@@ -91,7 +90,7 @@ lazy val common = (project in file("common"))
       "com.gu" %% "pan-domain-auth-play_2-8" % pandaVersion,
       "com.gu" %% "pan-domain-auth-verification" % pandaVersion,
       "com.gu" %% "pan-domain-auth-core" % pandaVersion,
-      "com.gu" %% "panda-hmac-play_2-8" % pandaHmacVersion,
+      "com.gu" %% "panda-hmac-play_2-8" % pandaVersion,
       ws,
       "com.typesafe.play" %% "play-json-joda" % "2.7.4",
       "com.gu" %% "atom-publisher-lib" % atomMakerVersion,


### PR DESCRIPTION
This is in preparation for the Play 2.9 upgrade in https://github.com/guardian/media-atom-maker/pull/1140 - the current Panda artifacts used actually _do_ have Scala 2.13 versions at the current artifact version number:

- https://repo1.maven.org/maven2/com/gu/pan-domain-auth-play_2-8_2.13/1.2.0/
- https://repo1.maven.org/maven2/com/gu/panda-hmac-play_2-8_2.13/2.1.0/

...but they _don't_ have Play 2.9 versions, not at this artifact number - so for https://github.com/guardian/media-atom-maker/pull/1140, we will need to update the Panda artifact version number, and it makes sense to separate this change out to make https://github.com/guardian/media-atom-maker/pull/1140 smaller.

We have tried upgrading Panda in this project back in July 2023 with https://github.com/guardian/media-atom-maker/pull/1123, but as @andrew-nowak points out below, a mismatch in the Google client libraries meant the change needed to be rolled back - now that we have https://github.com/guardian/media-atom-maker/pull/1129 to give updated YouTube partner client libraries, and https://github.com/guardian/media-atom-maker/pull/1146 to check for compatibility in those libraries, we should be in a less risky state for this upgrade.

Note that the `panda-hmac-play` artifacts have been moved out of the archived [guardian/panda-hmac repo](https://github.com/guardian/panda-hmac) repo, with the last version there being v2.2.0 released in June 2023. They are now in the main [guardian/pan-domain-authentication](https://github.com/guardian/pan-domain-authentication) repo, and releases are now done with the other panda artifacts - so version numbers of all the panda artifacts, including panda-hmac, are now aligned.

## Testing

[Deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/e7bf37cc-b10a-4408-8713-f802a70c8e0f) at https://video.code.dev-gutools.co.uk/videos, if I delete Panda's [`gutoolsAuth-assym`](https://github.com/guardian/pan-domain-authentication/blob/2e25b662a5eb8f4fcd72734d63d6a9b95995075c/README.md?plain=1#L297) cookie and refresh the page, you can see that the Panda cookie is regenerated.


https://github.com/guardian/media-atom-maker/assets/52038/564a75e5-231b-4f24-9072-8ecdbdb8f9f0

However, as pointed out by @andrew-nowak below, if we look at [an individual atom page](https://video.code.dev-gutools.co.uk/api/uploads?atomId=e6a260d4-d4dd-4c4f-b386-2e375fc68dd1) we get 'Could not get video usages' & `Could not get uploads` errors in the UI:

![image](https://github.com/guardian/media-atom-maker/assets/52038/104e7274-b13b-4391-8905-c7c1592c6b30)



