### PR TITLE
Fiddle with CSS to show progress text in consistent box height

### DIFF
--- a/public/video-ui/src/components/VideoUpload/VideoAsset.jsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.jsx
@@ -203,11 +203,10 @@ export function Asset({videoId, upload, isActive, selectAsset, deleteAsset, star
   if (processing && asset) {
     return (
       <div className="video-trail__item">
-        <div className="upload">
+        <div className="upload__progress">
           <AssetProgress {...processing} />
+          <p>{processing.status}</p>
         </div>
-        <div></div>
-        <div className="upload">{processing.status}</div>
         <div className="video-trail__item__details">
           <AssetControls user={user} selectAsset={selectAsset} deleteAsset={deleteAsset}>
             <AssetInfo info={info} timestamp={timestamp} />

--- a/public/video-ui/styles/layout/_upload.scss
+++ b/public/video-ui/styles/layout/_upload.scss
@@ -33,6 +33,14 @@
   }
 }
 
+.upload__progress {
+  display: grid;
+  align-items: center;
+  justify-items: center;
+  height: 250px;
+  color: white;
+}
+
 .upload__link {
   display: none;
 }


### PR DESCRIPTION

<img width="972" height="810" alt="image" src="https://github.com/user-attachments/assets/2811e091-4ee7-43af-ac23-810fefd24c5e" />

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
