### PR TITLE
WIP: start using actions-riff-raff

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,26 +7,49 @@ jobs:
   CI:
     runs-on: ubuntu-latest
     permissions:
+      # id-token and pull-requests required by actions-riff-raff
       id-token: write
+      pull-requests: write
       contents: read
     steps:
       - uses: actions/checkout@v2
-      - uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
       # See https://github.com/guardian/setup-java
       - name: Setup Java and sbt
         uses: guardian/setup-scala@v1
       - uses: actions/setup-node@v3
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: '.nvmrc'
       - name: Build Pluto lambda
         run: |
           ./scripts/pluto-ci.sh
       - name: Build Media Atom Maker
         run: |
           ./scripts/app-ci.sh
-      - name: Compile Scala and upload artifacts to RiffRaff
+      - name: Compile Scala and produce artefacts
         run: |
           ./scripts/scala-ci.sh
+
+      - name: Upload artefacts to Riff Raff’s S3 buckets
+        uses: guardian/actions-riff-raff@v4
+        with:
+          app: datawrapper-import
+          projectName: 'media-service:media-atom-maker'
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          configPath: conf/riff-raff.yaml
+          contentDirectories: |
+            pluto-message-ingestion:
+              - pluto-message-ingestion/target/pluto-message-ingestion.zip
+            media-atom-pipeline-cloudformation:
+              - media-atom-pipeline-yaml
+            media-atom-upload-actions:
+              - target/uploader
+            expirer:
+              - target/expirer
+            scheduler:
+              - target/scheduler
+            cdk.out:
+              - cdk/cdk.out/DatawrapperImport-useast-1-CODE.template.json
+              - cdk/cdk.out/DatawrapperImport-useast-1-PROD.template.json
+            datawrapper-import:
+              - target/validating-copy-lambda.jar


### PR DESCRIPTION
The [Riff Raff sbt
plugin](https://github.com/guardian/sbt-riffraff-artifact) that this app uses is deprecated, with the readme suggesting users should move to using actions-riff-raff. This commit makes that change.

I haven’t worked out the correct structure for contentDirectories yet, nor where the binaries are placed by sbt for it to look them up from.

Also, I quite like how with the plugin the binary paths are looked up automatically: when using actions-riff-raff I’ve been manually looking those up, which is a bit annoying. It might be worth exploring whether we can define sbt tasks to output the binary locations.

Finally, I should look at the current structure in Riff Raff’s S3 buckets for this app, to make sure the use of actions-riff-raff (once complete) replicates it correctly.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
