### PR TITLE
Add permission for adding subtitles to self hosted atoms

### DIFF
--- a/common/src/main/scala/com/gu/media/Permissions.scala
+++ b/common/src/main/scala/com/gu/media/Permissions.scala
@@ -12,6 +12,7 @@ import com.gu.permissions.PermissionDefinition
 case class Permissions(
   deleteAtom: Boolean = false,
   addSelfHostedAsset: Boolean = false,
+  addSubtitles: Boolean = false,
   setVideosOnAllChannelsPublic: Boolean = false,
   pinboard: Boolean = false
 )
@@ -22,6 +23,7 @@ object Permissions {
   val basicAccess = PermissionDefinition("media_atom_maker_access", app)
   val deleteAtom = PermissionDefinition("delete_atom", app)
   val addSelfHostedAsset = PermissionDefinition("add_self_hosted_asset", app)
+  val addSubtitles = PermissionDefinition("add_subtitles", app)
   val setVideosOnAllChannelsPublic = PermissionDefinition("set_videos_on_all_channels_public", app)
   val pinboard = PermissionDefinition("pinboard", "pinboard")
 }
@@ -34,6 +36,7 @@ class MediaAtomMakerPermissionsProvider(stage: String, region: String, credsProv
   def getAll(user: PandaUser): Permissions = Permissions(
     deleteAtom = hasPermission(deleteAtom, user),
     addSelfHostedAsset = hasPermission(addSelfHostedAsset, user),
+    addSubtitles = hasPermission(addSubtitles, user),
     setVideosOnAllChannelsPublic = hasPermission(setVideosOnAllChannelsPublic, user),
     pinboard = hasPermission(pinboard, user)
   )


### PR DESCRIPTION
## What does this change?
Adds a new permission for uploading subtitles to self hosted atoms.
