### PR TITLE
Fixes RiffRaff bucket warning by using SSM lookup

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -4,7 +4,8 @@ templates:
   lambda:
     type: aws-lambda
     parameters:
-      bucket: atom-maker-dist
+      bucketSsmLookup: true
+      bucketSsmKey: /media-atom-maker/artifact.bucket
       prefixStack: false
 deployments:
   media-atom-maker-ami-update:
@@ -17,7 +18,8 @@ deployments:
   media-atom-maker:
     type: autoscaling
     parameters:
-      bucket: atom-maker-dist
+      bucketSsmLookup: true
+      bucketSsmKey: /media-atom-maker/artifact.bucket
     dependencies:
       - media-atom-maker-ami-update
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Addressing #1226, this PR uses SSM lookup to allow for deploying the project without including the bucket name in the repo. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Can we deploy to CODE successfully? 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
No more RiffRaff deploy warnings. 