### PR TITLE
Upgrade to latest scala 2.13 and override jackson versions to 2.19

### DIFF
--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Encoders._
 import com.amazonaws.services.stepfunctions.model.{ExecutionAlreadyExistsException, ExecutionListItem}
 import com.gu.media.MediaAtomMakerPermissionsProvider
 import com.gu.media.logging.Logging
@@ -10,7 +10,7 @@ import com.gu.media.util.{MediaAtomHelpers, MediaAtomImplicits}
 import com.gu.media.youtube.YouTubeVideos
 import com.gu.pandahmac.HMACAuthActions
 import data.{DataStores, UnpackedDataStores}
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.{Format, Json}
 import play.api.mvc.ControllerComponents
 import util._

--- a/app/model/ClientConfig.scala
+++ b/app/model/ClientConfig.scala
@@ -1,8 +1,8 @@
 package model
 
-import ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Encoders._
 import com.gu.media.Permissions
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.Format
 
 case class Presence(domain: String, firstName: String, lastName: String, email: String) {

--- a/app/model/MediaAtomSummary.scala
+++ b/app/model/MediaAtomSummary.scala
@@ -1,8 +1,8 @@
 package model
 
 import com.gu.media.model.{Image, ContentChangeDetails}
-import ai.x.play.json.Encoders._
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.Format
 
 case class MediaAtomList(total: Int, atoms: List[MediaAtomSummary])

--- a/app/model/WorkflowMediaAtom.scala
+++ b/app/model/WorkflowMediaAtom.scala
@@ -1,7 +1,7 @@
 package model
 
-import ai.x.play.json.Encoders._
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.Format
 
 case class WorkflowMediaAtom(title: String)

--- a/app/model/commands/CreateAtomCommand.scala
+++ b/app/model/commands/CreateAtomCommand.scala
@@ -11,7 +11,7 @@ import com.gu.media.logging.Logging
 import com.gu.pandomainauth.model.{User => PandaUser}
 import data.DataStores
 import model.commands.CommandExceptions._
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.Format
 import com.gu.media.model.{ChangeRecord, MediaAtom, MediaAtomBeforeCreation}
 import com.gu.media.model.AuditMessage

--- a/app/model/transcoder/JobStatus.scala
+++ b/app/model/transcoder/JobStatus.scala
@@ -1,7 +1,7 @@
 package model.transcoder
 
-import ai.x.play.json.Encoders._
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.OFormat
 
 case class JobStatus(key: String, status: String, statusDetail: Option[String])

--- a/app/util/ActivateAssetRequest.scala
+++ b/app/util/ActivateAssetRequest.scala
@@ -1,7 +1,7 @@
 package util
 
-import ai.x.play.json.Encoders._
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json._
 
 case class ActivateAssetRequest (

--- a/build.sbt
+++ b/build.sbt
@@ -41,8 +41,7 @@ val jsoupVersion = "1.16.1"
 
 val enumeratumVersion = "1.5.15"
 
-lazy val jacksonVersion = "2.13.4"
-lazy val jacksonDatabindVersion = "2.13.4.2"
+lazy val jacksonVersion = "2.19.1"
 
 lazy val commonSettings = Seq(
   ThisBuild / scalaVersion := "2.13.16",
@@ -53,21 +52,22 @@ lazy val commonSettings = Seq(
 
   // silly SBT command to work-around lack of support for root projects that are not in the "root" folder
   // https://github.com/sbt/sbt/issues/2405
-  Global / onLoad := (Global/ onLoad).value andThen (Command.process("project root", _))
+  Global / onLoad := (Global/ onLoad).value andThen (Command.process("project root", _)),
+
+  dependencyOverrides ++= jacksonOverrides
 )
 
-// these Jackson dependencies are required to resolve issues in Play 2.8.x https://github.com/orgs/playframework/discussions/11222
 val jacksonOverrides = Seq(
   "com.fasterxml.jackson.core" % "jackson-core",
   "com.fasterxml.jackson.core" % "jackson-annotations",
+  "com.fasterxml.jackson.core" % "jackson-databind",
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor",
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8",
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310",
+  "com.fasterxml.jackson.module" % "jackson-module-parameter-names",
   "com.fasterxml.jackson.module" %% "jackson-module-scala",
 ).map(_ % jacksonVersion)
 
-val jacksonDatabindOverrides = Seq(
-  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
-)
 
 lazy val common = (project in file("common"))
   .settings(commonSettings,
@@ -124,7 +124,7 @@ lazy val common = (project in file("common"))
       "org.jsoup" % "jsoup" % jsoupVersion,
       "com.beachape" %% "enumeratum" % enumeratumVersion,
       "net.logstash.logback" % "logstash-logback-encoder" % "6.6"
-    ) ++ jacksonOverrides ++ jacksonDatabindOverrides
+    )
   )
 
 lazy val app = (project in file("."))
@@ -134,7 +134,6 @@ lazy val app = (project in file("."))
     name := "media-atom-maker",
     libraryDependencies ++= Seq(
       ehcache,
-      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
       "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
       "software.amazon.awssdk" % "sts" % awsV2Version,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ val atomMakerVersion = "2.0.0"
 val typesafeConfigVersion = "1.4.0" // to match what we get from Play transitively
 val scanamoVersion = "1.0.0-M28"
 
-val playJsonExtensionsVersion = "0.42.0"
+val playJsonExtensionsVersion = "1.0.3"
 val okHttpVersion = "2.4.0"
 
 val scalaTestVersion = "3.0.8"
@@ -45,7 +45,7 @@ lazy val jacksonVersion = "2.13.4"
 lazy val jacksonDatabindVersion = "2.13.4.2"
 
 lazy val commonSettings = Seq(
-  ThisBuild / scalaVersion := "2.13.11", // 2.13.12 blocked by https://github.com/scala/bug/issues/12862
+  ThisBuild / scalaVersion := "2.13.16",
   scalacOptions ++= Seq("-feature", "-deprecation", "-release:11"),
   ThisBuild / organization := "com.gu",
 
@@ -105,7 +105,7 @@ lazy val common = (project in file("common"))
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
       "software.amazon.awssdk" % "dynamodb" % awsV2Version,
       "com.amazonaws" % "aws-java-sdk-kinesis" % awsVersion,
-      "ai.x" %% "play-json-extensions" % playJsonExtensionsVersion,
+      "com.gu" %% "play-json-extensions" % playJsonExtensionsVersion,
       "ch.qos.logback" % "logback-classic" % logbackClassicVersion,
       "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
       "software.amazon.awssdk" % "sts" % awsV2Version,

--- a/common/src/main/scala/com/gu/media/Permissions.scala
+++ b/common/src/main/scala/com/gu/media/Permissions.scala
@@ -2,8 +2,8 @@ package com.gu.media
 
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.gu.permissions._
-import ai.x.play.json.Jsonx
-import ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 import com.gu.pandomainauth.model.{User => PandaUser}
 import com.gu.permissions.PermissionDefinition

--- a/common/src/main/scala/com/gu/media/model/Asset.scala
+++ b/common/src/main/scala/com/gu/media/model/Asset.scala
@@ -1,8 +1,8 @@
 package com.gu.media.model
 
 import com.gu.contentatom.thrift.atom.media.{Asset => ThriftAsset}
-import ai.x.play.json.Encoders._
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.OFormat
 
 case class Asset(assetType: AssetType,

--- a/common/src/main/scala/com/gu/media/model/ChangeRecord.scala
+++ b/common/src/main/scala/com/gu/media/model/ChangeRecord.scala
@@ -1,9 +1,9 @@
 package com.gu.media.model
 
-import ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Encoders._
 import com.gu.contentatom.thrift.{ChangeRecord => ThriftChangeRecord}
 import com.gu.pandomainauth.model.{User => PandaUser}
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Jsonx
 import org.joda.time.DateTime
 import play.api.libs.json.Format
 import play.api.libs.json.JodaWrites._

--- a/common/src/main/scala/com/gu/media/model/ClientAsset.scala
+++ b/common/src/main/scala/com/gu/media/model/ClientAsset.scala
@@ -1,9 +1,9 @@
 package com.gu.media.model
 
-import ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Encoders._
 import com.gu.media.upload.model.Upload
 import com.gu.media.youtube.YouTubeProcessingStatus
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.Format
 
 case class ClientAsset(id: String, asset: Option[VideoAsset] = None, processing: Option[ClientAssetProcessing] = None, metadata: Option[ClientAssetMetadata] = None)

--- a/common/src/main/scala/com/gu/media/model/ContentChangeDetails.scala
+++ b/common/src/main/scala/com/gu/media/model/ContentChangeDetails.scala
@@ -1,8 +1,8 @@
 package com.gu.media.model
 
 import com.gu.contentatom.thrift.{ContentChangeDetails => ThriftContentChangeDetails}
-import ai.x.play.json.Encoders._
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.OFormat
 
 case class ContentChangeDetails(

--- a/common/src/main/scala/com/gu/media/model/Image.scala
+++ b/common/src/main/scala/com/gu/media/model/Image.scala
@@ -1,8 +1,8 @@
 package com.gu.media.model
 
 import com.gu.contentatom.thrift.{Image => ThriftImage, ImageAsset => ThriftImageAsset, ImageAssetDimensions => ThriftImageAssetDimensions}
-import ai.x.play.json.Encoders._
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.OFormat
 
 case class ImageAssetDimensions(height: Int, width: Int) {

--- a/common/src/main/scala/com/gu/media/model/MediaAtom.scala
+++ b/common/src/main/scala/com/gu/media/model/MediaAtom.scala
@@ -1,7 +1,7 @@
 package com.gu.media.model
 
-import ai.x.play.json.Encoders._
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
 import com.gu.contentatom.thrift.atom.media.{MediaAtom => ThriftMediaAtom, Metadata => ThriftMetadata, YoutubeData => ThriftYoutubeData}
 import play.api.libs.json.Format
 import com.gu.contentatom.thrift.{AtomData, Atom => ThriftAtom, AtomType => ThriftAtomType, Flags => ThriftFlags}

--- a/common/src/main/scala/com/gu/media/model/PlutoData.scala
+++ b/common/src/main/scala/com/gu/media/model/PlutoData.scala
@@ -1,8 +1,8 @@
 package com.gu.media.model
 
-import ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Encoders._
 import com.gu.contentatom.thrift.atom.media.{PlutoData => ThriftPlutoData}
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.Format
 
 case class PlutoData (

--- a/common/src/main/scala/com/gu/media/model/PlutoIntegrationData.scala
+++ b/common/src/main/scala/com/gu/media/model/PlutoIntegrationData.scala
@@ -3,8 +3,8 @@ package com.gu.media.model
 import com.amazonaws.services.s3.model.PutObjectRequest
 import com.gu.media.aws.{AwsAccess, UploadAccess}
 import com.gu.media.upload.CompleteUploadKey
-import ai.x.play.json.Jsonx
-import ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 
 sealed trait PlutoIntegrationMessage {

--- a/common/src/main/scala/com/gu/media/model/User.scala
+++ b/common/src/main/scala/com/gu/media/model/User.scala
@@ -1,8 +1,8 @@
 package com.gu.media.model
 
-import ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Encoders._
 import com.gu.contentatom.thrift.{User => ThriftUser}
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.Format
 
 case class User(email: String, firstName: Option[String], lastName: Option[String]) {

--- a/common/src/main/scala/com/gu/media/model/VideoAsset.scala
+++ b/common/src/main/scala/com/gu/media/model/VideoAsset.scala
@@ -1,7 +1,7 @@
 package com.gu.media.model
 
-import ai.x.play.json.Encoders._
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.Format
 
 case class VideoSource(src: String, mimeType: String)

--- a/common/src/main/scala/com/gu/media/pluto/PlutoProject.scala
+++ b/common/src/main/scala/com/gu/media/pluto/PlutoProject.scala
@@ -1,7 +1,7 @@
 package com.gu.media.pluto
 
-import ai.x.play.json.Encoders._
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
 import org.joda.time.DateTime
 import play.api.libs.json._
 import com.gu.media.util.JsonDate._

--- a/common/src/main/scala/com/gu/media/upload/model/Upload.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/Upload.scala
@@ -1,7 +1,7 @@
 package com.gu.media.upload.model
 
-import ai.x.play.json.Jsonx
-import ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 
 // All data is conceptually immutable except UploadProgress

--- a/common/src/main/scala/com/gu/media/upload/model/UploadCredentials.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadCredentials.scala
@@ -1,7 +1,7 @@
 package com.gu.media.upload.model
 
-import ai.x.play.json.Jsonx
-import ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 
 case class UploadCredentials(temporaryAccessId: String, temporarySecretKey: String, sessionToken: String)

--- a/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
@@ -1,7 +1,7 @@
 package com.gu.media.upload.model
 
-import ai.x.play.json.Jsonx
-import ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 import com.gu.media.model.{PlutoSyncMetadataMessage, VideoAsset}
 

--- a/common/src/main/scala/com/gu/media/upload/model/UploadPart.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadPart.scala
@@ -1,7 +1,7 @@
 package com.gu.media.upload.model
 
-import ai.x.play.json.Jsonx
-import ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 
 case class UploadPart(key: String, start: Long, end: Long)

--- a/common/src/main/scala/com/gu/media/upload/model/UploadProgress.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadProgress.scala
@@ -1,7 +1,7 @@
 package com.gu.media.upload.model
 
-import ai.x.play.json.Jsonx
-import ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 
 case class UploadProgress(chunksInS3: Int, chunksInYouTube: Int, fullyUploaded: Boolean, fullyTranscoded: Boolean,

--- a/common/src/main/scala/com/gu/media/upload/model/UploadRequest.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadRequest.scala
@@ -1,7 +1,7 @@
 package com.gu.media.upload.model
 
-import ai.x.play.json.Jsonx
-import ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 
 case class UploadRequest(

--- a/common/src/main/scala/com/gu/media/upload/model/UploadStatus.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadStatus.scala
@@ -1,9 +1,9 @@
 package com.gu.media.upload.model
 
 import com.gu.media.model.VideoAsset
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.Format
-import ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Encoders._
 
 case class UploadStatus(id: String, status: String, asset: Option[VideoAsset], current: Option[Int], total: Option[Int], failed: Boolean)
 

--- a/common/src/main/scala/com/gu/media/youtube/MediaAtomYoutubeDescriptionHandler.scala
+++ b/common/src/main/scala/com/gu/media/youtube/MediaAtomYoutubeDescriptionHandler.scala
@@ -3,8 +3,8 @@ package com.gu.media.youtube
 import com.gu.contentatom.thrift.atom.media.{MediaAtom => ThriftMediaAtom}
 import com.gu.media.model.MediaAtom
 import com.gu.media.util.MediaAtomImplicits
-import ai.x.play.json.Jsonx
-import ai.x.play.json.Encoders._
+import com.gu.ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Encoders._
 import play.api.libs.json.Format
 
 

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeProcessingStatus.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeProcessingStatus.scala
@@ -1,7 +1,7 @@
 package com.gu.media.youtube
 
 import com.google.api.services.youtube.model.{Video, VideoProcessingDetails}
-import ai.x.play.json.Jsonx
+import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.Format
 
 import scala.util.Try


### PR DESCRIPTION
There's a high vuln CVE on jackson-core, so upgrade to a later version. 

The jackson module versions should be kept in sync, including the scala module.

The recent scala modules require being on later versions of Scala 2.13, so we need to overcome the problem which kept us from upgrading to 2.13.12.

This is fixed by moving to the guardian fork of play-json-extensions, which has [commits to deal with that compiler bug](https://github.com/scala/bug/issues/12862#issuecomment-1799369339) - thanks @rtyley !