### PR TITLE
Remove onEnter prop from <Redirect>

### DIFF
--- a/public/video-ui/src/routes.jsx
+++ b/public/video-ui/src/routes.jsx
@@ -26,7 +26,7 @@ export const routes = (
     <Route path="/" component={ReactApp}>
       <IndexRedirect to="/videos" />
       <Route path="/videos" component={Search} onEnter={sendTelemetry} />
-      <Redirect from="/videos/create" to="/create" onEnter={sendTelemetry} />
+      <Redirect from="/videos/create" to="/create" />
       <Route path="/videos/:id" component={Video} onEnter={sendTelemetry} />
       <Route path="/videos/:id/upload" component={Upload} onEnter={sendTelemetry} />
       <Route path="/create" component={Video} mode="create" onEnter={sendTelemetry} />


### PR DESCRIPTION
React is throwing an error in the console about use of the onEnter prop on a `<Redirect>` component, and I believe it isn’t being called. It was added in [commit ffcf776412819b811229654600a21ccdc1ea070c](https://github.com/guardian/media-atom-maker/commit/ffcf776412819b811229654600a21ccdc1ea070c) ([pull 1205](https://github.com/guardian/media-atom-maker/pull/1205)), but I can’t see any discussion on the PR about it.

This commit removes the prop, to silence the error.