### PR TITLE
Constrain height in video transcoder

### DIFF
--- a/uploader/src/main/resources/cfn-template.yaml
+++ b/uploader/src/main/resources/cfn-template.yaml
@@ -214,6 +214,7 @@ Resources:
                   Container: MP4
                   Mp4Settings: { }
                 VideoDescription:
+                  Height: 720
                   CodecSettings:
                     Codec: H_264
                     H264Settings:


### PR DESCRIPTION
## What does this change?

The existing transcoder constrains the video to 1280x720. MediaConvert doesn't allow us to constrain in quite the same way, but constraining the height and hoping that videos are uploaded in appropriate aspect ratios seems reasonable.

## How to test

Already tested in CODE with manual change. Main test is just whether the format of the cloudformation is correct. Deploy to CODE, check that height in mediaconvert template is set.

