### PR TITLE
Fix Snyk after Play upgrade, by running Snyk with Java 11

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -14,6 +14,6 @@ jobs:
       DEBUG: true
       ORG: guardian
       SKIP_NODE: false
-      JAVA_VERSION: 8
+      JAVA_VERSION: 11
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
I missed this in PR https://github.com/guardian/media-atom-maker/pull/1149, which upgraded media-atom-maker to use Java 11 - I didn't see that Snyk was still configured to run under Java 8!

When Snyk encountered the new Play 2.9 classes introduced by PR https://github.com/guardian/media-atom-maker/pull/1140, which have been compiled for Java 11 (class file version 55.0), it threw a `UnsupportedClassVersionError`, and the sbt process was blocked, waiting for user input, hanging indefinitely (eventually I manually cancelled [the GitHub job](https://github.com/guardian/media-atom-maker/actions/runs/7899976195/job/21560525180#step:13:214)):

```
Error: -14T10:42:47.661Z snyk-sbt-plugin [error] java.lang.UnsupportedClassVersionError: play/api/PlayException$ExceptionSource has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
Error: -14T10:42:47.661Z snyk-sbt-plugin [error] Use 'last' for the full log.
2024-02-14T10:42:47.665Z snyk-sbt-plugin [warn] Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? (default: r)
Error: The operation was canceled.
```

### Snyk only runs on `main` branch

Note that, as configured, Snyk only runs on the `main` branch, or on workflow dispatch, so we didn't pick up this issue while we were at the PR stage:

https://github.com/guardian/media-atom-maker/blob/d4eafb9f25fdaeee06399b94036a3e606973ef05/.github/workflows/snyk.yml#L4-L9

### Testing this PR

I ran Snyk on this branch using workflow dispatch, and confirmed that [it successfully ran](https://github.com/guardian/media-atom-maker/actions/runs/7900189432):

![image](https://github.com/guardian/media-atom-maker/assets/52038/f6d76408-d5f8-4fd5-971f-d43cdfbcef1f)

https://app.snyk.io/org/guardian/project/cfe2cbc1-80b2-4719-8c62-b6f2408f2a15/history/ab510021-c5db-4514-bb5f-55f8a3866fe2

![image](https://github.com/guardian/media-atom-maker/assets/52038/ebba70a1-b914-4193-96ce-82226375f3e3)

