### PR TITLE
Add some user experience improvements to the uploads page

### DIFF
--- a/public/video-ui/src/components/DeleteButton.js
+++ b/public/video-ui/src/components/DeleteButton.js
@@ -6,7 +6,8 @@ import Icon from './Icon';
 export default class DeleteButton extends React.Component {
   static propTypes = {
     tooltip: PropTypes.string.isRequired,
-    onDelete: PropTypes.func.isRequired
+    onDelete: PropTypes.func.isRequired,
+    disabled: PropTypes.bool
   };
 
   state = {
@@ -27,6 +28,7 @@ export default class DeleteButton extends React.Component {
         className="btn button__secondary--remove-confirm"
         onClick={this.props.onDelete}
         data-tip="Confirm delete. This cannot be undone."
+        disabled={this.props.disabled}
       >
         <Icon icon="delete_forever">Confirm delete</Icon>
       </button>
@@ -38,7 +40,8 @@ export default class DeleteButton extends React.Component {
       <button
         className="btn button__secondary--remove"
         onClick={() => this.changeState()}
-        data-tip={this.props.tooltip}
+        data-tip={ this.props.tooltip}
+        disabled={this.props.disabled}
       >
         <Icon icon="delete">Delete</Icon>
       </button>

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.js
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.js
@@ -92,7 +92,7 @@ function AssetDisplay({ id, isActive, sources }) {
 
   return (
     <div className="upload">
-      {id ? <YouTubeEmbed id={id} /> : <VideoEmbed sources={sources} />}
+      {id ? <YouTubeEmbed id={id} largePreview={true}/> : <VideoEmbed sources={sources} />}
       {linkProps
         ? <a {...linkProps}>
             <Icon icon="open_in_new" className="icon__assets" />

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.js
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.js
@@ -21,17 +21,24 @@ function presenceInitials(email) {
   return initials.join('');
 }
 
-function AssetControls({ user, children, isActive, selectAsset, deleteAsset }) {
+function AssetControls({ user, children, isActive, selectAsset, deleteAsset, processing }) {
   const activateButton = !isActive
-    ? <button className="btn upload__activate-btn" onClick={selectAsset}>
+
+    ? <button
+        className="btn upload__activate-btn"
+        onClick={selectAsset}
+        disabled={!!processing}
+        data-tip={processing ? "Cannot activate video during processing" : null}
+      >
         Activate
       </button>
     : false;
 
   const deleteButton = !isActive
     ? <DeleteButton
-        tooltip="Remove asset from Atom (does not affect YouTube.com)"
+        tooltip={processing ? "Cannot delete video during processing" : "Remove asset from Atom (does not affect YouTube.com)"}
         onDelete={deleteAsset}
+        disabled={!!processing}
       />
     : false;
 
@@ -93,6 +100,7 @@ function AssetDisplay({ id, isActive, sources }) {
         : false}
       {isActive
         ? <div className="grid__status__overlay">
+
             <span className="publish__label label__live label__frontpage__overlay">
               Active
             </span>
@@ -121,7 +129,6 @@ function AssetProgress({ failed, current, total }) {
 export function Asset({ upload, isActive, selectAsset, deleteAsset }) {
   const { asset, metadata, processing } = upload;
   const user = metadata ? metadata.user : false;
-
   if (processing) {
     return (
       <div className="grid__item">
@@ -129,7 +136,7 @@ export function Asset({ upload, isActive, selectAsset, deleteAsset }) {
           <AssetProgress {...processing} />
         </div>
         <div className="grid__item__footer">
-          <AssetControls user={user} selectAsset={selectAsset} deleteAsset={deleteAsset}>
+          <AssetControls user={user} selectAsset={selectAsset} deleteAsset={deleteAsset} processing={processing}>
             <AssetInfo info={processing.status} />
           </AssetControls>
         </div>

--- a/public/video-ui/src/components/VideoUpload/YoutubeUpload.js
+++ b/public/video-ui/src/components/VideoUpload/YoutubeUpload.js
@@ -31,7 +31,7 @@ export default class YoutubeUpload extends React.Component {
           <div className="form__row">
             <input
               className="form__field__file"
-              type="file"m
+              type="file"
               onChange={this.setFile}
               disabled={!canUploadToYouTube || this.props.uploading}
               accept="video/*,.mxf"

--- a/public/video-ui/src/components/VideoUpload/YoutubeUpload.js
+++ b/public/video-ui/src/components/VideoUpload/YoutubeUpload.js
@@ -17,21 +17,13 @@ export default class YoutubeUpload extends React.Component {
     }
   };
 
-  renderWarning() {
-    return (
-      <p className="form__message form__message--warning">
-        A YouTube channel, category and privacy status are needed before uploading a video
-      </p>
-    );
-  }
-
   render() {
     const { video, startUpload } = this.props;
 
     const canUploadToYouTube = VideoUtils.canUploadToYouTube(video);
 
     return (
-      <div className="video__detailbox video__detailbox__assets">   
+      <div className="video__detailbox video__detailbox__assets">
         <div className="form__group">
           <header className="video__detailbox__header video__detailbox__header-with-border">
             Upload to YouTube
@@ -39,11 +31,16 @@ export default class YoutubeUpload extends React.Component {
           <div className="form__row">
             <input
               className="form__field__file"
-              type="file"
+              type="file"m
               onChange={this.setFile}
               disabled={!canUploadToYouTube || this.props.uploading}
               accept="video/*,.mxf"
             />
+            { !canUploadToYouTube ?
+              <p className="form__message form__message--warning">
+              A YouTube channel, category and privacy status are needed before uploading a video. Please set these in the YouTube furniture tab.
+              </p> : null
+            }
             <button
               type="button"
               className="btn button__secondary__assets"

--- a/public/video-ui/src/components/utils/YouTubeEmbed.js
+++ b/public/video-ui/src/components/utils/YouTubeEmbed.js
@@ -6,7 +6,7 @@ export const getYouTubeEmbedUrl = (id) => {
   const embedUrl = getStore().getState().config.youtubeEmbedUrl;
   return `${embedUrl}${id}?showinfo=0&rel=0`;
 }
-export function YouTubeEmbed({ id, className }) {
+export function YouTubeEmbed({ id, className, largePreview }) {
   return (
     <iframe
       type="text/html"
@@ -14,6 +14,8 @@ export function YouTubeEmbed({ id, className }) {
       src={getYouTubeEmbedUrl(id)}
       allowFullScreen
       frameBorder="0"
+      height={largePreview ? "250px" : undefined}
+      width={largePreview ? "400px" : undefined}
     />
   );
 }

--- a/public/video-ui/styles/abstracts/_mixins.scss
+++ b/public/video-ui/styles/abstracts/_mixins.scss
@@ -12,7 +12,7 @@
   }
 
   &:disabled {
-    cursor: default;
+    cursor: not-allowed;
     opacity: 0.5;
   }
 

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -102,6 +102,16 @@
         cursor: pointer;
       }
     }
+
+    &:disabled {
+      &::file-selector-button {
+        background-color: #888888;
+        &:hover {
+          background-color: #888888;
+          cursor: not-allowed;
+        }
+      }
+    }
   }
 
   // Placeholder styling, separated because if one selector is invalid, the browser will ignore the rest

--- a/public/video-ui/styles/components/_presence.scss
+++ b/public/video-ui/styles/components/_presence.scss
@@ -16,6 +16,7 @@
     border-radius: 50%;
     color: $color600Grey;
     background-color: $cWhite;
+    height: 32px;
 
     &:not(:last-child) {
       margin-right: 7px;

--- a/public/video-ui/styles/layout/_grid.scss
+++ b/public/video-ui/styles/layout/_grid.scss
@@ -75,7 +75,7 @@
   left: 0;
   width: 100%;
   background-color: $color700Grey;
-  height: 60px;
+  min-height: 60px;
 }
 
 .grid__item__title {

--- a/public/video-ui/styles/layout/_upload.scss
+++ b/public/video-ui/styles/layout/_upload.scss
@@ -23,7 +23,7 @@
   &__info {
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: normal;
     color: white;
   }
 

--- a/public/video-ui/styles/layout/_upload.scss
+++ b/public/video-ui/styles/layout/_upload.scss
@@ -18,6 +18,7 @@
 
   &__right {
     display: flex;
+    height: 38px;
   }
 
   &__info {

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -110,6 +110,11 @@
 
     .grid__item {
       width: 400px;
+      height: 300px;
+
+      .upload {
+        height: 250px;
+      }
     }
   }
 }

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -110,6 +110,10 @@
 
     .grid__item {
       width: 400px;
+
+      .presence-list {
+        display: none;
+      }
     }
   }
 }

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -107,6 +107,10 @@
     margin-top: 20px;
     padding-left: 20px;
     flex: 8;
+
+    .grid__item {
+      width: 400px;
+    }
   }
 }
 

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -110,10 +110,6 @@
 
     .grid__item {
       width: 400px;
-
-      .presence-list {
-        display: none;
-      }
     }
   }
 }


### PR DESCRIPTION
This PR fixes some bits of awkward functionality on the uploads page, specifically:

- The video previews on the uploads are bigger, accommodate more text by default and the description bar expands to accommodate longer text. Before, they took up an oddly small amount of screen space and consequently the information about the progress through the upload process was usually unreadable.

| Before | After |
| --- | --- |
| ![image](https://github.com/guardian/media-atom-maker/assets/34686302/a1fb4905-acc1-40e5-9958-82851dabd2df) | ![image](https://github.com/guardian/media-atom-maker/assets/34686302/6699bd51-d92e-4158-86af-73a5a0f40309) |

- Disables the 'Activate' and 'Delete' buttons until the video processing is done. Clicking on these before the video is processed wasn't functional and gave a misleading error ('Could not revert asset'). I've added a tooltip explaining why they're disabled on hover.

| Before | After |
| --- | --- |
| ![image](https://github.com/guardian/media-atom-maker/assets/34686302/9b403c72-b567-4d59-ab8e-8a7604c07752) | ![image](https://github.com/guardian/media-atom-maker/assets/34686302/0ab9322a-f952-4286-9b5e-0f9a1d32af7a) |

- Adds a message explaining why the 'Upload to Youtube' 'Choose file' button is disabled when it is - previously it wasn't clear (though there was a suitable error message in the code that wasn't ever rendered). Also removes the hover styling when it's disabled.


| Before | After |
| --- | --- |
| ![image](https://github.com/guardian/media-atom-maker/assets/34686302/3ddeb6cd-9de7-43f1-b14a-c8b69f41dc4c) | ![image](https://github.com/guardian/media-atom-maker/assets/34686302/17d676b7-d76a-49f5-9159-a1fd86cee798) |

- Adds a 'not-allowed' cursor for disabled buttons.

## How to test

This PR will be simpler to test on CODE because getting the end-to-end YouTube upload working locally will be complicated.
1. Deploy this branch to CODE.
2. Fill out the 'YouTube Furniture' **without setting the Privacy status**. This will let you check the validation is showing properly in the 'Edit Assets' page.
3. Click the pencil icon in the top right, which shows a tolltip saying 'Edit Assets' on hover.
4. Is there an explanation of why you can't upload a video? On hover, does the 'choose file' button under 'Upload to YouTube' remain the same colour?
5. Go back to the YouTube furniture tab and add a privacy status, e.g. unlisted.
6. Try uploading a .mp4 video. Are the Activate and Delete buttons disabled with a tooltip until the processing is done? Can you read the various messages shown while the processing takes place?