### PR TITLE
upgrade aws sdk v2 to latest version to get updated netty dep

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import scala.sys.process.*
 
 val scroogeVersion = "4.12.0"
 val awsVersion = "1.11.1034"
-val awsV2Version = "2.30.38"
+val awsV2Version = "2.32.26"
 val pandaVersion = "7.0.0"
 val atomMakerVersion = "2.0.0"
 val typesafeConfigVersion = "1.4.0" // to match what we get from Play transitively


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Resolve https://github.com/guardian/media-atom-maker/security/dependabot/205 by upgrading the v2 aws sdk to latest. (Not really a vulnerability since we don't offer an http2 server, but hey ho)

## How to test

- [x] Run on CODE and check MAM continues to operate as expected.
