### PR TITLE
Bump dependencies to resolve vulnerabilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ val scalaCheckVersion = "1.14.0" // to match ScalaTest version
 val awsLambdaCoreVersion = "1.1.0"
 val awsLambdaEventsVersion = "1.3.0"
 
-val logbackClassicVersion = "1.2.3"
+val logbackClassicVersion = "1.2.13"
 val logstashLogbackEncoderVersion = "4.8"
 
 val guavaVersion = "31.1-jre"

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import scala.collection.immutable.Seq
 import scala.sys.process.*
 
 val scroogeVersion = "4.12.0"
-val awsVersion = "1.11.678"
+val awsVersion = "1.11.1034"
 val awsV2Version = "2.21.17"
 val pandaVersion = "3.1.0"
 val atomMakerVersion = "2.0.0"

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import scala.sys.process.*
 val scroogeVersion = "4.12.0"
 val awsVersion = "1.11.678"
 val awsV2Version = "2.21.17"
-val pandaVersion = "3.0.1"
+val pandaVersion = "3.1.0"
 val atomMakerVersion = "2.0.0"
 val typesafeConfigVersion = "1.4.0" // to match what we get from Play transitively
 val scanamoVersion = "1.0.0-M28"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@dnd-kit/utilities": "^3.2.1",
     "aws-sdk": "^2.1309.0",
     "fast-check": "^3.6.3",
-    "fork-ts-checker-webpack-plugin": "^8.0.0",
+    "fork-ts-checker-webpack-plugin": "9.0.2",
     "moment": "^2.29.4",
     "panda-session": "^0.1.6",
     "prop-types": "^15.8.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@dnd-kit/utilities": "^3.2.1",
     "aws-sdk": "^2.1309.0",
     "fast-check": "^3.6.3",
-    "fork-ts-checker-webpack-plugin": "^7.3.0",
+    "fork-ts-checker-webpack-plugin": "^8.0.0",
     "moment": "^2.29.4",
     "panda-session": "^0.1.6",
     "prop-types": "^15.8.1",
@@ -93,7 +93,7 @@
     "redux": "^4.2.1",
     "redux-thunk": "^2.4.2",
     "reqwest": "^2.0.5",
-    "ts-loader": "9.4.2",
+    "ts-loader": "9.5.1",
     "typescript": "^4.7.4",
     "valid-url": "^1.0.9"
   },

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4021,10 +4021,10 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
 
-fork-ts-checker-webpack-plugin@^7.3.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-7.3.0.tgz#a9c984a018493962360d7c7e77a67b44a2d5f3aa"
-  integrity sha512-IN+XTzusCjR5VgntYFgxbxVx3WraPRnKehBFrf00cMSrtUuW9MsG9dhL6MWpY6MkjC3wVwoujfCDgZZCQwbswA==
+fork-ts-checker-webpack-plugin@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-8.0.0.tgz#dae45dfe7298aa5d553e2580096ced79b6179504"
+  integrity sha512-mX3qW3idpueT2klaQXBzrIM/pHw+T0B/V9KHEvNrqijTq9NFnMZU6oreVxDYcf33P8a5cW+67PjodNHthGnNVg==
   dependencies:
     "@babel/code-frame" "^7.16.7"
     chalk "^4.1.2"
@@ -7938,6 +7938,11 @@ source-map@^0.6.0, source-map@^0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+source-map@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
+  integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
+
 sourcemapped-stacktrace@^1.1.6:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.11.tgz#e2dede7fc148599c52a4f883276e527f8452657d"
@@ -8418,15 +8423,16 @@ ts-jest@^28.0.5:
     semver "7.x"
     yargs-parser "^21.0.1"
 
-ts-loader@9.4.2:
-  version "9.4.2"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.4.2.tgz#80a45eee92dd5170b900b3d00abcfa14949aeb78"
-  integrity sha512-OmlC4WVmFv5I0PpaxYb+qGeGOdm5giHU7HwDDUjw59emP2UYMHy9fFSDcYgSNoH8sXcj4hGCSEhlDZ9ULeDraA==
+ts-loader@9.5.1:
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.5.1.tgz#63d5912a86312f1fbe32cef0859fb8b2193d9b89"
+  integrity sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==
   dependencies:
     chalk "^4.1.0"
     enhanced-resolve "^5.0.0"
     micromatch "^4.0.0"
     semver "^7.3.4"
+    source-map "^0.7.4"
 
 tslib@^1.8.1:
   version "1.14.1"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This bumps some dependencies in order to reduce the number of high priority vulnerabilities reported by Snyk.

It reduces the number of Scala vulnerabilities from 6 to 2. Of the remaining two:
1. One is present in the latest release of Play, so we can't solve it for now.
2. One is present in the latest version of [panda](https://github.com/guardian/pan-domain-authentication) so we'll need to sort it there first. More details are available in Snyk.

The JS changes don't solve the vulnerabilities, but they do bring ts-loader to its latest version (where the vuln is still present).

## How to test

Deploy to CODE and see if everything appears to be working normally. 