### PR TITLE
Store output in year/month/day not year/minute/day

### DIFF
--- a/common/src/main/scala/com/gu/media/upload/UploadKeys.scala
+++ b/common/src/main/scala/com/gu/media/upload/UploadKeys.scala
@@ -22,7 +22,7 @@ case class TranscoderOutputKey(prefix: String, title: String, id: String, extens
 object TranscoderOutputKey {
   def apply(title: String, id: String, extension: String): TranscoderOutputKey = {
     val now = ZonedDateTime.now(ZoneOffset.UTC)
-    val prefix = now.format(DateTimeFormatter.ofPattern("yyyy/mm/dd"))
+    val prefix = now.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"))
 
     TranscoderOutputKey(prefix, title, id, extension)
   }


### PR DESCRIPTION
## What does this change?

I noticed that we had files in suspicious looking folder names like "2024/58/29/", uploaded on 29th July 2024.

This PR fixes a bug in our date format string so that this would now be stored in "2024/07/29".

I don't think the incorrect output folder actually matters beyond causing confusion.