### PR TITLE
Separate styles for the upload feedback and asset display

### DIFF
--- a/public/video-ui/src/components/VideoUpload/VideoAsset.jsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.jsx
@@ -70,7 +70,7 @@ function AssetDisplay({id, isActive, sources}) {
   const embed = id ? <YouTubeEmbed id={id} largePreview={true}/> : <VideoEmbed sources={sources}/>
 
   return (
-    <div className={"video-trail__upload"}>
+    <div className={"video-trail__asset"}>
       {embed}
       {id &&
         <a className={'upload__link'}
@@ -93,7 +93,7 @@ function AssetDisplay({id, isActive, sources}) {
 function AssetProgress({ failed, current, total }) {
   if (failed) {
     return (
-      <div className="upload">
+      <div>
         <p>
           <strong>Upload Failed</strong>
         </p>
@@ -203,11 +203,10 @@ export function Asset({videoId, upload, isActive, selectAsset, deleteAsset, star
   if (processing && asset) {
     return (
       <div className="video-trail__item">
-        <div className="upload">
+        <div className="video-trail__upload">
           <AssetProgress {...processing} />
+          <div>{processing.status}</div>
         </div>
-        <div></div>
-        <div className="upload">{processing.status}</div>
         <div className="video-trail__item__details">
           <AssetControls user={user} selectAsset={selectAsset} deleteAsset={deleteAsset}>
             <AssetInfo info={info} timestamp={timestamp} />
@@ -221,7 +220,7 @@ export function Asset({videoId, upload, isActive, selectAsset, deleteAsset, star
   if (processing) {
     return (
       <div className="video-trail__item">
-        <div className="upload">
+        <div className="video-trail__upload">
           <AssetProgress {...processing} />
         </div>
         <div className="video-trail__item__details">

--- a/public/video-ui/styles/components/_video-trail.scss
+++ b/public/video-ui/styles/components/_video-trail.scss
@@ -8,10 +8,18 @@
 
 }
 
+.video-trail__asset{
+  display: flex;
+  height: 250px;
+}
+
 .video-trail__upload{
   display: flex;
-  height:250px;
-  color: #fff;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  height: 250px;
+  row-gap: 20px;
 }
 
 .video-trail__status__overlay {


### PR DESCRIPTION
The UI for the upload feedback and for the asset display is different so the CSS has been decoupled. As part of this, further styling has been added to upload feedback so that the detail is centred on the card.

**Before**
<img width="919" height="689" alt="Screenshot 2025-08-13 at 18 37 00" src="https://github.com/user-attachments/assets/b5f7525a-faba-4fe7-bd2a-2df8a2ab058c" />

**After** 
<img width="893" height="519" alt="Screenshot 2025-08-13 at 18 30 54" src="https://github.com/user-attachments/assets/1c91dead-ba2f-4593-9255-0af07e2e1761" />
