### PR TITLE
Use migrated settings

### DIFF
--- a/uploader/src/main/resources/cfn-template.yaml
+++ b/uploader/src/main/resources/cfn-template.yaml
@@ -221,7 +221,9 @@ Resources:
                     Codec: H_264
                     H264Settings:
                       Bitrate: 2400000
-                      RateControlMode: CBR
+                      RateControlMode: QVBR
+                      QvbrSettings:
+                        QvbrQualityLevel: 10
                       CodecProfile: BASELINE
                       CodecLevel: LEVEL_3_1
                       EntropyEncoding: CAVLC # This is only specified because it is required if you chose CodecProfile: BASELINE

--- a/uploader/src/main/resources/cfn-template.yaml
+++ b/uploader/src/main/resources/cfn-template.yaml
@@ -230,6 +230,7 @@ Resources:
                       FramerateControl: SPECIFIED
                       FramerateNumerator: 30000
                       FramerateDenominator: 1001
+                      HrdBufferSize: 16800000
                 AudioDescriptions:
                   - CodecSettings:
                       Codec: AAC

--- a/uploader/src/main/resources/cfn-template.yaml
+++ b/uploader/src/main/resources/cfn-template.yaml
@@ -214,13 +214,18 @@ Resources:
                   Container: MP4
                   Mp4Settings: { }
                 VideoDescription:
+                  Width: 1280
                   Height: 720
+                  ScalingBehavior: FIT_NO_UPSCALE
                   CodecSettings:
                     Codec: H_264
                     H264Settings:
                       Bitrate: 2400000
+                      RateControlMode: CBR
                       CodecProfile: BASELINE
+                      CodecLevel: LEVEL_3_1
                       EntropyEncoding: CAVLC # This is only specified because it is required if you chose CodecProfile: BASELINE
+                      NumberReferenceFrames: 3
                       NumberBFramesBetweenReferenceFrames: 0 # This is only specified because it is required if you chose CodecProfile: BASELINE
                       FramerateControl: SPECIFIED
                       FramerateNumerator: 30000
@@ -232,6 +237,8 @@ Resources:
                         Bitrate: 160000
                         CodingMode: CODING_MODE_2_0
                         SampleRate: 44100
+                        CodecProfile: LC
+                    AudioSourceName: Audio Selector 1
             OutputGroupSettings:
               Type: FILE_GROUP_SETTINGS
               FileGroupSettings: { }


### PR DESCRIPTION
## What does this change?

Alternative to #1210 - using the AWS migration script (https://github.com/aws-samples/migrate-workflow-from-amazon-elastic-trancoder-to-aws-elemental-mediaconvert) to migrate our old ElasticTranscoder preset settings to MediaConvert job template settings.

In addition, we use some settings specified by a ticket we raised with AWS support:
> We apologize for the inconvenience migrating from Elastic Transcoder to MediaConvert. There are some differences in how default settings are handled between the two services. One such difference that impacts video quality is bufferSize (or hrdBufferSize in MediaConvert). We are working to improve the migration script to accommodate for the differences in how these are handled.

> As a workaround you can manually set the HRD buffer to 16800000 for your MediaConvert preset using baseline profile and Level 3.1. Note that this value can vary depending on your selected profile and level. We also recommend that you use QVBR rate control and set quality level to 10, if it is compatible with your workflow. Thank you for using MediaConvert.