### PR TITLE
ensure final thrift asset contains .m3u8 extension

### DIFF
--- a/app/util/UploadBuilder.scala
+++ b/app/util/UploadBuilder.scala
@@ -63,11 +63,11 @@ object UploadBuilder {
       // YouTube assets are added after they have been uploaded (once we know the ID)
       None
     } else {
-      val mp4Key = TranscoderOutputKey(title, id, Some("mp4")).toString
+      val mp4Key = TranscoderOutputKey(title, id, "mp4").toString
       val mp4Source = if (includeMp4) Some(VideoSource(mp4Key, "video/mp4")) else None
 
       // m3u8 has multiple file extensions, let it sort itself out
-      val m3u8Key = TranscoderOutputKey(title, id, None).toString
+      val m3u8Key = TranscoderOutputKey(title, id, "m3u8").toString
       val m3u8Source = if (includeM3u8) Some(VideoSource(m3u8Key, "application/vnd.apple.mpegurl")) else None
       val sources = mp4Source ++ m3u8Source
       Some(SelfHostedAsset(sources.toList))

--- a/common/src/main/scala/com/gu/media/upload/UploadKeys.scala
+++ b/common/src/main/scala/com/gu/media/upload/UploadKeys.scala
@@ -15,15 +15,12 @@ case class CompleteUploadKey(folder: String, id: String) {
   override def toString = s"$folder/$id/complete"
 }
 
-case class TranscoderOutputKey(prefix: String, title: String, id: String, extension: Option[String]) {
-  override def toString = extension match {
-    case Some(ext) => s"$prefix/$title--$id.$ext"
-    case None => s"$prefix/$title--$id"
-  }
+case class TranscoderOutputKey(prefix: String, title: String, id: String, extension: String) {
+  override def toString = s"$prefix/$title--$id.$extension"
 }
 
 object TranscoderOutputKey {
-  def apply(title: String, id: String, extension: Option[String]): TranscoderOutputKey = {
+  def apply(title: String, id: String, extension: String): TranscoderOutputKey = {
     val now = ZonedDateTime.now(ZoneOffset.UTC)
     val prefix = now.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"))
 

--- a/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
@@ -61,7 +61,15 @@ class AddAssetToAtom extends LambdaWithParams[Upload, Upload] with DynamoAccess 
 
       case Some(SelfHostedAsset(sources)) =>
         SelfHostedAsset(sources.map { source =>
-          source.copy(src = s"$selfHostedOrigin/${URLEncoder.encode(source.src, "UTF-8")}")
+          val parts = source.src.split("/")
+          parts.length match {
+            case 1 =>
+              source.copy(src = s"$selfHostedOrigin/${URLEncoder.encode(source.src, "UTF-8")}")
+            case _ =>
+              val filename = parts.last
+              val path = parts.dropRight(1).mkString("/")
+              source.copy(src = s"$selfHostedOrigin/$path/${URLEncoder.encode(filename, "UTF-8")}")
+          }
         })
 
       case None =>

--- a/uploader/src/main/scala/com/gu/media/upload/SendToTranscoderV2.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/SendToTranscoderV2.scala
@@ -80,9 +80,10 @@ class SendToTranscoderV2 extends LambdaWithParams[Upload, Upload]
         new OutputGroup().withOutputGroupSettings(outputGroupSettings)
 
       case VideoSource(output, "application/vnd.apple.mpegurl") =>
+        val filenameWithoutM3u8 = if (output.endsWith(".m3u8")) output.dropRight(5) else output
         val outputGroupSettings = new OutputGroupSettings()
           .withHlsGroupSettings(new HlsGroupSettings()
-            .withDestination(s"s3://${destinationBucket}/$output")
+            .withDestination(s"s3://${destinationBucket}/$filenameWithoutM3u8")
             .withSegmentLength(10)
             .withMinSegmentLength(0)
           )


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
