### PR TITLE
Add unit test for `YouTube` client initialisation

### DIFF
--- a/test/YouTubeSDKCompatibilityCheckSpec.scala
+++ b/test/YouTubeSDKCompatibilityCheckSpec.scala
@@ -1,0 +1,24 @@
+import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential
+import com.google.api.client.http.javanet.NetHttpTransport
+import com.google.api.client.http.{HttpRequestInitializer, HttpTransport}
+import com.google.api.client.json.JsonFactory
+import com.google.api.client.json.gson.GsonFactory
+import org.scalatest.FunSpec
+
+class YouTubeSDKCompatibilityCheckSpec extends FunSpec {
+
+  val transport: HttpTransport = new NetHttpTransport()
+  val jsonFactory: JsonFactory = GsonFactory.getDefaultInstance
+  val httpRequestInitializer: HttpRequestInitializer = new MockGoogleCredential.Builder().build()
+
+  describe("The YouTube SDK checks for a matching version of the google-api-client library") {
+    it("should NOT throw an exception creating a com.google.api.services.youtube.YouTube client") {
+      new com.google.api.services.youtube.YouTube(transport, jsonFactory, httpRequestInitializer)
+    }
+
+    it("should NOT throw an exception creating a com.google.api.services.youtubePartner.YouTubePartner client") {
+      new com.google.api.services.youtubePartner.YouTubePartner(transport, jsonFactory, httpRequestInitializer)
+    }
+  }
+}
+


### PR DESCRIPTION
In the past, we've had runtime failures when we've updated dependencies (like Panda in PR https://github.com/guardian/media-atom-maker/pull/1123) that update the version of google-api-client library used, without also updating the YouTube client SDK to match (note, for the reasons below, it can be hard to get updated compatible versions of the YouTube client).

The YouTube client specifically checks whether it is using an expected version of the google-api-client library, and will throw an exception like this if its requirements aren't met:

```
java.lang.IllegalStateException: You are currently running with version 2.1.2 of google-api-client. You need at least version 1.15 of google-api-client to run version 1.22.0 of the YouTube Data API library.
```

This change adds a unit test that just exercises the constructor of both the `YouTube` & `YouTubePartner` clients, and which will fail in the same way the client did at runtime - but, better for our purposes, it will fail the unit test, not the running app server!

An example of the test failing, and thus notifying of us a problem as we need, is [here](https://github.com/guardian/media-atom-maker/actions/runs/7828479116/job/21358445038#step:8:3721), against PR #1145.

## Getting updated compatible versions of the YouTube clients

Media Atom Maker uses the semi-private YouTube content partner API. From an SDK point of view, this involves two particular clients, which we started using as of https://github.com/guardian/media-atom-maker/pull/399 in April 2017:

* `com.google.api.services.youtube.YouTube` - a _modified_ version of the standard client, with additional fields (like `onBehalfOfContentOwner`) that are visible in Google's APIs Discovery Service, but _not_ typically included in the standard [`google-api-services-youtube`](https://central.sonatype.com/artifact/com.google.apis/google-api-services-youtube/versions) client SDK published to Maven Central.
* `com.google.api.services.youtubePartner.YouTubePartner` - an _additional_ client, that hits a different API endpoint and has different actions entirely from the standard `YouTube` client (claims, etc).

In the past, Google _would_ share special jars for both clients, which were hosted on their docs pages at:

https://developers.google.com/youtube/partner/client_libraries

However, that page now links off to just the standard versions of the Google API Client Library for Java - with the unmodified `YouTube` client, and no `YouTubePartner` at all.

Consequently, @andrew-nowak has produced https://github.com/guardian/media-atom-maker/pull/1129, which scripts the production of the custom Content Partner API clients.

See also:

* https://github.com/guardian/media-atom-maker/pull/1145#issuecomment-1931940022
* https://github.com/guardian/media-atom-maker/pull/1124