### PR TITLE
Add some user experience improvements to the uploads page (again)

### DIFF
--- a/public/video-ui/src/components/VideoUpload/AddAssetFromURL.js
+++ b/public/video-ui/src/components/VideoUpload/AddAssetFromURL.js
@@ -25,6 +25,12 @@ export default class AddAssetFromURL extends React.Component {
           <header className="video__detailbox__header video__detailbox__header-with-border">Asset URL</header>
           <div className="form__row">
             <div>
+              <p className="form__message form__message--warning">
+                This should only be used as a backup if the &apos;Upload to YouTube&apos; option is not available.
+              </p>
+              <p className="form__message form__message--warning">
+                Using an Asset URL from an existing YouTube video will not pass video data to our video commissioning and syndication tool, Pluto.
+              </p>
               <input
                 className="form__field"
                 type="text"

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.js
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.js
@@ -85,7 +85,7 @@ function AssetDisplay({ id, isActive, sources }) {
 
   return (
     <div className="upload">
-      {id ? <YouTubeEmbed id={id} /> : <VideoEmbed sources={sources} />}
+      {id ? <YouTubeEmbed id={id} largePreview={true}/> : <VideoEmbed sources={sources} />}
       {linkProps
         ? <a {...linkProps}>
             <Icon icon="open_in_new" className="icon__assets" />

--- a/public/video-ui/src/components/VideoUpload/YoutubeUpload.js
+++ b/public/video-ui/src/components/VideoUpload/YoutubeUpload.js
@@ -17,21 +17,13 @@ export default class YoutubeUpload extends React.Component {
     }
   };
 
-  renderWarning() {
-    return (
-      <p className="form__message form__message--warning">
-        A YouTube channel, category and privacy status are needed before uploading a video
-      </p>
-    );
-  }
-
   render() {
     const { video, startUpload } = this.props;
 
     const canUploadToYouTube = VideoUtils.canUploadToYouTube(video);
 
     return (
-      <div className="video__detailbox video__detailbox__assets">   
+      <div className="video__detailbox video__detailbox__assets">
         <div className="form__group">
           <header className="video__detailbox__header video__detailbox__header-with-border">
             Upload to YouTube
@@ -44,6 +36,11 @@ export default class YoutubeUpload extends React.Component {
               disabled={!canUploadToYouTube || this.props.uploading}
               accept="video/*,.mxf"
             />
+            { !canUploadToYouTube ?
+              <p className="form__message form__message--warning">
+              A YouTube channel, category and privacy status are needed before uploading a video. Please set these in the YouTube furniture tab.
+              </p> : null
+            }
             <button
               type="button"
               className="btn button__secondary__assets"

--- a/public/video-ui/src/components/utils/YouTubeEmbed.js
+++ b/public/video-ui/src/components/utils/YouTubeEmbed.js
@@ -6,7 +6,7 @@ export const getYouTubeEmbedUrl = (id) => {
   const embedUrl = getStore().getState().config.youtubeEmbedUrl;
   return `${embedUrl}${id}?showinfo=0&rel=0`;
 }
-export function YouTubeEmbed({ id, className }) {
+export function YouTubeEmbed({ id, className, largePreview }) {
   return (
     <iframe
       type="text/html"
@@ -14,6 +14,8 @@ export function YouTubeEmbed({ id, className }) {
       src={getYouTubeEmbedUrl(id)}
       allowFullScreen
       frameBorder="0"
+      height={largePreview ? "250px" : undefined}
+      width={largePreview ? "400px" : undefined}
     />
   );
 }

--- a/public/video-ui/styles/abstracts/_mixins.scss
+++ b/public/video-ui/styles/abstracts/_mixins.scss
@@ -12,7 +12,7 @@
   }
 
   &:disabled {
-    cursor: default;
+    cursor: not-allowed;
     opacity: 0.5;
   }
 

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -102,6 +102,16 @@
         cursor: pointer;
       }
     }
+
+    &:disabled {
+      &::file-selector-button {
+        background-color: #888888;
+        &:hover {
+          background-color: #888888;
+          cursor: not-allowed;
+        }
+      }
+    }
   }
 
   // Placeholder styling, separated because if one selector is invalid, the browser will ignore the rest

--- a/public/video-ui/styles/components/_presence.scss
+++ b/public/video-ui/styles/components/_presence.scss
@@ -56,6 +56,7 @@
     border-radius: 50%;
     color: $color600Grey;
     background-color: $cWhite;
+    height: 32px;
 
     &:not(:last-child) {
       margin-right: 7px;

--- a/public/video-ui/styles/layout/_grid.scss
+++ b/public/video-ui/styles/layout/_grid.scss
@@ -76,6 +76,7 @@
   width: 100%;
   background-color: $color700Grey;
   height: 60px;
+  min-height: 60px;
 }
 
 .grid__item__title {

--- a/public/video-ui/styles/layout/_upload.scss
+++ b/public/video-ui/styles/layout/_upload.scss
@@ -18,12 +18,13 @@
 
   &__right {
     display: flex;
+    height: 38px;
   }
 
   &__info {
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: normal;
     color: white;
   }
 

--- a/public/video-ui/styles/layout/_video.scss
+++ b/public/video-ui/styles/layout/_video.scss
@@ -107,6 +107,15 @@
     margin-top: 20px;
     padding-left: 20px;
     flex: 8;
+
+    .grid__item {
+      width: 400px;
+      height: 300px;
+
+      .upload {
+        height: 250px;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Re-run of https://github.com/guardian/media-atom-maker/pull/1155 - without disabling the buttons. That PR [was reverted](https://github.com/guardian/media-atom-maker/pull/1158) because it inadvertently stopped users being able to activate YouTube live feeds, which media-atom-maker apparently supports.

The logic around this is not clear so I'm just going to introduce the more simple UI tweaks without touching this area. My guess is that YouTube live feeds never come out of the `processing` phase.

This PR fixes some bits of awkward functionality on the uploads page, specifically:

- The video previews on the uploads are bigger, accommodate more text by default and the description bar expands to accommodate longer text. Before, they took up an oddly small amount of screen space and consequently the information about the progress through the upload process was usually unreadable.

| Before | After |
| --- | --- |
| ![image](https://github.com/guardian/media-atom-maker/assets/34686302/a1fb4905-acc1-40e5-9958-82851dabd2df) | ![image](https://github.com/guardian/media-atom-maker/assets/34686302/6699bd51-d92e-4158-86af-73a5a0f40309) |

- Adds a message explaining why the 'Upload to Youtube' 'Choose file' button is disabled when it is - previously it wasn't clear (though there was a suitable error message in the code that wasn't ever rendered). Also removes the hover styling when it's disabled.
