### PR TITLE
Media Atom Maker - minor version for subtitle uploads

### DIFF
--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -193,7 +193,7 @@ class UploadController(override val authActions: HMACAuthActions, awsConfig: AWS
    * @return
    */
   private def processSubtitleChange(upload: Upload): Unit = {
-    val executionName = s"${upload.id}.${upload.metadata.subtitleVersion.getOrElse(1L)}"
+    val executionName = s"${upload.id}.${Upload.getCurrentSubtitleVersion(upload)}"
     stepFunctions.start(upload, Some(executionName))
   }
 

--- a/app/model/commands/SubtitleFileDeleteCommand.scala
+++ b/app/model/commands/SubtitleFileDeleteCommand.scala
@@ -23,14 +23,10 @@ case class SubtitleFileDeleteCommand(
   awsConfig: AWSConfig
 ) extends Command with Logging {
 
-  override type T = Upload
+  override type T = Unit
 
-  override def process(): Upload = {
-
+  override def process(): Unit = {
     // remove subtitle files from S3
     SubtitleUtil.deleteSubtitlesFromUserUploadBucket(upload, awsConfig)
-
-    // remove subtitle files from upload asset's list of sources
-    SubtitleUtil.updateSubtitleSourceOnUpload(upload, None)
   }
 }

--- a/app/model/commands/SubtitleFileUploadCommand.scala
+++ b/app/model/commands/SubtitleFileUploadCommand.scala
@@ -30,9 +30,9 @@ case class SubtitleFileUploadCommand(
   awsConfig: AWSConfig
 ) extends Command with Logging {
 
-  override type T = Upload
+  override type T = VideoSource
 
-  override def process(): Upload = {
+  override def process(): VideoSource = {
 
     // remove any existing subtitle files from S3
     SubtitleUtil.deleteSubtitlesFromUserUploadBucket(upload, awsConfig)
@@ -47,8 +47,7 @@ case class SubtitleFileUploadCommand(
 
     awsConfig.s3Client.putObject(request) match {
       case _: PutObjectResult =>
-        // add subtitle file to upload asset's list of sources
-        SubtitleUtil.updateSubtitleSourceOnUpload(upload, Some(VideoSource(key, metadata.getContentType)))
+        VideoSource(key, metadata.getContentType)
       case _ => SubtitleFileUploadFailed
     }
   }

--- a/app/util/SubtitleUtil.scala
+++ b/app/util/SubtitleUtil.scala
@@ -4,6 +4,7 @@ import com.amazonaws.services.s3.model.DeleteObjectRequest
 import com.gu.media.logging.Logging
 import com.gu.media.model.VideoSource
 import com.gu.media.upload.model.Upload
+import util.UploadBuilder.getAsset
 
 /**
  * These functions help to manipulate the subtitle source file given an `upload` object, which represents the
@@ -36,8 +37,7 @@ object SubtitleUtil extends Logging {
     }
   }
 
-  def updateSubtitleSourceOnUpload(upload: Upload, newSubtitleSource: Option[VideoSource]): Upload = {
-    val updatedMetadata = upload.metadata.copy(subtitleSource = newSubtitleSource)
-    upload.copy(metadata = updatedMetadata)
+  def getNextSubtitleVersion(upload: Upload): Long = {
+    upload.metadata.subtitleVersion.map(v => v + 1).getOrElse(1L)
   }
 }

--- a/app/util/SubtitleUtil.scala
+++ b/app/util/SubtitleUtil.scala
@@ -2,9 +2,7 @@ package util
 
 import com.amazonaws.services.s3.model.DeleteObjectRequest
 import com.gu.media.logging.Logging
-import com.gu.media.model.VideoSource
 import com.gu.media.upload.model.Upload
-import util.UploadBuilder.getAsset
 
 /**
  * These functions help to manipulate the subtitle source file given an `upload` object, which represents the
@@ -35,9 +33,5 @@ object SubtitleUtil extends Logging {
           log.warn("error deleting subtitle file", e)
       }
     }
-  }
-
-  def getNextSubtitleVersion(upload: Upload): Long = {
-    upload.metadata.subtitleVersion.map(v => v + 1).getOrElse(1L)
   }
 }

--- a/app/util/UploadBuilder.scala
+++ b/app/util/UploadBuilder.scala
@@ -6,7 +6,6 @@ import com.gu.media.model.{MediaAtom, PlutoSyncMetadataMessage, SelfHostedAsset,
 import com.gu.media.upload.{TranscoderOutputKey, UploadPartKey}
 import com.gu.media.upload.model._
 import model.commands.CommandExceptions.AtomMissingYouTubeChannel
-import util.SubtitleUtil.getNextSubtitleVersion
 
 object UploadBuilder {
   def build(atom: MediaAtom, email: String, version: Long, request: UploadRequest, aws: AwsAccess with UploadAccess): Upload = {
@@ -48,7 +47,7 @@ object UploadBuilder {
    */
   def buildForSubtitleChange(upload: Upload, newSubtitleSource: Option[VideoSource]): Upload = {
     val version = upload.metadata.version.getOrElse(1L)
-    val newSubtitleVersion = getNextSubtitleVersion(upload)
+    val newSubtitleVersion = Upload.getNextSubtitleVersion(upload)
     val updatedAsset = getAsset(upload.metadata.selfHost, upload.metadata.title, upload.metadata.pluto.atomId, version, newSubtitleVersion)
     upload.copy(
       metadata = upload.metadata.copy(asset = updatedAsset, subtitleSource = newSubtitleSource, subtitleVersion = Some(newSubtitleVersion)),

--- a/app/util/UploadBuilder.scala
+++ b/app/util/UploadBuilder.scala
@@ -6,6 +6,7 @@ import com.gu.media.model.{MediaAtom, PlutoSyncMetadataMessage, SelfHostedAsset,
 import com.gu.media.upload.{TranscoderOutputKey, UploadPartKey}
 import com.gu.media.upload.model._
 import model.commands.CommandExceptions.AtomMissingYouTubeChannel
+import util.SubtitleUtil.getNextSubtitleVersion
 
 object UploadBuilder {
   def build(atom: MediaAtom, email: String, version: Long, request: UploadRequest, aws: AwsAccess with UploadAccess): Upload = {
@@ -21,7 +22,7 @@ object UploadBuilder {
       pluto = plutoData,
       selfHost = request.selfHost,
       runtime = getRuntimeMetadata(request.selfHost, atom.channelId),
-      asset = getAsset(request.selfHost, atom.title, id),
+      asset = getAsset(request.selfHost, atom.title, atom.id, version, subtitleVersion = 0),
       originalFilename = Some(request.filename),
       version = Some(version),
       startTimestamp = Some(Instant.now().toEpochMilli)
@@ -45,10 +46,12 @@ object UploadBuilder {
    * @param upload
    * @return
    */
-  def buildForSubtitleChange(upload: Upload): Upload = {
-    val updatedAsset = getAsset(upload.metadata.selfHost, upload.metadata.title, upload.id)
+  def buildForSubtitleChange(upload: Upload, newSubtitleSource: Option[VideoSource]): Upload = {
+    val version = upload.metadata.version.getOrElse(1L)
+    val newSubtitleVersion = getNextSubtitleVersion(upload)
+    val updatedAsset = getAsset(upload.metadata.selfHost, upload.metadata.title, upload.metadata.pluto.atomId, version, newSubtitleVersion)
     upload.copy(
-      metadata = upload.metadata.copy(asset = updatedAsset),
+      metadata = upload.metadata.copy(asset = updatedAsset, subtitleSource = newSubtitleSource, subtitleVersion = Some(newSubtitleVersion)),
       progress = upload.progress.copy(fullyTranscoded = false)
     )
   }
@@ -56,17 +59,21 @@ object UploadBuilder {
   private def getAsset(
         selfHosted: Boolean,
         title: String,
-        id: String,
+        atomId: String,
+        version: Long,
+        subtitleVersion: Long,
         includeMp4: Boolean = true,
         includeM3u8: Boolean = true): Option[SelfHostedAsset] = {
     if(!selfHosted) {
       // YouTube assets are added after they have been uploaded (once we know the ID)
       None
     } else {
-      val mp4Key = TranscoderOutputKey(title, id, "mp4").toString
+      // mp4 output doesn't change with subtitle processing, so s3 key stays at minor version 0
+      val mp4Key = TranscoderOutputKey(title, atomId, version, 0, "mp4").toString
       val mp4Source = if (includeMp4) Some(VideoSource(mp4Key, "video/mp4")) else None
 
-      val m3u8Key = TranscoderOutputKey(title, id, "m3u8").toString
+      // m3u8 output changes when subtitles are processed, so s3 key includes a subtitle minor version
+      val m3u8Key = TranscoderOutputKey(title, atomId, version, subtitleVersion, "m3u8").toString
       val m3u8Source = if (includeM3u8) Some(VideoSource(m3u8Key, "application/vnd.apple.mpegurl")) else None
       val sources = mp4Source ++ m3u8Source
       Some(SelfHostedAsset(sources.toList))

--- a/app/util/UploadBuilder.scala
+++ b/app/util/UploadBuilder.scala
@@ -8,8 +8,8 @@ import com.gu.media.upload.model._
 import model.commands.CommandExceptions.AtomMissingYouTubeChannel
 
 object UploadBuilder {
-  def build(atom: MediaAtom, email: String, version: Long, request: UploadRequest, aws: AwsAccess with UploadAccess): Upload = {
-    val id = s"${atom.id}-$version"
+  def build(atom: MediaAtom, email: String, assetVersion: Long, request: UploadRequest, aws: AwsAccess with UploadAccess): Upload = {
+    val id = s"${atom.id}-$assetVersion"
 
     val plutoData = PlutoSyncMetadataMessage.build(id, atom, aws, email)
 
@@ -21,9 +21,9 @@ object UploadBuilder {
       pluto = plutoData,
       selfHost = request.selfHost,
       runtime = getRuntimeMetadata(request.selfHost, atom.channelId),
-      asset = getAsset(request.selfHost, atom.title, atom.id, version, subtitleVersion = 0),
+      asset = getAsset(request.selfHost, atom.title, atom.id, assetVersion, subtitleVersion = 0),
       originalFilename = Some(request.filename),
-      version = Some(version),
+      version = Some(assetVersion),
       startTimestamp = Some(Instant.now().toEpochMilli)
     )
 
@@ -46,33 +46,33 @@ object UploadBuilder {
    * @return
    */
   def buildForSubtitleChange(upload: Upload, newSubtitleSource: Option[VideoSource]): Upload = {
-    val majorVersion = upload.metadata.version.getOrElse(1L)
-    val minorVersion = Upload.getNextSubtitleVersion(upload)
-    val updatedAsset = getAsset(upload.metadata.selfHost, upload.metadata.title, upload.metadata.pluto.atomId, majorVersion, minorVersion)
+    val assetVersion = upload.metadata.version.getOrElse(1L)
+    val subtitleVersion = Upload.getNextSubtitleVersion(upload)
+    val updatedAsset = getAsset(upload.metadata.selfHost, upload.metadata.title, upload.metadata.pluto.atomId, assetVersion, subtitleVersion)
     upload.copy(
-      metadata = upload.metadata.copy(asset = updatedAsset, subtitleSource = newSubtitleSource, subtitleVersion = Some(minorVersion)),
+      metadata = upload.metadata.copy(asset = updatedAsset, subtitleSource = newSubtitleSource, subtitleVersion = Some(subtitleVersion)),
       progress = upload.progress.copy(fullyTranscoded = false)
     )
   }
 
   private def getAsset(
-        selfHosted: Boolean,
-        title: String,
-        atomId: String,
-        version: Long,
-        subtitleVersion: Long,
-        includeMp4: Boolean = true,
-        includeM3u8: Boolean = true): Option[SelfHostedAsset] = {
+                        selfHosted: Boolean,
+                        title: String,
+                        atomId: String,
+                        assetVersion: Long,
+                        subtitleVersion: Long,
+                        includeMp4: Boolean = true,
+                        includeM3u8: Boolean = true): Option[SelfHostedAsset] = {
     if(!selfHosted) {
       // YouTube assets are added after they have been uploaded (once we know the ID)
       None
     } else {
-      // mp4 output doesn't change with subtitle processing, so s3 key stays at minor version 0
-      val mp4Key = TranscoderOutputKey(title, atomId, version, 0, "mp4").toString
+      // mp4 output doesn't change with subtitle processing, so s3 key stays at subtitle version 0
+      val mp4Key = TranscoderOutputKey(title, atomId, assetVersion, 0, "mp4").toString
       val mp4Source = if (includeMp4) Some(VideoSource(mp4Key, "video/mp4")) else None
 
-      // m3u8 output changes when subtitles are processed, so s3 key includes a subtitle minor version
-      val m3u8Key = TranscoderOutputKey(title, atomId, version, subtitleVersion, "m3u8").toString
+      // m3u8 output changes when subtitles are processed, so s3 key includes a subtitle version
+      val m3u8Key = TranscoderOutputKey(title, atomId, assetVersion, subtitleVersion, "m3u8").toString
       val m3u8Source = if (includeM3u8) Some(VideoSource(m3u8Key, "application/vnd.apple.mpegurl")) else None
       val sources = mp4Source ++ m3u8Source
       Some(SelfHostedAsset(sources.toList))

--- a/app/util/UploadBuilder.scala
+++ b/app/util/UploadBuilder.scala
@@ -46,11 +46,11 @@ object UploadBuilder {
    * @return
    */
   def buildForSubtitleChange(upload: Upload, newSubtitleSource: Option[VideoSource]): Upload = {
-    val version = upload.metadata.version.getOrElse(1L)
-    val newSubtitleVersion = Upload.getNextSubtitleVersion(upload)
-    val updatedAsset = getAsset(upload.metadata.selfHost, upload.metadata.title, upload.metadata.pluto.atomId, version, newSubtitleVersion)
+    val majorVersion = upload.metadata.version.getOrElse(1L)
+    val minorVersion = Upload.getNextSubtitleVersion(upload)
+    val updatedAsset = getAsset(upload.metadata.selfHost, upload.metadata.title, upload.metadata.pluto.atomId, majorVersion, minorVersion)
     upload.copy(
-      metadata = upload.metadata.copy(asset = updatedAsset, subtitleSource = newSubtitleSource, subtitleVersion = Some(newSubtitleVersion)),
+      metadata = upload.metadata.copy(asset = updatedAsset, subtitleSource = newSubtitleSource, subtitleVersion = Some(minorVersion)),
       progress = upload.progress.copy(fullyTranscoded = false)
     )
   }

--- a/build.sbt
+++ b/build.sbt
@@ -15,11 +15,11 @@ val scanamoVersion = "1.0.0-M28"
 val playJsonExtensionsVersion = "1.0.3"
 val okHttpVersion = "2.4.0"
 
-val scalaTestVersion = "3.0.8"
-val scalaTestPlusPlayVersion = "4.0.3"
-val mockitoVersion = "2.0.97-beta"
+val scalaTestVersion = "3.2.19"
+val scalaTestPlusPlayVersion = "7.0.2"
+val mockitoVersion = "2.0.0"
 val scalaXmlVersion = "2.2.0"
-val scalaCheckVersion = "1.14.0" // to match ScalaTest version
+val scalaCheckVersion = "1.18.0" // to match ScalaTest version
 
 val awsLambdaCoreVersion = "1.1.0"
 val awsLambdaEventsVersion = "1.3.0"
@@ -121,6 +121,7 @@ lazy val common = (project in file("common"))
       "com.amazonaws" % "aws-java-sdk-ses" % awsVersion,
       "com.gu" %% "content-api-client-aws" % "0.7.3",
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
+      "org.scalatestplus" %% "scalacheck-1-18" % "3.2.19.0" % "test",
       "org.jsoup" % "jsoup" % jsoupVersion,
       "com.beachape" %% "enumeratum" % enumeratumVersion,
       "net.logstash.logback" % "logstash-logback-encoder" % "6.6"
@@ -138,7 +139,7 @@ lazy val app = (project in file("."))
       "software.amazon.awssdk" % "sts" % awsV2Version,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
       "org.scalatestplus.play" %% "scalatestplus-play" % scalaTestPlusPlayVersion % "test",
-      "org.mockito" %  "mockito-core" % mockitoVersion % "test",
+      "org.mockito" %%  "mockito-scala" % mockitoVersion % "test",
       "org.scala-lang.modules" %% "scala-xml" % scalaXmlVersion   % "test"
     ),
 

--- a/common/src/main/scala/com/gu/media/model/ClientAsset.scala
+++ b/common/src/main/scala/com/gu/media/model/ClientAsset.scala
@@ -57,7 +57,7 @@ object ClientAsset {
   }
 
   /**
-   * The client asset's id is a string representation of its major version within the atom.
+   * The client asset's id is a string representation of the asset's version within the atom.
    * This method converts the id to a numeric version e.g. to allow sorting
    *
    * @param clientAsset

--- a/common/src/main/scala/com/gu/media/upload/UploadKeys.scala
+++ b/common/src/main/scala/com/gu/media/upload/UploadKeys.scala
@@ -7,6 +7,10 @@ case class UploadKey(folder: String, id: String) {
   override def toString = s"$folder/$id"
 }
 
+case class UploadUri(bucket: String, key: String) {
+  override def toString: String = s"s3://$bucket/$key"
+}
+
 case class UploadPartKey(folder: String, id: String, part: Int) {
   override def toString = s"$folder/$id/parts/$part"
 }
@@ -27,6 +31,11 @@ object TranscoderOutputKey {
     val prefix = now.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"))
 
     TranscoderOutputKey(prefix, title, id, extension)
+  }
+
+  def apply(title: String, atomId: String, version: Long, subtitleVersion: Long, extension: String): TranscoderOutputKey = {
+    val id = s"$atomId-$version.$subtitleVersion"
+    TranscoderOutputKey(title, id, extension)
   }
 
   def stripSpecialCharsInPath(path: String): String =

--- a/common/src/main/scala/com/gu/media/upload/UploadKeys.scala
+++ b/common/src/main/scala/com/gu/media/upload/UploadKeys.scala
@@ -26,11 +26,13 @@ case class TranscoderOutputKey(prefix: String, title: String, id: String, extens
 }
 
 object TranscoderOutputKey {
-  def apply(title: String, id: String, extension: String): TranscoderOutputKey = {
+  def currentDate: String = {
     val now = ZonedDateTime.now(ZoneOffset.UTC)
-    val prefix = now.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"))
+    now.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"))
+  }
 
-    TranscoderOutputKey(prefix, title, id, extension)
+  def apply(title: String, id: String, extension: String): TranscoderOutputKey = {
+    TranscoderOutputKey(currentDate, title, id, extension)
   }
 
   def apply(title: String, atomId: String, version: Long, subtitleVersion: Long, extension: String): TranscoderOutputKey = {

--- a/common/src/main/scala/com/gu/media/upload/UploadKeys.scala
+++ b/common/src/main/scala/com/gu/media/upload/UploadKeys.scala
@@ -35,8 +35,8 @@ object TranscoderOutputKey {
     TranscoderOutputKey(currentDate, title, id, extension)
   }
 
-  def apply(title: String, atomId: String, version: Long, subtitleVersion: Long, extension: String): TranscoderOutputKey = {
-    val id = s"$atomId-$version.$subtitleVersion"
+  def apply(title: String, atomId: String, assetVersion: Long, subtitleVersion: Long, extension: String): TranscoderOutputKey = {
+    val id = s"$atomId-$assetVersion.$subtitleVersion"
     TranscoderOutputKey(title, id, extension)
   }
 

--- a/common/src/main/scala/com/gu/media/upload/model/Upload.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/Upload.scala
@@ -2,6 +2,7 @@ package com.gu.media.upload.model
 
 import com.gu.ai.x.play.json.Jsonx
 import com.gu.ai.x.play.json.Encoders._
+import com.gu.media.upload.UploadUri
 import play.api.libs.json.Format
 
 // All data is conceptually immutable except UploadProgress
@@ -23,6 +24,12 @@ object Upload {
         bigChunks :+ (start, start + remainder)
     }
   }
+
+  def videoInputUri(upload: Upload): UploadUri =
+    UploadUri(upload.metadata.bucket, upload.metadata.pluto.s3Key)
+
+  def subtitleInputUri(upload: Upload): Option[UploadUri] =
+    upload.metadata.subtitleSource.map(s => UploadUri(upload.metadata.bucket, s.src))
 
   private def chunksOfExactly(chunkSize: Long, size: Long): (List[(Long, Long)], Long) = {
     val numParts = (size / chunkSize).toInt

--- a/common/src/main/scala/com/gu/media/upload/model/Upload.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/Upload.scala
@@ -31,6 +31,12 @@ object Upload {
   def subtitleInputUri(upload: Upload): Option[UploadUri] =
     upload.metadata.subtitleSource.map(s => UploadUri(upload.metadata.bucket, s.src))
 
+  def getCurrentSubtitleVersion(upload: Upload): Long =
+    upload.metadata.subtitleVersion.getOrElse(0L)
+
+  def getNextSubtitleVersion(upload: Upload): Long =
+    upload.metadata.subtitleVersion.map(v => v + 1).getOrElse(1L)
+
   private def chunksOfExactly(chunkSize: Long, size: Long): (List[(Long, Long)], Long) = {
     val numParts = (size / chunkSize).toInt
     val remainder = size % chunkSize

--- a/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
@@ -17,7 +17,8 @@ case class UploadMetadata(
   asset: Option[VideoAsset] = None,
   originalFilename: Option[String] = None,
   startTimestamp: Option[Long] = None, // unix timestamp
-  subtitleSource: Option[VideoSource] = None
+  subtitleSource: Option[VideoSource] = None,
+  subtitleVersion: Option[Long] = None
 )
 
 sealed abstract class RuntimeUploadMetadata

--- a/common/src/test/scala/com/gu/media/model/AdSettingsTest.scala
+++ b/common/src/test/scala/com/gu/media/model/AdSettingsTest.scala
@@ -1,8 +1,9 @@
 package com.gu.media.model
 
-import org.scalatest.{FunSuite, MustMatchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers
 
-class AdSettingsTest extends FunSuite with MustMatchers {
+class AdSettingsTest extends AnyFunSuite with Matchers {
   private val initialAtom = MediaAtom(
     id = "test",
     labels = List.empty,

--- a/common/src/test/scala/com/gu/media/model/MediaAtomTest.scala
+++ b/common/src/test/scala/com/gu/media/model/MediaAtomTest.scala
@@ -1,10 +1,11 @@
 package com.gu.media.model
 
-import org.scalatest.{FunSuite, MustMatchers}
 import com.gu.contentatom.thrift.{AtomData, Atom => ThriftAtom, AtomType => ThriftAtomType, ContentChangeDetails => ThriftContentChangeDetails}
 import com.gu.contentatom.thrift.atom.media.{Category => ThriftMediaCategory, MediaAtom => ThriftMediaAtom, Metadata => ThriftMetaData, YoutubeData => ThriftYoutubeData}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers
 
-class MediaAtomTest extends FunSuite with MustMatchers {
+class MediaAtomTest extends AnyFunSuite with Matchers {
   private val htmlDescription =
     """
       |<p>

--- a/common/src/test/scala/com/gu/media/pluto/PlutoItemTest.scala
+++ b/common/src/test/scala/com/gu/media/pluto/PlutoItemTest.scala
@@ -1,9 +1,10 @@
 package com.gu.media.pluto
 
 import com.gu.media.pluto.PlutoItem.numericIdsOnlyFilter
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class PlutoItemTest extends FunSuite with Matchers {
+class PlutoItemTest extends AnyFunSuite with Matchers {
 
   test("numericIdsOnlyFilter must filter out items with non-numeric IDs") {
     val numericItems = List(

--- a/common/src/test/scala/com/gu/media/upload/UploadKeyTest.scala
+++ b/common/src/test/scala/com/gu/media/upload/UploadKeyTest.scala
@@ -35,6 +35,7 @@ class UploadKeyTest extends FlatSpec with Matchers {
   "TranscoderOutputKey" should "include major and minor versions for the atom" in {
     val key = TranscoderOutputKey("my-title", atomId = "123xyz", version = 2, subtitleVersion = 10, extension = "m3u8")
     key.toString should fullyMatch regex """\d{4}/\d{2}/\d{2}/my-title--123xyz-2.10.m3u8"""
+  }
 
   "TranscoderOutputKey" should "replace special characters with underscores" in {
     TranscoderOutputKey("2025/08/20", "Loop: Japan fireball", id = "1c44ce4e-760a-4312-a803-40939aeea355-2.0", extension = "m3u8")

--- a/common/src/test/scala/com/gu/media/upload/UploadKeyTest.scala
+++ b/common/src/test/scala/com/gu/media/upload/UploadKeyTest.scala
@@ -32,8 +32,8 @@ class UploadKeyTest extends AnyFlatSpec with Matchers {
     key.toString should fullyMatch regex """\d{4}/\d{2}/\d{2}/my-title--123xyz.m3u8"""
   }
 
-  "TranscoderOutputKey" should "include major and minor versions for the atom" in {
-    val key = TranscoderOutputKey("my-title", atomId = "123xyz", version = 2, subtitleVersion = 10, extension = "m3u8")
+  "TranscoderOutputKey" should "include asset and subtitle versions for the atom" in {
+    val key = TranscoderOutputKey("my-title", atomId = "123xyz", assetVersion = 2, subtitleVersion = 10, extension = "m3u8")
     key.toString should fullyMatch regex """\d{4}/\d{2}/\d{2}/my-title--123xyz-2.10.m3u8"""
   }
 

--- a/common/src/test/scala/com/gu/media/upload/UploadKeyTest.scala
+++ b/common/src/test/scala/com/gu/media/upload/UploadKeyTest.scala
@@ -10,6 +10,10 @@ class UploadKeyTest extends FlatSpec with Matchers {
     UploadKey("my-path/with/slashes", "my-file").toString shouldBe "my-path/with/slashes/my-file"
   }
 
+  "UploadUri" should "create an s3:// uri" in {
+    UploadUri("my-bucket", "my-key").toString shouldBe "s3://my-bucket/my-key"
+  }
+
   "UploadPartKey" should "create a numbered key containing the id" in {
     UploadPartKey("my-folder", id = "123xyz", part = 24).toString shouldBe "my-folder/123xyz/parts/24"
   }
@@ -27,6 +31,10 @@ class UploadKeyTest extends FlatSpec with Matchers {
     val key = TranscoderOutputKey("my-title", id = "123xyz", extension = "m3u8")
     key.toString should fullyMatch regex """\d{4}/\d{2}/\d{2}/my-title--123xyz.m3u8"""
   }
+
+  "TranscoderOutputKey" should "include major and minor versions for the atom" in {
+    val key = TranscoderOutputKey("my-title", atomId = "123xyz", version = 2, subtitleVersion = 10, extension = "m3u8")
+    key.toString should fullyMatch regex """\d{4}/\d{2}/\d{2}/my-title--123xyz-2.10.m3u8"""
 
   "TranscoderOutputKey" should "replace special characters with underscores" in {
     TranscoderOutputKey("2025/08/20", "Loop: Japan fireball", id = "1c44ce4e-760a-4312-a803-40939aeea355-2.0", extension = "m3u8")

--- a/common/src/test/scala/com/gu/media/upload/UploadKeyTest.scala
+++ b/common/src/test/scala/com/gu/media/upload/UploadKeyTest.scala
@@ -1,9 +1,9 @@
 package com.gu.media.upload
 
-import org.scalatest.Matchers.regex
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class UploadKeyTest extends FlatSpec with Matchers {
+class UploadKeyTest extends AnyFlatSpec with Matchers {
 
   "UploadKey" should "link a path and filename" in {
     UploadKey("my-path", "my-file").toString shouldBe "my-path/my-file"

--- a/common/src/test/scala/com/gu/media/upload/UploadTest.scala
+++ b/common/src/test/scala/com/gu/media/upload/UploadTest.scala
@@ -2,12 +2,13 @@ package com.gu.media.upload
 
 import com.gu.media.model.{PlutoSyncMetadataMessage, VideoSource}
 import com.gu.media.upload.model.{SelfHostedUploadMetadata, Upload, UploadMetadata, UploadProgress}
-import org.scalatest.{FunSuite, MustMatchers}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import com.gu.media.upload.model.Upload._
 import org.scalacheck.Gen
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class UploadTest extends FunSuite with MustMatchers with GeneratorDrivenPropertyChecks {
+class UploadTest extends AnyFunSuite with Matchers with ScalaCheckDrivenPropertyChecks {
   private val oneHundredGigabytes = oneHundredMegabytes * 1024
   private val fiveMegabytes: Long = 1024 * 1024 * 5
   private val reasonableVideoSize = Gen.choose(fiveMegabytes, oneHundredGigabytes)

--- a/common/src/test/scala/com/gu/media/util/MediaAtomHelpersTest.scala
+++ b/common/src/test/scala/com/gu/media/util/MediaAtomHelpersTest.scala
@@ -2,12 +2,13 @@ package com.gu.media.util
 
 import com.gu.contentatom.thrift.atom.media._
 import com.gu.contentatom.thrift.{Atom, AtomData, AtomType, ContentChangeDetails, User}
-import org.scalatest.{FunSuite, MustMatchers}
 import MediaAtomHelpers._
 import com.gu.media.model.{SelfHostedAsset, VideoSource, YouTubeAsset}
 import org.joda.time.DateTime
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers
 
-class MediaAtomHelpersTest extends FunSuite with MustMatchers {
+class MediaAtomHelpersTest extends AnyFunSuite with Matchers {
   test("add YouTube asset") {
     val startTime = DateTime.now().getMillis
     val newAtom = updateAtom(atom(), user()) { mediaAtom =>

--- a/common/src/test/scala/com/gu/media/youtube/MediaAtomYoutubeDescriptionHandlerTest.scala
+++ b/common/src/test/scala/com/gu/media/youtube/MediaAtomYoutubeDescriptionHandlerTest.scala
@@ -2,9 +2,10 @@ package com.gu.media.youtube
 
 import com.gu.contentatom.thrift.atom.media.{Category => ThriftMediaCategory, MediaAtom => ThriftMediaAtom}
 import com.gu.media.youtube.MediaAtomYoutubeDescriptionHandler.getYoutubeDescription
-import org.scalatest.{FunSuite, MustMatchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers
 
-class MediaAtomYoutubeDescriptionHandlerTest extends FunSuite with MustMatchers {
+class MediaAtomYoutubeDescriptionHandlerTest extends AnyFunSuite with Matchers {
 
   val thriftAtomData = ThriftMediaAtom(
     title = "a title",

--- a/common/src/test/scala/com/gu/media/youtube/YoutubeDescriptionTest.scala
+++ b/common/src/test/scala/com/gu/media/youtube/YoutubeDescriptionTest.scala
@@ -1,8 +1,9 @@
 package com.gu.media.youtube
 
-import org.scalatest.{FunSuite, MustMatchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers
 
-class YoutubeDescriptionTest extends FunSuite with MustMatchers {
+class YoutubeDescriptionTest extends AnyFunSuite with Matchers {
   test("cleaning nothing") {
     YoutubeDescription.clean(None) must be(None)
   }

--- a/common/src/test/scala/com/gu/media/youtube/YoutubeUrlTest.scala
+++ b/common/src/test/scala/com/gu/media/youtube/YoutubeUrlTest.scala
@@ -1,8 +1,9 @@
 package com.gu.media.youtube
 
-import org.scalatest.{FunSuite, MustMatchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers
 
-class YoutubeUrlTest extends FunSuite with MustMatchers {
+class YoutubeUrlTest extends AnyFunSuite with Matchers {
   test("Extract video id from standard YouTube URL") {
     YoutubeUrl.parse("https://www.youtube.com/watch?v=CqUDO-livlc") must be(Some("CqUDO-livlc"))
   }

--- a/expirer/src/test/scala/com/gu/media/ExpirerLambdaTest.scala
+++ b/expirer/src/test/scala/com/gu/media/ExpirerLambdaTest.scala
@@ -4,10 +4,11 @@ import com.amazonaws.util.IOUtils
 import com.gu.contentatom.thrift.atom.media.PrivacyStatus
 import com.gu.media.expirer.ExpirerLambda
 import com.gu.media.model.{AdSettings, VideoUpdateError}
-import org.scalatest.{FunSuite, MustMatchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers
 import play.api.libs.json.{JsValue, Json}
 
-class ExpirerLambdaTest extends FunSuite with MustMatchers {
+class ExpirerLambdaTest extends AnyFunSuite with Matchers {
   test("Make YouTube assets private") {
     val result = capiResult("one-expired-atom-two-yt-assets.json")
     val lambda = new TestExpirerLambda(List(result))

--- a/test/ThriftUtilSpec.scala
+++ b/test/ThriftUtilSpec.scala
@@ -4,11 +4,13 @@ import com.gu.contentatom.thrift._
 import com.gu.contentatom.thrift.atom.media._
 import com.gu.media.util.ThriftUtil
 import org.jsoup.Jsoup
-import org.scalatest.{FunSpec, Inside, Matchers}
+import org.scalatest.Inside
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.xml.XML
 
-class ThriftUtilSpec extends FunSpec
+class ThriftUtilSpec extends AnyFunSpec
     with Matchers
     with Inside {
 

--- a/test/YouTubeSDKCompatibilityCheckSpec.scala
+++ b/test/YouTubeSDKCompatibilityCheckSpec.scala
@@ -3,9 +3,9 @@ import com.google.api.client.http.javanet.NetHttpTransport
 import com.google.api.client.http.{HttpRequestInitializer, HttpTransport}
 import com.google.api.client.json.JsonFactory
 import com.google.api.client.json.gson.GsonFactory
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class YouTubeSDKCompatibilityCheckSpec extends FunSpec {
+class YouTubeSDKCompatibilityCheckSpec extends AnyFunSpec {
 
   val transport: HttpTransport = new NetHttpTransport()
   val jsonFactory: JsonFactory = GsonFactory.getDefaultInstance

--- a/test/model/ClientAssetTest.scala
+++ b/test/model/ClientAssetTest.scala
@@ -3,9 +3,10 @@ package model
 import com.gu.media.model._
 import com.gu.media.upload.model._
 import com.gu.media.youtube.YouTubeProcessingStatus
-import org.scalatest.{FunSuite, MustMatchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers
 
-class ClientAssetTest extends FunSuite with MustMatchers {
+class ClientAssetTest extends AnyFunSuite with Matchers {
   val ytAsset = Asset(AssetType.Video, 1, "12345", Platform.Youtube, None)
   val ytProcessing = YouTubeProcessingStatus("1", "processing", 0, 0, 0, None)
 

--- a/test/model/commands/UpdateAtomCommandTest.scala
+++ b/test/model/commands/UpdateAtomCommandTest.scala
@@ -2,9 +2,10 @@ package model.commands
 
 import com.gu.media.model.{Category, ContentChangeDetails, MediaAtom}
 import model.commands.UpdateAtomCommand.createDiffString
-import org.scalatest.{FunSuite, MustMatchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers
 
-class UpdateAtomCommandTest extends FunSuite with MustMatchers {
+class UpdateAtomCommandTest extends AnyFunSuite with Matchers {
   val mediaAtomFixture: MediaAtom = MediaAtom(
     id = "123",
     labels = List.empty,

--- a/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/test/util/SubtitleUtilTest.scala
+++ b/test/util/SubtitleUtilTest.scala
@@ -1,8 +1,9 @@
 package util
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class SubtitleUtilTest extends FlatSpec with Matchers {
+class SubtitleUtilTest extends AnyFlatSpec with Matchers {
 
   "contentTypeForFilename" should "return the content type based on file extension" in {
     SubtitleUtil.contentTypeForFilename("filename.srt") shouldBe "application/x-subrip"

--- a/test/util/SubtitleUtilTest.scala
+++ b/test/util/SubtitleUtilTest.scala
@@ -1,0 +1,15 @@
+package util
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class SubtitleUtilTest extends FlatSpec with Matchers {
+
+  "contentTypeForFilename" should "return the content type based on file extension" in {
+    SubtitleUtil.contentTypeForFilename("filename.srt") shouldBe "application/x-subrip"
+    SubtitleUtil.contentTypeForFilename("/some/path/filename.srt") shouldBe "application/x-subrip"
+    SubtitleUtil.contentTypeForFilename("filename.vtt.SRT") shouldBe "application/x-subrip"
+    SubtitleUtil.contentTypeForFilename("foo.vtt") shouldBe "text/vtt"
+    SubtitleUtil.contentTypeForFilename("/some/path/foo.VTT") shouldBe "text/vtt"
+    SubtitleUtil.contentTypeForFilename("/some/path/foo.bar") shouldBe "application/octet-stream"
+  }
+}

--- a/test/util/UploadBuilderTest.scala
+++ b/test/util/UploadBuilderTest.scala
@@ -6,10 +6,12 @@ import com.gu.contentatom.thrift.{Atom, AtomData, AtomType, ContentChangeDetails
 import com.gu.media.Settings
 import com.gu.media.aws.{AwsAccess, AwsCredentials, UploadAccess}
 import com.gu.media.model.{MediaAtom, PlutoSyncMetadataMessage, SelfHostedAsset, VideoSource}
+import com.gu.media.upload.TranscoderOutputKey
 import com.gu.media.upload.model.{CopyProgress, SelfHostedUploadMetadata, UploadMetadata, UploadPart, UploadProgress, UploadRequest}
 import com.typesafe.config.Config
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.mockito.MockitoSugar.{when, withObjectSpied}
 import play.api.Configuration
 
 class UploadBuilderTest extends AnyFlatSpec with Matchers {
@@ -25,100 +27,115 @@ class UploadBuilderTest extends AnyFlatSpec with Matchers {
 
   "build" should "create an Upload record for a new self-hosted video upload" in {
     val selfHostVideoRequest = UploadRequest(atomId, "my-video.mp4", 12345L, selfHost=true)
-    val upload = UploadBuilder.build(MediaAtom.fromThrift(atom), "jo.blogs@guardian.co.uk", 2L, selfHostVideoRequest, aws)
 
-    upload.id shouldBe "61e7a4c3-cb36-492d-889c-163abdae68e4-2"
-    upload.parts shouldBe List(
-      UploadPart(key = "uploads/61e7a4c3-cb36-492d-889c-163abdae68e4-2/parts/0", start = 0L, end = 12345L))
+    withObjectSpied[TranscoderOutputKey.type] {
+      when(TranscoderOutputKey.currentDate) thenReturn "2025/08/20"
 
-    upload.metadata.user shouldBe "jo.blogs@guardian.co.uk"
-    upload.metadata.bucket shouldBe "upload-test-bucket"
-    upload.metadata.region shouldBe "eu-west-1"
-    upload.metadata.title shouldBe "Atom Title"
-    upload.metadata.pluto shouldBe PlutoSyncMetadataMessage(
-      `type` = "video-upload",
-      projectId = None,
-      s3Key = "uploads/61e7a4c3-cb36-492d-889c-163abdae68e4-2/complete",
-      atomId = "61e7a4c3-cb36-492d-889c-163abdae68e4",
-      title = "Atom Title",
-      user = "jo.blogs@guardian.co.uk",
-      posterImageUrl = None)
-    upload.metadata.runtime shouldBe SelfHostedUploadMetadata(jobs = List())
-    upload.metadata.version should contain (2L)
-    upload.metadata.selfHost shouldBe true
-    upload.metadata.asset should contain (SelfHostedAsset(sources = List(
-      VideoSource(src = "2025/08/20/Atom Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.0.mp4", mimeType = "video/mp4"),
-      VideoSource(src = "2025/08/20/Atom Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.0.m3u8", mimeType = "application/vnd.apple.mpegurl")
-    )))
-    upload.metadata.originalFilename should contain ("my-video.mp4")
-    upload.metadata.startTimestamp should not be empty
-    upload.metadata.subtitleSource shouldBe empty
-    upload.metadata.subtitleVersion shouldBe empty
+      val upload = UploadBuilder.build(MediaAtom.fromThrift(atom), "jo.blogs@guardian.co.uk", 2L, selfHostVideoRequest, aws)
 
-    upload.progress shouldBe UploadProgress(
-      chunksInS3 = 0,
-      chunksInYouTube = 0,
-      fullyUploaded = false,
-      fullyTranscoded = false,
-      retries = 0,
-      copyProgress = None)
+      upload.id shouldBe "61e7a4c3-cb36-492d-889c-163abdae68e4-2"
+      upload.parts shouldBe List(
+        UploadPart(key = "uploads/61e7a4c3-cb36-492d-889c-163abdae68e4-2/parts/0", start = 0L, end = 12345L))
+
+      upload.metadata.user shouldBe "jo.blogs@guardian.co.uk"
+      upload.metadata.bucket shouldBe "upload-test-bucket"
+      upload.metadata.region shouldBe "eu-west-1"
+      upload.metadata.title shouldBe "Atom Title"
+      upload.metadata.pluto shouldBe PlutoSyncMetadataMessage(
+        `type` = "video-upload",
+        projectId = None,
+        s3Key = "uploads/61e7a4c3-cb36-492d-889c-163abdae68e4-2/complete",
+        atomId = "61e7a4c3-cb36-492d-889c-163abdae68e4",
+        title = "Atom Title",
+        user = "jo.blogs@guardian.co.uk",
+        posterImageUrl = None)
+      upload.metadata.runtime shouldBe SelfHostedUploadMetadata(jobs = List())
+      upload.metadata.version should contain (2L)
+      upload.metadata.selfHost shouldBe true
+      upload.metadata.asset shouldBe Some(SelfHostedAsset(sources = List(
+        VideoSource(src = "2025/08/20/Atom_Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.0.mp4", mimeType = "video/mp4"),
+        VideoSource(src = "2025/08/20/Atom_Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.0.m3u8", mimeType = "application/vnd.apple.mpegurl")
+      )))
+      upload.metadata.originalFilename should contain ("my-video.mp4")
+      upload.metadata.startTimestamp should not be empty
+      upload.metadata.subtitleSource shouldBe empty
+      upload.metadata.subtitleVersion shouldBe empty
+
+      upload.progress shouldBe UploadProgress(
+        chunksInS3 = 0,
+        chunksInYouTube = 0,
+        fullyUploaded = false,
+        fullyTranscoded = false,
+        retries = 0,
+        copyProgress = None)
+    }
   }
 
   "buildForSubtitleChange" should "modify the existing Upload record to reflect a subtitle change" in {
     val selfHostVideoRequest = UploadRequest(atomId, "my-video.mp4", 12345L, selfHost=true)
-    val videoUpload = UploadBuilder.build(MediaAtom.fromThrift(atom), "jo.blogs@guardian.co.uk", 2L, selfHostVideoRequest, aws)
 
-    // simulate a completed video upload by updating the progress record
-    val completedVideoUpload = videoUpload.copy(progress = completedProgress)
+    withObjectSpied[TranscoderOutputKey.type] {
+      when(TranscoderOutputKey.currentDate) thenReturn "2025/08/20"
 
-    // add subtitles
-    val subtitleSource = VideoSource("uploads/61e7a4c3-cb36-492d-889c-163abdae68e4-2/subtitle.srt", "application/x-subrip")
-    val subtitleUpload = UploadBuilder.buildForSubtitleChange(completedVideoUpload, Some(subtitleSource))
+      val videoUpload = UploadBuilder.build(MediaAtom.fromThrift(atom), "jo.blogs@guardian.co.uk", 2L, selfHostVideoRequest, aws)
 
-    // we expect the modified upload record to have bumped the minor version on the m3u8 filename,
-    // stored the subtitle source and version and set the progress to not fully transcoded
-    val expectedAsset = SelfHostedAsset(sources = List(
-      VideoSource(src = "2025/08/20/Atom Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.0.mp4", mimeType = "video/mp4"),
-      VideoSource(src = "2025/08/20/Atom Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.1.m3u8", mimeType = "application/vnd.apple.mpegurl")
-    ))
-    val expectedMetadata = completedVideoUpload.metadata.copy(
-      asset = Some(expectedAsset),
-      subtitleSource = Some(subtitleSource),
-      subtitleVersion = Some(1))
-    val expectedProgress = completedVideoUpload.progress.copy(fullyTranscoded = false)
-    val expected = completedVideoUpload.copy(metadata = expectedMetadata, progress = expectedProgress)
+      // simulate a completed video upload by updating the progress record
+      val completedVideoUpload = videoUpload.copy(progress = completedProgress)
 
-    subtitleUpload shouldBe expected
+      // add subtitles
+      val subtitleSource = VideoSource("uploads/61e7a4c3-cb36-492d-889c-163abdae68e4-2/subtitle.srt", "application/x-subrip")
+      val subtitleUpload = UploadBuilder.buildForSubtitleChange(completedVideoUpload, Some(subtitleSource))
+
+      // we expect the modified upload record to have bumped the minor version on the m3u8 filename,
+      // stored the subtitle source and version and set the progress to not fully transcoded
+      val expectedAsset = SelfHostedAsset(sources = List(
+        VideoSource(src = "2025/08/20/Atom_Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.0.mp4", mimeType = "video/mp4"),
+        VideoSource(src = "2025/08/20/Atom_Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.1.m3u8", mimeType = "application/vnd.apple.mpegurl")
+      ))
+      val expectedMetadata = completedVideoUpload.metadata.copy(
+        asset = Some(expectedAsset),
+        subtitleSource = Some(subtitleSource),
+        subtitleVersion = Some(1))
+      val expectedProgress = completedVideoUpload.progress.copy(fullyTranscoded = false)
+      val expected = completedVideoUpload.copy(metadata = expectedMetadata, progress = expectedProgress)
+
+      subtitleUpload shouldBe expected
+    }
   }
 
   "buildForSubtitleChange" should "modify the existing Upload record to reflect subtitle removal" in {
     val selfHostVideoRequest = UploadRequest(atomId, "my-video.mp4", 12345L, selfHost=true)
-    val videoUpload = UploadBuilder.build(MediaAtom.fromThrift(atom), "jo.blogs@guardian.co.uk", 2L, selfHostVideoRequest, aws)
 
-    // simulate a completed video upload by updating the progress record
-    val completedVideoUpload = videoUpload.copy(progress = completedProgress)
+    withObjectSpied[TranscoderOutputKey.type] {
+      when(TranscoderOutputKey.currentDate) thenReturn "2025/08/20"
 
-    // simulate adding subtitles
-    val subtitleSource = VideoSource("uploads/61e7a4c3-cb36-492d-889c-163abdae68e4-2/subtitle.srt", "application/x-subrip")
-    val subtitleUpload = UploadBuilder.buildForSubtitleChange(completedVideoUpload, Some(subtitleSource))
+      val videoUpload = UploadBuilder.build(MediaAtom.fromThrift(atom), "jo.blogs@guardian.co.uk", 2L, selfHostVideoRequest, aws)
 
-    // remove subtitles
-    val subtitlesRemovedUpload = UploadBuilder.buildForSubtitleChange(subtitleUpload, newSubtitleSource = None)
+      // simulate a completed video upload by updating the progress record
+      val completedVideoUpload = videoUpload.copy(progress = completedProgress)
 
-    // we expect the modified upload record to have bumped the minor version on the m3u8 filename,
-    // removed the subtitle source and set the progress to not fully transcoded
-    val expectedAsset = SelfHostedAsset(sources = List(
-      VideoSource(src = "2025/08/20/Atom Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.0.mp4", mimeType = "video/mp4"),
-      VideoSource(src = "2025/08/20/Atom Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.2.m3u8", mimeType = "application/vnd.apple.mpegurl")
-    ))
-    val expectedMetadata = subtitlesRemovedUpload.metadata.copy(
-      asset = Some(expectedAsset),
-      subtitleSource = None,
-      subtitleVersion = Some(2))
-    val expectedProgress = subtitlesRemovedUpload.progress.copy(fullyTranscoded = false)
-    val expected = subtitlesRemovedUpload.copy(metadata = expectedMetadata, progress = expectedProgress)
+      // simulate adding subtitles
+      val subtitleSource = VideoSource("uploads/61e7a4c3-cb36-492d-889c-163abdae68e4-2/subtitle.srt", "application/x-subrip")
+      val subtitleUpload = UploadBuilder.buildForSubtitleChange(completedVideoUpload, Some(subtitleSource))
 
-    subtitlesRemovedUpload shouldBe expected
+      // remove subtitles
+      val subtitlesRemovedUpload = UploadBuilder.buildForSubtitleChange(subtitleUpload, newSubtitleSource = None)
+
+      // we expect the modified upload record to have bumped the minor version on the m3u8 filename,
+      // removed the subtitle source and set the progress to not fully transcoded
+      val expectedAsset = SelfHostedAsset(sources = List(
+        VideoSource(src = "2025/08/20/Atom_Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.0.mp4", mimeType = "video/mp4"),
+        VideoSource(src = "2025/08/20/Atom_Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.2.m3u8", mimeType = "application/vnd.apple.mpegurl")
+      ))
+      val expectedMetadata = subtitlesRemovedUpload.metadata.copy(
+        asset = Some(expectedAsset),
+        subtitleSource = None,
+        subtitleVersion = Some(2))
+      val expectedProgress = subtitlesRemovedUpload.progress.copy(fullyTranscoded = false)
+      val expected = subtitlesRemovedUpload.copy(metadata = expectedMetadata, progress = expectedProgress)
+
+      subtitlesRemovedUpload shouldBe expected
+    }
   }
 
   private def asset: Asset = Asset(

--- a/test/util/UploadBuilderTest.scala
+++ b/test/util/UploadBuilderTest.scala
@@ -86,7 +86,7 @@ class UploadBuilderTest extends AnyFlatSpec with Matchers {
       val subtitleSource = VideoSource("uploads/61e7a4c3-cb36-492d-889c-163abdae68e4-2/subtitle.srt", "application/x-subrip")
       val subtitleUpload = UploadBuilder.buildForSubtitleChange(completedVideoUpload, Some(subtitleSource))
 
-      // we expect the modified upload record to have bumped the minor version on the m3u8 filename,
+      // we expect the modified upload record to have bumped the subtitle version on the m3u8 filename,
       // stored the subtitle source and version and set the progress to not fully transcoded
       val expectedAsset = SelfHostedAsset(sources = List(
         VideoSource(src = "2025/08/20/Atom_Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.0.mp4", mimeType = "video/mp4"),
@@ -121,7 +121,7 @@ class UploadBuilderTest extends AnyFlatSpec with Matchers {
       // remove subtitles
       val subtitlesRemovedUpload = UploadBuilder.buildForSubtitleChange(subtitleUpload, newSubtitleSource = None)
 
-      // we expect the modified upload record to have bumped the minor version on the m3u8 filename,
+      // we expect the modified upload record to have bumped the subtitle version on the m3u8 filename,
       // removed the subtitle source and set the progress to not fully transcoded
       val expectedAsset = SelfHostedAsset(sources = List(
         VideoSource(src = "2025/08/20/Atom_Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.0.mp4", mimeType = "video/mp4"),

--- a/test/util/UploadBuilderTest.scala
+++ b/test/util/UploadBuilderTest.scala
@@ -8,10 +8,11 @@ import com.gu.media.aws.{AwsAccess, AwsCredentials, UploadAccess}
 import com.gu.media.model.{MediaAtom, PlutoSyncMetadataMessage, SelfHostedAsset, VideoSource}
 import com.gu.media.upload.model.{CopyProgress, SelfHostedUploadMetadata, UploadMetadata, UploadPart, UploadProgress, UploadRequest}
 import com.typesafe.config.Config
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.Configuration
 
-class UploadBuilderTest extends FlatSpec with Matchers {
+class UploadBuilderTest extends AnyFlatSpec with Matchers {
 
   private val atomId = "61e7a4c3-cb36-492d-889c-163abdae68e4"
   private val regionName = "eu-west-1"

--- a/test/util/UploadBuilderTest.scala
+++ b/test/util/UploadBuilderTest.scala
@@ -1,0 +1,166 @@
+package util
+
+import com.amazonaws.regions.{Region, RegionUtils}
+import com.gu.contentatom.thrift.atom.media.{Asset, AssetType, Category, Platform, MediaAtom => ThriftMediaAtom}
+import com.gu.contentatom.thrift.{Atom, AtomData, AtomType, ContentChangeDetails}
+import com.gu.media.Settings
+import com.gu.media.aws.{AwsAccess, AwsCredentials, UploadAccess}
+import com.gu.media.model.{MediaAtom, PlutoSyncMetadataMessage, SelfHostedAsset, VideoSource}
+import com.gu.media.upload.model.{CopyProgress, SelfHostedUploadMetadata, UploadMetadata, UploadPart, UploadProgress, UploadRequest}
+import com.typesafe.config.Config
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.Configuration
+
+class UploadBuilderTest extends FlatSpec with Matchers {
+
+  private val atomId = "61e7a4c3-cb36-492d-889c-163abdae68e4"
+  private val regionName = "eu-west-1"
+  private val configData = List("aws.upload.bucket" -> "upload-test-bucket",
+    "aws.upload.folder" -> "uploads",
+    "aws.upload.role" -> "arn:dummy-aws-role",
+    "aws.profile" -> "test",
+    "aws.upload.accessKey" -> "dummyKey",
+    "aws.upload.secretKey" -> "dummySecret")
+
+  "build" should "create an Upload record for a new self-hosted video upload" in {
+    val selfHostVideoRequest = UploadRequest(atomId, "my-video.mp4", 12345L, selfHost=true)
+    val upload = UploadBuilder.build(MediaAtom.fromThrift(atom), "jo.blogs@guardian.co.uk", 2L, selfHostVideoRequest, aws)
+
+    upload.id shouldBe "61e7a4c3-cb36-492d-889c-163abdae68e4-2"
+    upload.parts shouldBe List(
+      UploadPart(key = "uploads/61e7a4c3-cb36-492d-889c-163abdae68e4-2/parts/0", start = 0L, end = 12345L))
+
+    upload.metadata.user shouldBe "jo.blogs@guardian.co.uk"
+    upload.metadata.bucket shouldBe "upload-test-bucket"
+    upload.metadata.region shouldBe "eu-west-1"
+    upload.metadata.title shouldBe "Atom Title"
+    upload.metadata.pluto shouldBe PlutoSyncMetadataMessage(
+      `type` = "video-upload",
+      projectId = None,
+      s3Key = "uploads/61e7a4c3-cb36-492d-889c-163abdae68e4-2/complete",
+      atomId = "61e7a4c3-cb36-492d-889c-163abdae68e4",
+      title = "Atom Title",
+      user = "jo.blogs@guardian.co.uk",
+      posterImageUrl = None)
+    upload.metadata.runtime shouldBe SelfHostedUploadMetadata(jobs = List())
+    upload.metadata.version should contain (2L)
+    upload.metadata.selfHost shouldBe true
+    upload.metadata.asset should contain (SelfHostedAsset(sources = List(
+      VideoSource(src = "2025/08/20/Atom Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.0.mp4", mimeType = "video/mp4"),
+      VideoSource(src = "2025/08/20/Atom Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.0.m3u8", mimeType = "application/vnd.apple.mpegurl")
+    )))
+    upload.metadata.originalFilename should contain ("my-video.mp4")
+    upload.metadata.startTimestamp should not be empty
+    upload.metadata.subtitleSource shouldBe empty
+    upload.metadata.subtitleVersion shouldBe empty
+
+    upload.progress shouldBe UploadProgress(
+      chunksInS3 = 0,
+      chunksInYouTube = 0,
+      fullyUploaded = false,
+      fullyTranscoded = false,
+      retries = 0,
+      copyProgress = None)
+  }
+
+  "buildForSubtitleChange" should "modify the existing Upload record to reflect a subtitle change" in {
+    val selfHostVideoRequest = UploadRequest(atomId, "my-video.mp4", 12345L, selfHost=true)
+    val videoUpload = UploadBuilder.build(MediaAtom.fromThrift(atom), "jo.blogs@guardian.co.uk", 2L, selfHostVideoRequest, aws)
+
+    // simulate a completed video upload by updating the progress record
+    val completedVideoUpload = videoUpload.copy(progress = completedProgress)
+
+    // add subtitles
+    val subtitleSource = VideoSource("uploads/61e7a4c3-cb36-492d-889c-163abdae68e4-2/subtitle.srt", "application/x-subrip")
+    val subtitleUpload = UploadBuilder.buildForSubtitleChange(completedVideoUpload, Some(subtitleSource))
+
+    // we expect the modified upload record to have bumped the minor version on the m3u8 filename,
+    // stored the subtitle source and version and set the progress to not fully transcoded
+    val expectedAsset = SelfHostedAsset(sources = List(
+      VideoSource(src = "2025/08/20/Atom Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.0.mp4", mimeType = "video/mp4"),
+      VideoSource(src = "2025/08/20/Atom Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.1.m3u8", mimeType = "application/vnd.apple.mpegurl")
+    ))
+    val expectedMetadata = completedVideoUpload.metadata.copy(
+      asset = Some(expectedAsset),
+      subtitleSource = Some(subtitleSource),
+      subtitleVersion = Some(1))
+    val expectedProgress = completedVideoUpload.progress.copy(fullyTranscoded = false)
+    val expected = completedVideoUpload.copy(metadata = expectedMetadata, progress = expectedProgress)
+
+    subtitleUpload shouldBe expected
+  }
+
+  "buildForSubtitleChange" should "modify the existing Upload record to reflect subtitle removal" in {
+    val selfHostVideoRequest = UploadRequest(atomId, "my-video.mp4", 12345L, selfHost=true)
+    val videoUpload = UploadBuilder.build(MediaAtom.fromThrift(atom), "jo.blogs@guardian.co.uk", 2L, selfHostVideoRequest, aws)
+
+    // simulate a completed video upload by updating the progress record
+    val completedVideoUpload = videoUpload.copy(progress = completedProgress)
+
+    // simulate adding subtitles
+    val subtitleSource = VideoSource("uploads/61e7a4c3-cb36-492d-889c-163abdae68e4-2/subtitle.srt", "application/x-subrip")
+    val subtitleUpload = UploadBuilder.buildForSubtitleChange(completedVideoUpload, Some(subtitleSource))
+
+    // remove subtitles
+    val subtitlesRemovedUpload = UploadBuilder.buildForSubtitleChange(subtitleUpload, newSubtitleSource = None)
+
+    // we expect the modified upload record to have bumped the minor version on the m3u8 filename,
+    // removed the subtitle source and set the progress to not fully transcoded
+    val expectedAsset = SelfHostedAsset(sources = List(
+      VideoSource(src = "2025/08/20/Atom Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.0.mp4", mimeType = "video/mp4"),
+      VideoSource(src = "2025/08/20/Atom Title--61e7a4c3-cb36-492d-889c-163abdae68e4-2.2.m3u8", mimeType = "application/vnd.apple.mpegurl")
+    ))
+    val expectedMetadata = subtitlesRemovedUpload.metadata.copy(
+      asset = Some(expectedAsset),
+      subtitleSource = None,
+      subtitleVersion = Some(2))
+    val expectedProgress = subtitlesRemovedUpload.progress.copy(fullyTranscoded = false)
+    val expected = subtitlesRemovedUpload.copy(metadata = expectedMetadata, progress = expectedProgress)
+
+    subtitlesRemovedUpload shouldBe expected
+  }
+
+  private def asset: Asset = Asset(
+    assetType = AssetType.Video,
+    version = 1,
+    id = "test",
+    platform = Platform.Youtube,
+    mimeType = None
+  )
+
+  private def atom: Atom = Atom(
+    id = atomId,
+    atomType = AtomType.Media,
+    labels = Seq.empty,
+    defaultHtml = "",
+    data = AtomData.Media(thriftMediaAtom),
+    contentChangeDetails = ContentChangeDetails(revision = 1)
+  )
+
+  private def thriftMediaAtom = ThriftMediaAtom(
+    assets = Seq(asset),
+    activeVersion = Some(1),
+    title = "Atom Title",
+    category = Category.Feature
+  )
+
+  private def aws = new Settings with AwsAccess with UploadAccess {
+
+    override def config: Config = Configuration(configData: _*).underlying
+
+    override def readTag(tag: String): Option[String] = None
+
+    override val credentials: AwsCredentials = AwsCredentials.dev(Settings(config))
+
+    override def region: Region = RegionUtils.getRegion(regionName)
+  }
+
+  private def completedProgress = UploadProgress(
+    chunksInS3 = 1,
+    chunksInYouTube = 0,
+    fullyUploaded = true,
+    fullyTranscoded = true,
+    retries = 0,
+    copyProgress = Some(CopyProgress(copyId = "1234", fullyCopied = true, eTags = Nil))
+  )
+}

--- a/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
@@ -27,9 +27,9 @@ class AddAssetToAtom extends LambdaWithParams[Upload, Upload] with DynamoAccess 
     val user = getUser(upload.metadata.user)
 
     val after = updateAtom(before, user) { mediaAtom =>
-      val version = upload.metadata.version.getOrElse(MediaAtomHelpers.getNextAssetVersion(mediaAtom))
+      val assetVersion = upload.metadata.version.getOrElse(MediaAtomHelpers.getNextAssetVersion(mediaAtom))
 
-      addAsset(mediaAtom, asset, version)
+      addAsset(mediaAtom, asset, assetVersion)
     }
 
     saveAtom(after)

--- a/uploader/src/main/scala/com/gu/media/upload/SendToTranscoderV2.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/SendToTranscoderV2.scala
@@ -75,7 +75,7 @@ class SendToTranscoderV2 extends LambdaWithParams[Upload, Upload]
         val filenameWithoutMp4 = if (output.endsWith(".mp4")) output.dropRight(4) else output
         val outputGroupSettings = new OutputGroupSettings()
           .withFileGroupSettings(new FileGroupSettings()
-            .withDestination(UploadKey(destinationBucket, filenameWithoutMp4).toS3Uri)
+            .withDestination(UploadUri(destinationBucket, filenameWithoutMp4).toString)
           )
         new OutputGroup().withOutputGroupSettings(outputGroupSettings)
 
@@ -83,7 +83,7 @@ class SendToTranscoderV2 extends LambdaWithParams[Upload, Upload]
         val filenameWithoutM3u8 = if (output.endsWith(".m3u8")) output.dropRight(5) else output
         val outputGroupSettings = new OutputGroupSettings()
           .withHlsGroupSettings(new HlsGroupSettings()
-            .withDestination(UploadKey(destinationBucket, filenameWithoutM3u8).toS3Uri)
+            .withDestination(UploadUri(destinationBucket, filenameWithoutM3u8).toString)
             .withSegmentLength(10)
             .withMinSegmentLength(0)
           )


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

https://trello.com/c/lTJd3tqe/1439-mam-add-minor-version-to-processed-m3u8-files-to-reflect-subtitle-change

changes the m3u8 filenames used in S3 and the media atom dynamo db record to include a minor version that is incremented every time subtitles are changed or removed.

before url example:
https://uploads.guim.co.uk/2025/08/20/Loop%3A+Japan+fireball--1c44ce4e-760a-4312-a803-40939aeea355-2.m3u8

after url example:
https://uploads.guim.co.uk/2025/08/20/Loop%3A+Japan+fireball--1c44ce4e-760a-4312-a803-40939aeea355-2.0.m3u8

i.e. version `2` changes to `2.0`

Note that the minor version is also applied to mp4 files e.g. 
https://uploads.guim.co.uk/2025/08/20/Loop%3A+Japan+fireball--1c44ce4e-760a-4312-a803-40939aeea355-2.0.mp4

And that the minor version of the mp4 files stays at zero when subtitles are changed, because the mp4 content doesn't change.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
- Upload a self-hosted video to an atom.
- Add a subtitle file to the video
- remove a subtitle file from the video
- check in s3 uploads bucket that there are three versions of the m3u8 files, with version X.0, X.1 and X.2

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

