### PR TITLE
Enable  transfer acceleration for s3 uploads

### DIFF
--- a/public/video-ui/src/services/UploadsApi.js
+++ b/public/video-ui/src/services/UploadsApi.js
@@ -61,7 +61,8 @@ function getS3(bucket, region, credentials) {
     apiVersion: '2006-03-01',
     credentials: awsCredentials,
     params: { Bucket: bucket },
-    region: region
+    region: region,
+    useAccelerateEndpoint: true
   });
 }
 


### PR DESCRIPTION
## What does this change?

This PR enables the application to use transfer acceleration for s3 uploads, which should improve upload speeds for users in Australia and the US.

I've already updated the PROD, CODE and DEV s3 upload buckets for media-atom-maker in the AWS console by enabling transfer acceleration for them.

Transfer Acceleration achieves faster speeds by using the globally distributed edge locations in CloudFront for data transport. The improvements should be more noticeable for users further from `eu-west-1` (Ireland).

## How to test

1. Deploy to CODE.
2. Try uploading a video to YouTube, by filling out required fields in the YouTube furniture panel and clicking on the pencil icon in the Video Preview panel.
3. Does upload still work?

I'll be running a test from here (UK) to see if there are any improvements here.

## How can we measure success?

Uploads succeed, US and AU see faster upload speeds.