### PR TITLE
temporary again: Accept thumbnail update failure

### DIFF
--- a/app/model/commands/PublishAtomCommand.scala
+++ b/app/model/commands/PublishAtomCommand.scala
@@ -165,7 +165,11 @@ case class PublishAtomCommand(
           createOrUpdateYoutubeClaim(publishedAtom, previewAtom, asset)
         }
         updateYoutubeMetadata(previewAtom, asset)
-        updateYoutubeThumbnail(previewAtom, asset)
+        updateYoutubeThumbnail(previewAtom, asset).recover {
+          case e: Throwable =>
+            log.error("failed to update thumbnail; skipping", e)
+            previewAtom
+        }
 
       case Some(_) =>
         // third party YouTube video that we do not have permission to edit


### PR DESCRIPTION
Reverts guardian/media-atom-maker#1075

Some of our videos are getting publish failures since youtube won't allow us to update the thumbnails

We really need to add a proper workaround one of these days...