### PR TITLE
Fixes duplicate atom create requests issue

### DIFF
--- a/public/video-ui/src/pages/Video/index.jsx
+++ b/public/video-ui/src/pages/Video/index.jsx
@@ -239,8 +239,11 @@ class VideoDisplay extends React.Component {
       video,
       usages,
       workflow,
-      publishedVideo
+      publishedVideo,
+      saveState
     } = this.props;
+
+    const { saving } = this.props.saveState;
 
     const {
       isCreateMode,
@@ -290,8 +293,8 @@ class VideoDisplay extends React.Component {
                 // Error handling is done in the saveVideo action
               });
           }}
-          canSave={() => !this.formHasErrors(formNames.videoData)}
-          canCancel={() => !isCreateMode}
+          canSave={() => !this.formHasErrors(formNames.videoData) && !saving}
+          canCancel={() => !isCreateMode && !saving}
           video={video}
           updateVideo={this.updateVideo}
           updateErrors={this.props.formErrorActions.updateFormErrors}
@@ -325,7 +328,8 @@ class VideoDisplay extends React.Component {
                 // Error handling is done in the saveVideo action
               });
           }}
-          canSave={() => !this.formHasErrors(formNames.youtubeFurniture)}
+          canSave={() => !this.formHasErrors(formNames.youtubeFurniture) && !saving}
+          canCancel={() => !saving}
           video={video}
           updateVideo={this.updateVideo}
           updateErrors={this.props.formErrorActions.updateFormErrors}
@@ -349,7 +353,8 @@ class VideoDisplay extends React.Component {
                 // Error handling should be implemented in workflow actions
               });
           }}
-          canSave={() => workflow.status.section && workflow.status.status}
+          canSave={() => workflow.status.section && workflow.status.status && !saving}
+          canCancel={() => !saving}
           video={video}
           isTrackedInWorkflow={workflow.status.isTrackedInWorkflow || false}
         />
@@ -419,6 +424,7 @@ import * as updateWorkflowData
   from '../../actions/WorkflowActions/updateWorkflowData';
 import {getYouTubeEmbedUrl} from "../../components/utils/YouTubeEmbed";
 import {getComposerId} from "../../util/getComposerData";
+import {saveStateVals} from "../../constants/saveStateVals";
 
 function mapStateToProps(state) {
   return {
@@ -429,7 +435,8 @@ function mapStateToProps(state) {
     publishedVideo: state.publishedVideo,
     videoEditOpen: state.videoEditOpen,
     checkedFormFields: state.checkedFormFields,
-    workflow: state.workflow
+    workflow: state.workflow,
+    saveState: state.saveState
   };
 }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Introduced by #1232, which waits until the save request return successfully before transitioning to the non-editable view of forms. This introduced the potential for a user to press save multiple times whilst a request is inflight, especially in the case of poor network connectivity. 

This PR improves the situation by preventing further save requests if a save is already inflight:

| Before | After |
|--------|--------|
| ![2025-08-18 10 15 15](https://github.com/user-attachments/assets/742b0eea-5b95-42a5-922a-61414a643cef) | ![2025-08-18 10 16 48](https://github.com/user-attachments/assets/ec913c3e-1c9f-4cf4-b179-d7267021dd66) | 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Testable locally when creating or updating atoms. Use browser network throttling to slow requests down and attempt to save atom changes by repeatedly pressing the save button. 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users are prevented from making multiple duplicate save requests.
