### PR TITLE
add tracking pixel

### DIFF
--- a/public/video-ui/src/app.jsx
+++ b/public/video-ui/src/app.jsx
@@ -7,19 +7,10 @@ import { browserHistory } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
 import { configureStore } from './util/configureStore';
 import { setStore } from './util/storeAccessor';
+import { extractConfigFromPage } from './util/config';
 import { routes } from './routes';
 
 import '../styles/main.scss';
-
-function extractConfigFromPage() {
-  const configEl = document.getElementById('config');
-
-  if (!configEl) {
-    return {};
-  }
-
-  return JSON.parse(configEl.innerHTML);
-}
 
 const store = configureStore();
 syncHistoryWithStore(browserHistory, store);

--- a/public/video-ui/src/routes.jsx
+++ b/public/video-ui/src/routes.jsx
@@ -1,24 +1,37 @@
 import React from 'react';
-import { Router, Route, browserHistory, IndexRedirect, Redirect } from 'react-router';
+import { browserHistory, IndexRedirect, Redirect, Route, Router } from 'react-router';
 
-import Search from './pages/Search';
-import Video from './pages/Video';
-import Upload from './pages/Upload';
-import Help from './pages/Help';
-import Training from './pages/Training';
 import ReactApp from './components/ReactApp';
+import Help from './pages/Help';
+import Search from './pages/Search';
+import Training from './pages/Training';
+import Upload from './pages/Upload';
+import Video from './pages/Video';
+import { extractConfigFromPage, getUserTelemetryClient } from './util/config';
+
+const telemetryClientUrl = getUserTelemetryClient(extractConfigFromPage().stage);
+
+function loadTrackingPixel(clientUrl, path) {
+  const image = new Image();
+  image.src = `${clientUrl}/guardian-tool-accessed?app=video&path=${path}`;
+}
+
+function sendTelemetry(state) {
+  loadTrackingPixel(telemetryClientUrl, state.location.pathname);
+  return state
+}
 
 export const routes = (
   <Router history={browserHistory}>
     <Route path="/" component={ReactApp}>
       <IndexRedirect to="/videos" />
-      <Route path="/videos" component={Search} />
-      <Redirect from="/videos/create" to="/create" />
-      <Route path="/videos/:id" component={Video} />
-      <Route path="/videos/:id/upload" component={Upload} />
-      <Route path="/create" component={Video} mode="create" />
-      <Route path="/help" component={Help} />
-      <Route path="/training" component={Training} />
+      <Route path="/videos" component={Search} onEnter={sendTelemetry} />
+      <Redirect from="/videos/create" to="/create" onEnter={sendTelemetry} />
+      <Route path="/videos/:id" component={Video} onEnter={sendTelemetry} />
+      <Route path="/videos/:id/upload" component={Upload} onEnter={sendTelemetry} />
+      <Route path="/create" component={Video} mode="create" onEnter={sendTelemetry} />
+      <Route path="/help" component={Help} onEnter={sendTelemetry} />
+      <Route path="/training" component={Training} onEnter={sendTelemetry} />
     </Route>
   </Router>
 );

--- a/public/video-ui/src/util/config.js
+++ b/public/video-ui/src/util/config.js
@@ -1,0 +1,20 @@
+export function extractConfigFromPage() {
+  const configEl = document.getElementById('config');
+
+  if (!configEl) {
+    return {};
+  }
+
+  return JSON.parse(configEl.innerHTML);
+}
+
+export function getUserTelemetryClient(stage) {
+  switch (stage) {
+    case 'CODE':
+      return 'https://user-telemetry.code.dev-gutools.co.uk';
+    case 'PROD':
+      return 'https://user-telemetry.gutools.co.uk';
+    default:
+      return 'https://user-telemetry.local.dev-gutools.co.uk';
+  }
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds tracking to the media-atom-maker using the [user-telemetry tracking pixel](https://github.com/guardian/editorial-tools-user-telemetry-service?tab=readme-ov-file#tracking-pixel). This will allow us to find out more about the usage of the tool. On merge, results should be visible in the [tool audit dashboard](https://metrics.gutools.co.uk/d/aegzv59r9eghsd/tool-audit?orgId=1&var-domain=video.discussion.gutools.co.uk&var-path=All&var-interval=1d&var-chosen_apps=All).

The PR uses an '[onEnter](https://github.com/remix-run/react-router/blob/v3.2.6/docs/Glossary.md#enterhook)' hook to send the telemetry as a side effect of the a react route being opened client-side, so we get telemetry for every route/location the app serves.

## How to test

Running locally, you should see request for the pixel in the network tab on every client-side navigation between routes - the requests will fail if you do not have the telemetry service running locally.

On code, the pixel request should work and populate the code dashboard with usage data.

## How can we measure success?


We have a clear idea how much the tool is being used. 
