### PR TITLE
Upgrade to Java 11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
           aws-region: eu-west-1
       - uses: actions/setup-java@v3
         with:
-          java-version: "8"
+          java-version: "11"
           distribution: "corretto"
       - uses: actions/setup-node@v3
         with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11.0.22.7.1

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
-import StateMachine._
+import StateMachine.*
 import sbtbuildinfo.BuildInfoPlugin.autoImport.{BuildInfoKey, buildInfoKeys}
-import scala.sys.process._
+
+import scala.collection.immutable.Seq
+import scala.sys.process.*
 
 val scroogeVersion = "4.12.0"
 val awsVersion = "1.11.678"
@@ -44,7 +46,7 @@ lazy val jacksonDatabindVersion = "2.13.4.2"
 
 lazy val commonSettings = Seq(
   ThisBuild / scalaVersion := "2.13.11", // 2.13.12 blocked by https://github.com/scala/bug/issues/12862
-  scalacOptions ++= Seq("-feature", "-deprecation"/*, "-Xfatal-warnings"*/),
+  scalacOptions ++= Seq("-feature", "-deprecation", "-release:11"),
   ThisBuild / organization := "com.gu",
 
   resolvers ++= Resolver.sonatypeOssRepos("releases"),
@@ -155,7 +157,6 @@ lazy val app = (project in file("."))
 
     buildInfoPackage := "app",
 
-    debianPackageDependencies := Seq("openjdk-8-jre-headless"),
     maintainer := "Digital CMS <digitalcms.dev@guardian.co.uk>",
     packageSummary := "media-atom-maker",
     packageDescription := """making media atoms""",

--- a/cloudformation/media-atom-maker-dev.yml
+++ b/cloudformation/media-atom-maker-dev.yml
@@ -319,7 +319,7 @@ Resources:
           CONFIG_KEY: !FindInMap [LambdaConfig, Expirer, DEV]
       MemorySize: 256
       Role: !GetAtt ExpirerRole.Arn
-      Runtime: "java8"
+      Runtime: "java11"
       Timeout: 300
 
   SchedulerLambda:
@@ -340,7 +340,7 @@ Resources:
           CONFIG_KEY: !FindInMap [LambdaConfig, Scheduler, DEV]
       MemorySize: 256
       Role: !GetAtt SchedulerRole.Arn
-      Runtime: "java8"
+      Runtime: "java11"
       Timeout: 300
   ExpirerLambdaTrigger:
     Type: "AWS::Events::Rule"

--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -12,7 +12,7 @@ deployments:
       app: media-atom-maker
       parameters:
         amiTags:
-          Recipe: editorial-tools-focal-java8-ARM-WITH-cdk-base
+          Recipe: editorial-tools-focal-java11-ARM-WITH-cdk-base
           AmigoStage: PROD
   media-atom-maker:
     type: autoscaling

--- a/uploader/src/main/resources/lambda-template.yaml
+++ b/uploader/src/main/resources/lambda-template.yaml
@@ -26,5 +26,5 @@
         PLUTO_TABLE_NAME: !Ref 'ManualPlutoTable'
     MemorySize: 512
     Role: !GetAtt LambdaExecutionRole.Arn
-    Runtime: "java8"
+    Runtime: "java11"
     Timeout: {{timeout}}


### PR DESCRIPTION
This is a pre-requisite for the upcoming Play 2.9 upgrade in PR https://github.com/guardian/media-atom-maker/pull/1140 - [Play 2.9 requires Java 11, 17, or 21](https://www.playframework.com/documentation/2.9.x/Requirements#Play-Requirements) (and actually recommends Java 17).

Upgrading from Java 8 to Java 11 has also been a [DevX recommendation](https://docs.google.com/document/d/1ZR-YnaXCT5_gLVmTCeGs0mWd3KPaAozPjQK8uUzHZ9w/edit?usp=sharing) since 2022!

See also:

* https://github.com/guardian/atom-workshop/pull/349/files#r1457319862
* https://github.com/guardian/atom-workshop/pull/349/files#r1463164617
