### PR TITLE
make permissions load from CODE, even if running locally

### DIFF
--- a/app/di.scala
+++ b/app/di.scala
@@ -60,7 +60,12 @@ class MediaAtomMaker(context: Context)
 
   private val aws = new AWSConfig(config, credentials)
 
-  private val permissions = new MediaAtomMakerPermissionsProvider(aws.stage, aws.region.getName, aws.credentials.instance.awsV1Creds)
+  private val permissionsStage = aws.stage match {
+    case "PROD" => "PROD"
+    case _ => "CODE"
+  }
+
+  private val permissions = new MediaAtomMakerPermissionsProvider(permissionsStage, aws.region.getName, aws.credentials.instance.awsV1Creds)
 
   private val hmacAuthActions = new PanDomainAuthActions {
     override def conf: Configuration = MediaAtomMaker.this.configuration


### PR DESCRIPTION
MAM currently loads permissions from the same stage as it's running in, even if running locally. Most other tools will load from CODE when running locally - let's make MAM behave the same.