### PR TITLE
pluto-message-ingestion: remove externals from ncc config

### DIFF
--- a/pluto-message-ingestion/ncc.config.json
+++ b/pluto-message-ingestion/ncc.config.json
@@ -1,7 +1,3 @@
 {
-  "externals": {
-    "aws-sdk": "aws-sdk",
-    "/aws-sdk(/.*)/": "aws-sdk$1"
-  },
   "minify": true
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Remove the "externals" field from pluto message ingestion's ncc config.

The externals field excludes a package from the bundled JS output. This could be used in AWS Lambda runtimes <= 16 which bundled the v2 AWS JS SDK. However 18 and above bundle the v3 SDK, so we need to either 1) stop excluding the SDK from the bundle or 2) migrate to the v3 SDK. We should probably do both (the first so we have confidence about which version of the SDK is being used at runtime, the second to keep uptodate with library updates) but for now I'm focused on upgrading the runtime, so we'll come back to the SDK upgrade at a later date.

## How to test

`cd pluto-message-ingestion; yarn; yarn build`. Before this change, the bundled output is 34kB (11kB zipped). After this change it is ~10.7MB (1.3MB zipped).

(That's a huge increase but still well within AWS limits, so we'll live with it. Moving the v3 SDK will help as the unused parts of the SDK are more easily excluded by bundlers like ncc).


## How can we measure success?

Lambda can run on the Node 18 runtime.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
