### PR TITLE
Refresh atoms on subtitle upload

### DIFF
--- a/public/video-ui/src/actions/UploadActions/s3Upload.js
+++ b/public/video-ui/src/actions/UploadActions/s3Upload.js
@@ -81,6 +81,6 @@ export function deleteSubtitle({id, version}) {
   };
 }
 
-export function resetS3Upload() {
+export function resetS3UploadStatus() {
   return { type: 'UPLOAD_RESET' };
 }

--- a/public/video-ui/src/actions/UploadActions/s3Upload.js
+++ b/public/video-ui/src/actions/UploadActions/s3Upload.js
@@ -80,3 +80,7 @@ export function deleteSubtitle({id, version}) {
     });
   };
 }
+
+export function resetS3Upload() {
+  return { type: 'UPLOAD_RESET' };
+}

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.jsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.jsx
@@ -123,6 +123,7 @@ function SubtitleActions({ subtitles, onUpload, onDelete}) {
   const fileInputRef = React.useRef();
 
   const handleFileChange = (event) => {
+    const input = event.target;
     const file = event.target.files[0];
 
     if (!file) return;
@@ -132,6 +133,7 @@ function SubtitleActions({ subtitles, onUpload, onDelete}) {
 
     if (!isSRT && !isVTT) {
       alert('Invalid file type. Please upload a .srt or .vtt subtitle file.');
+      input.value = '';
       return;
     }
 
@@ -145,10 +147,12 @@ function SubtitleActions({ subtitles, onUpload, onDelete}) {
 
       if ((isSRT && !isSRTFormat) || (isVTT && !isVTTFormat)) {
         alert('The file content does not match the expected subtitle format.');
+        input.value = '';
         return;
       }
 
       onUpload(file);
+      input.value = '';
     };
 
     reader.readAsText(file);

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.jsx
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.jsx
@@ -31,6 +31,11 @@ export default class VideoTrail extends React.Component {
   getAssets = () => {
     const ret = [];
 
+     if (this.props.s3Upload.status === "complete") {
+       this.props.getUploads()
+       this.props.resetS3UploadStatus(); // reset status to 'idle'
+     }
+
     if (this.props.s3Upload.total) {
       ret.push({
         id: 's3Upload',

--- a/public/video-ui/src/pages/Upload/index.jsx
+++ b/public/video-ui/src/pages/Upload/index.jsx
@@ -80,12 +80,11 @@ class VideoUpload extends React.Component {
                 )}
               getUploads={() => {
                 this.props.uploadActions.getUploads(this.props.video.id)
-                this.props.uploadActions.resetS3Upload(); // reset status to 'idle'
-
               }}
               startSubtitleFileUpload={this.props.uploadActions.startSubtitleFileUpload}
               deleteSubtitle={this.props.uploadActions.deleteSubtitle}
               permissions={getStore().getState().config.permissions}
+              resetS3UploadStatus={this.props.uploadActions.resetS3UploadStatus}
             />
           </div>
         </div>

--- a/public/video-ui/src/pages/Upload/index.jsx
+++ b/public/video-ui/src/pages/Upload/index.jsx
@@ -10,11 +10,9 @@ import PlutoProjectLink from '../../components/Pluto/PlutoProjectLink';
 
 class VideoUpload extends React.Component {
   hasCategories = () =>
-    this.props &&
-    this.props.youtube &&
-    this.props.youtube.categories.length !== 0;
+    this.props.youtube?.categories?.length !== 0;
   hasChannels = () =>
-    this.props.youtube && this.props.youtube.channels.length !== 0;
+    this.props.youtube?.channels?.length !== 0;
 
   componentWillMount() {
     this.props.videoActions.getVideo(this.props.params.id);
@@ -28,9 +26,9 @@ class VideoUpload extends React.Component {
 
   render() {
     const uploading = this.props.s3Upload.total > 0;
-    const activeVersion = this.props.video ? this.props.video.activeVersion : 0;
+    const activeVersion = this.props.video?.activeVersion  ?? 0;
 
-    const projectId = this.props.video.plutoData && this.props.video.plutoData.projectId;
+    const projectId = this.props.video?.plutoData?.projectId;
 
     return (
       <div>
@@ -80,8 +78,11 @@ class VideoUpload extends React.Component {
                   this.props.video.id,
                   version
                 )}
-              getUploads={() =>
-                this.props.uploadActions.getUploads(this.props.video.id)}
+              getUploads={() => {
+                this.props.uploadActions.getUploads(this.props.video.id)
+                this.props.uploadActions.resetS3Upload(); // reset status to 'idle'
+
+              }}
               startSubtitleFileUpload={this.props.uploadActions.startSubtitleFileUpload}
               deleteSubtitle={this.props.uploadActions.deleteSubtitle}
               permissions={getStore().getState().config.permissions}

--- a/public/video-ui/src/reducers/s3UploadReducer.js
+++ b/public/video-ui/src/reducers/s3UploadReducer.js
@@ -1,4 +1,5 @@
 const EMPTY = { id: null, progress: 0, total: 0 };
+const EMPTY = { id: null, progress: 0, total: 0, status: 'idle' };
 
 // This key covers the first part of a video upload where we put the video into S3 from the client browser.
 // We hold that progress in a separate state key from the progress of uploading to YouTube on the server side.
@@ -10,19 +11,25 @@ export default function s3Upload(state = EMPTY, action) {
       return Object.assign({}, state, {
         id: action.upload.id,
         total: total
+        total: total,
+        status: 'uploading'
       });
     }
 
     case 'UPLOAD_PROGRESS':
       return Object.assign({}, state, { progress: action.progress });
+      return Object.assign({}, state, { progress: action.progress, status: 'uploading' });
 
     case 'UPLOAD_COMPLETE':
       return EMPTY;
+      return {...EMPTY, status: 'complete'};
 
     case 'SHOW_ERROR':
       return EMPTY;
+      return {...EMPTY, status: 'error'};
 
-    default:
+
+      default:
       return state;
   }
 }

--- a/public/video-ui/src/reducers/s3UploadReducer.js
+++ b/public/video-ui/src/reducers/s3UploadReducer.js
@@ -1,4 +1,3 @@
-const EMPTY = { id: null, progress: 0, total: 0 };
 const EMPTY = { id: null, progress: 0, total: 0, status: 'idle' };
 
 // This key covers the first part of a video upload where we put the video into S3 from the client browser.
@@ -10,24 +9,22 @@ export default function s3Upload(state = EMPTY, action) {
       const total = action.upload.parts[action.upload.parts.length - 1].end;
       return Object.assign({}, state, {
         id: action.upload.id,
-        total: total
         total: total,
         status: 'uploading'
       });
     }
 
     case 'UPLOAD_PROGRESS':
-      return Object.assign({}, state, { progress: action.progress });
       return Object.assign({}, state, { progress: action.progress, status: 'uploading' });
 
     case 'UPLOAD_COMPLETE':
-      return EMPTY;
       return {...EMPTY, status: 'complete'};
 
     case 'SHOW_ERROR':
-      return EMPTY;
       return {...EMPTY, status: 'error'};
 
+    case 'UPLOAD_RESET':
+      return { ...EMPTY };
 
       default:
       return state;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Allows the UI to refresh once a subtitle track has been successfully added, deleted or replaced in S3. 

To achieve this, a status key has been added to the s3 upload reducer to indicate progress. Dispatching an uploading status triggers a fresh call to get uploads.

This PR also addresses a bug where the same subtitle track could not be re-uploaded if it had been deleted. To resolve this, we make sure the input value is cleared after success or failure. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Ensure you have the MAMA subtitle permissions set to true via the permissions tool.

Run MAM and add/delete/replace a subtitle track attached to a video. Note the UI updating accordingly.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

https://github.com/user-attachments/assets/e309c3c0-b3eb-4806-8e37-82df2bf2da88


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
