### PR TITLE
log when user has no MAM permission or when they have something but not the new `media_atom_maker_access` permission 

### DIFF
--- a/app/controllers/PanDomainAuthActions.scala
+++ b/app/controllers/PanDomainAuthActions.scala
@@ -1,19 +1,39 @@
 package controllers
 
+import com.gu.media.{MediaAtomMakerPermissionsProvider, Permissions}
+import com.gu.media.logging.Logging
 import com.gu.pandahmac.HMACAuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
 import play.api.Configuration
 
-trait PanDomainAuthActions extends HMACAuthActions {
+trait PanDomainAuthActions extends HMACAuthActions with Logging {
 
   def conf: Configuration
 
   override def validateUser(authedUser: AuthenticatedUser): Boolean = {
-    (authedUser.user.emailDomain == "guardian.co.uk") &&
-    (authedUser.multiFactor)
+    val isValid =
+      (authedUser.user.emailDomain == "guardian.co.uk") &&
+      (authedUser.multiFactor)
+
+    val hasBasicAccessExplicitly = permissionsProvider.hasPermission(Permissions.basicAccess, authedUser.user)
+    val hasAnyAtomMakerPermission = permissionsProvider.hasAnyAtomMakerPermission(authedUser.user)
+
+    if(!isValid) {
+      log.warn(s"User ${authedUser.user.email} is not valid")
+    }
+    else if (!hasAnyAtomMakerPermission) {
+      log.warn(s"User ${authedUser.user.email} does not have any MAM permissions")
+    }
+    else if (!hasBasicAccessExplicitly) {
+      log.warn(s"User ${authedUser.user.email} does not have media_atom_maker_access permission but does have other MAM permissions")
+    }
+
+    isValid
   }
 
   override def authCallbackUrl: String = "https://" + conf.get[String]("host") + "/oauthCallback"
 
   override def secret: String = conf.get[String]("secret")
+
+  def permissionsProvider: MediaAtomMakerPermissionsProvider
 }

--- a/app/di.scala
+++ b/app/di.scala
@@ -58,6 +58,10 @@ class MediaAtomMaker(context: Context)
     s3Client = S3Access.buildClient(pandaAwsCredentialsProvider, "eu-west-1")
   )
 
+  private val aws = new AWSConfig(config, credentials)
+
+  private val permissions = new MediaAtomMakerPermissionsProvider(aws.stage, aws.region.getName, aws.credentials.instance.awsV1Creds)
+
   private val hmacAuthActions = new PanDomainAuthActions {
     override def conf: Configuration = MediaAtomMaker.this.configuration
 
@@ -66,14 +70,13 @@ class MediaAtomMaker(context: Context)
     override def controllerComponents: ControllerComponents = MediaAtomMaker.this.controllerComponents
 
     override def panDomainSettings: PanDomainAuthSettingsRefresher = MediaAtomMaker.this.panDomainSettings
-  }
 
-  private val aws = new AWSConfig(config, credentials)
+    override val permissionsProvider = permissions
+  }
 
   private val capi = new Capi(config)
 
   private val stores = new DataStores(aws, capi)
-  private val permissions = new MediaAtomMakerPermissionsProvider(aws.stage, aws.region.getName, aws.credentials.instance.awsV1Creds)
 
   private val reindexer = buildReindexer()
 

--- a/common/src/main/scala/com/gu/media/Permissions.scala
+++ b/common/src/main/scala/com/gu/media/Permissions.scala
@@ -19,6 +19,7 @@ object Permissions {
   implicit val format: Format[Permissions] = Jsonx.formatCaseClass[Permissions]
 
   val app = "atom-maker"
+  val basicAccess = PermissionDefinition("media_atom_maker_access", app)
   val deleteAtom = PermissionDefinition("delete_atom", app)
   val addSelfHostedAsset = PermissionDefinition("add_self_hosted_asset", app)
   val setVideosOnAllChannelsPublic = PermissionDefinition("set_videos_on_all_channels_public", app)
@@ -45,5 +46,11 @@ class MediaAtomMakerPermissionsProvider(stage: String, region: String, credsProv
     // HACK: HMAC authenticated users are a `PandaUser` without an email
     case "" if user.firstName == "media-atom-scheduler-lambda" => true
     case _ => permissions.hasPermission(permission, user.email)
+  }
+
+  def hasAnyAtomMakerPermission(user: PandaUser): Boolean = {
+    permissions.listPermissions(user.email).exists {
+      case (PermissionDefinition(_, app), isActive) => app == Permissions.app && isActive
+    }
   }
 }


### PR DESCRIPTION
In https://github.com/guardian/permissions/pull/188 we add the new `media_atom_maker_access` permission and in this PR we log when user has no MAM permission or when they have something but not the new `media_atom_maker_access` permission - later we'll decide whether to require `media_atom_maker_access` as well as other permissions or to allow access based on any permission with `app` = `AtomMaker`  - we'll decide based on how many users access with what permissions (if any) - i.e. how much work it is for CP.

✅  tested on `CODE`
![image](https://github.com/guardian/media-atom-maker/assets/19289579/91cd714d-db4d-4fc6-9c2f-b412ebfd4202)
![image](https://github.com/guardian/media-atom-maker/assets/19289579/9cab9454-5c6a-4cbb-8f96-615f11e060d2)
