### PR TITLE
Add some user experience improvements to the uploads page (again)

### DIFF
--- a/public/video-ui/src/components/DeleteButton.js
+++ b/public/video-ui/src/components/DeleteButton.js
@@ -6,8 +6,7 @@ import Icon from './Icon';
 export default class DeleteButton extends React.Component {
   static propTypes = {
     tooltip: PropTypes.string.isRequired,
-    onDelete: PropTypes.func.isRequired,
-    disabled: PropTypes.bool
+    onDelete: PropTypes.func.isRequired
   };
 
   state = {
@@ -28,7 +27,6 @@ export default class DeleteButton extends React.Component {
         className="btn button__secondary--remove-confirm"
         onClick={this.props.onDelete}
         data-tip="Confirm delete. This cannot be undone."
-        disabled={this.props.disabled}
       >
         <Icon icon="delete_forever">Confirm delete</Icon>
       </button>
@@ -40,8 +38,7 @@ export default class DeleteButton extends React.Component {
       <button
         className="btn button__secondary--remove"
         onClick={() => this.changeState()}
-        data-tip={ this.props.tooltip}
-        disabled={this.props.disabled}
+        data-tip={this.props.tooltip}
       >
         <Icon icon="delete">Delete</Icon>
       </button>

--- a/public/video-ui/src/components/VideoUpload/AddAssetFromURL.js
+++ b/public/video-ui/src/components/VideoUpload/AddAssetFromURL.js
@@ -25,6 +25,12 @@ export default class AddAssetFromURL extends React.Component {
           <header className="video__detailbox__header video__detailbox__header-with-border">Asset URL</header>
           <div className="form__row">
             <div>
+              <p className="form__message form__message--warning">
+                This should only be used as a backup if the &apos;Upload to YouTube&apos; option is not available.
+              </p>
+              <p className="form__message form__message--warning">
+                Using an Asset URL from an existing YouTube video will not pass video data to our video commissioning and syndication tool, Pluto.
+              </p>
               <input
                 className="form__field"
                 type="text"

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.js
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.js
@@ -21,24 +21,17 @@ function presenceInitials(email) {
   return initials.join('');
 }
 
-function AssetControls({ user, children, isActive, selectAsset, deleteAsset, processing }) {
+function AssetControls({ user, children, isActive, selectAsset, deleteAsset }) {
   const activateButton = !isActive
-
-    ? <button
-        className="btn upload__activate-btn"
-        onClick={selectAsset}
-        disabled={!!processing}
-        data-tip={processing ? "Cannot activate video during processing" : null}
-      >
+    ? <button className="btn upload__activate-btn" onClick={selectAsset}>
         Activate
       </button>
     : false;
 
   const deleteButton = !isActive
     ? <DeleteButton
-        tooltip={processing ? "Cannot delete video during processing" : "Remove asset from Atom (does not affect YouTube.com)"}
+        tooltip="Remove asset from Atom (does not affect YouTube.com)"
         onDelete={deleteAsset}
-        disabled={!!processing}
       />
     : false;
 
@@ -100,7 +93,6 @@ function AssetDisplay({ id, isActive, sources }) {
         : false}
       {isActive
         ? <div className="grid__status__overlay">
-
             <span className="publish__label label__live label__frontpage__overlay">
               Active
             </span>
@@ -136,7 +128,7 @@ export function Asset({ upload, isActive, selectAsset, deleteAsset }) {
           <AssetProgress {...processing} />
         </div>
         <div className="grid__item__footer">
-          <AssetControls user={user} selectAsset={selectAsset} deleteAsset={deleteAsset} processing={processing}>
+          <AssetControls user={user} selectAsset={selectAsset} deleteAsset={deleteAsset}>
             <AssetInfo info={processing.status} />
           </AssetControls>
         </div>


### PR DESCRIPTION
Re-run of https://github.com/guardian/media-atom-maker/pull/1155 - without disabling the buttons. That PR [was reverted](https://github.com/guardian/media-atom-maker/pull/1158) because it inadvertently stopped users being able to activate YouTube live feeds, which media-atom-maker apparently supports.

The logic around this is not clear so I'm just going to introduce the more simple UI tweaks without touching this area. My guess is that YouTube live feeds never come out of the `processing` phase.

This PR fixes some bits of awkward functionality on the uploads page, specifically:

- The video previews on the uploads are bigger, accommodate more text by default and the description bar expands to accommodate longer text. Before, they took up an oddly small amount of screen space and consequently the information about the progress through the upload process was usually unreadable.

| Before | After |
| --- | --- |
| ![image](https://github.com/guardian/media-atom-maker/assets/34686302/a1fb4905-acc1-40e5-9958-82851dabd2df) | ![image](https://github.com/guardian/media-atom-maker/assets/34686302/6699bd51-d92e-4158-86af-73a5a0f40309) |

- Adds a message explaining why the 'Upload to Youtube' 'Choose file' button is disabled when it is - previously it wasn't clear (though there was a suitable error message in the code that wasn't ever rendered). Also removes the hover styling when it's disabled.


| Before | After |
| --- | --- |
| ![image](https://github.com/guardian/media-atom-maker/assets/34686302/3ddeb6cd-9de7-43f1-b14a-c8b69f41dc4c) | ![image](https://github.com/guardian/media-atom-maker/assets/34686302/17d676b7-d76a-49f5-9159-a1fd86cee798) |

- Adds a message explaining why it's naughty to use the Asset URL option, to hopefully discourage the behaviour that led to videos not ending up in Pluto.

| Before | After |
| --- | --- |
| ![image](https://github.com/guardian/media-atom-maker/assets/34686302/0ff48014-07cc-4c45-b8cd-620a9c5a3a95) | ![image](https://github.com/guardian/media-atom-maker/assets/34686302/e7959f76-1157-44dc-8c6e-f1050a79a5b5) |
- Adds a 'not-allowed' cursor for disabled buttons.

## How to test

This PR will be simpler to test on CODE because getting the end-to-end YouTube upload working locally will be complicated.
1. Deploy this branch to CODE.
2. Fill out the 'YouTube Furniture' **without setting the Privacy status**. This will let you check the validation is showing properly in the 'Edit Assets' page.
3. Click the pencil icon in the top right, which shows a tolltip saying 'Edit Assets' on hover.
4. Is there an explanation of why you can't upload a video? On hover, does the 'choose file' button under 'Upload to YouTube' remain the same colour?
5. Go back to the YouTube furniture tab and add a privacy status, e.g. unlisted.