### PR TITLE
If MaM is in an iFrame, post key events on Message API

### DIFF
--- a/public/video-ui/src/components/ReactApp.jsx
+++ b/public/video-ui/src/components/ReactApp.jsx
@@ -32,6 +32,20 @@ class ReactApp extends React.Component {
     }
   }
 
+  componentDidMount() {
+    window.addEventListener('keyup', this.handleKeyUp);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('keyup', this.handleKeyUp);
+  }
+
+  handleKeyUp = (event) => {
+    if (window.self !== window.top) {
+      window.parent.postMessage({ eventKey: event.key }, '*');
+    }
+  };
+
   render() {
     const showPublishedState = this.props.params.id;
 


### PR DESCRIPTION
See https://github.com/guardian/facia-tool/pull/1823. 

When MaM is in an iFrame (i.e. in the Replace Video modal in the Fronts Tool), it swallows keypress events when the iFrame has focus. This PR passes those events up to the parent context where it can be used to e.g. detect keyboard shortcuts to exit the modal.

### To test
Toggle the 'Enable replacement video' feature switch on (e.g. https://fronts.local.dev-gutools.co.uk/v2/features).

Select the 'Video' option on any card. Open the Video Replace modal. You should be able to exit using the Escape key, even if the MaM modal has focus.