### PR TITLE
Reverts the video image to the previous version on failure

### DIFF
--- a/public/video-ui/src/components/VideoImages/VideoImages.jsx
+++ b/public/video-ui/src/components/VideoImages/VideoImages.jsx
@@ -9,15 +9,17 @@ export default class VideoImages extends React.Component {
     gridDomain: PropTypes.string.isRequired,
     video: PropTypes.object.isRequired,
     saveAndUpdateVideo: PropTypes.func.isRequired,
+    updateVideo: PropTypes.func.isRequired,
     videoEditOpen: PropTypes.bool.isRequired,
     updateErrors: PropTypes.func.isRequired
   };
 
   saveAndUpdateVideoImage = (image, location) => {
+    const revertVideo = Object.assign({}, this.props.video);
     const newVideo = Object.assign({}, this.props.video, {
       [location]: image
     });
-    this.props.saveAndUpdateVideo(newVideo);
+    this.props.saveAndUpdateVideo(newVideo).catch(() => this.props.updateVideo(revertVideo));
   };
 
   getGridUrl(cropType) {

--- a/public/video-ui/src/pages/Video/index.jsx
+++ b/public/video-ui/src/pages/Video/index.jsx
@@ -93,6 +93,7 @@ class VideoDisplay extends React.Component {
       <VideoImages
         gridDomain={this.props.config.gridUrl}
         video={this.props.video || {}}
+        updateVideo={this.updateVideo}
         saveAndUpdateVideo={this.saveAndUpdateVideo}
         videoEditOpen={this.props.videoEditOpen}
         updateErrors={this.props.formErrorActions.updateFormErrors}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
As a follow-on from #1232. This PR prevents failed crop changes being applied, instead reverting to the previous version of the save was not sucessful:

| Before | After |
|--------|--------|
| ![2025-08-11 10 55 50](https://github.com/user-attachments/assets/c85eeb1d-c752-4170-b178-3bd179e937a3) | ![2025-08-11 10 56 26](https://github.com/user-attachments/assets/03013655-2927-4baa-a0de-b54347a28320) |

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Testable locally and in CODE. When selecting an image results in a save failed state, you should notice the UI no longer updates the previewed crop. 

To replicate a save failure, either:

- Block outbound network requests
- Delete your auth cookies
- Use the network throttling debug tools

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
When a crop fails to update, the UI reverts to the previous (non-updated) state.
