### PR TITLE
backport stream encryption to dev cloudformation to maintain parity with real

### DIFF
--- a/cloudformation/media-atom-maker-dev.yml
+++ b/cloudformation/media-atom-maker-dev.yml
@@ -415,6 +415,9 @@ Resources:
     Properties:
       Name: !Sub "${UploadsStreamName}-${Stage}"
       ShardCount: 1
+      StreamEncryption:
+        EncryptionType: KMS
+        KeyId: !Ref KmsKeyKinesisStreamAlias
   PlutoTopic:
     Type: "AWS::SNS::Topic"
     Properties:
@@ -462,6 +465,29 @@ Resources:
       AliasName: !Sub "alias/media-atom-maker/sns-to-sqs-${Stage}"
       TargetKeyId:
         Ref: KmsKeySqsQueueFromSns
+
+  KmsKeyKinesisStream:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: "Shared key for encryption the kinesis stream"
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: Kinesis-Stream-Key
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action:
+              - kms:*
+            Resource: "*"
+
+  KmsKeyKinesisStreamAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub "alias/media-atom-maker/kinesis-${Stage}"
+      TargetKeyId:
+        Ref: KmsKeyKinesisStream
+
   PlutoQueuePolicy:
     Type: "AWS::SQS::QueuePolicy"
     Properties:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The pipeline cloudformation is currently not deployable to DEV, as it requires the existence of an encryption key which is not currently included in the DEV stack. Backport https://github.com/guardian/editorial-tools-platform/pull/435 to here, so we have one and can include it in the parameter list for DEV pipeline.

## How to test

Already deployed and working on DEV stacks.
