### PR TITLE
Finally remove superfluous `sbt-coursier` plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,3 @@
-// This early version of coursier needs to be removed, but right now doing so exposes dependency conflicts...
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC12")
-
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
 


### PR DESCRIPTION
sbt v1.3 and above ship with coursier support out-of-the-box (https://get-coursier.io/docs/sbt-coursier), so we don't want to additionally specify an older version.

![image](https://github.com/guardian/media-atom-maker/assets/52038/196b91a1-1fe3-4911-a40b-cca54c5762b6)

IntelliJ IDEA, in particular, found the extra plugin unhelpful, and couldn't extract the project with it present.

However, until very recently, removing the old `sbt-coursier` plugin exposed existing version conflicts in library dependencies (see https://github.com/guardian/media-atom-maker/pull/1088):

* https://github.com/guardian/media-atom-maker/actions/runs/7729320064/job/21072198692
* https://gist.github.com/rtyley/2802ea4235f5f9018aac4f273dc10975

Thankfully, it looks like we've done enough upgrades now that that's no longer a problem, and we can finally remove superfluous `sbt-coursier` plugin.
