### PR TITLE
Wait for server before updating active asset

### DIFF
--- a/public/video-ui/src/reducers/videoReducer.js
+++ b/public/video-ui/src/reducers/videoReducer.js
@@ -29,7 +29,7 @@ export default function video(state = null, action) {
         type: 'media'
       });
 
-    case 'ASSET_REVERT_REQUEST':
+    case 'ASSET_REVERT_RECEIVE':
       return Object.assign({}, state, {
         activeVersion: action.assetVersion
       });


### PR DESCRIPTION
## What does this change?

This commit updates the client to wait on a successful response from the server (when the user selects a new asset to be active) before marking that asset as active in the client state.

Before now, the client-side code would immediately update which asset was marked as active before sending the request to the server: see [revertAsset](https://github.com/guardian/media-atom-maker/blob/47c84b2e321fd1c778d530e5fbf884896f79d910/public/video-ui/src/actions/VideoActions/revertAsset.js#L32-L35).

This meant that if the request failed, the client’s state had updated to show the intended asset as active, while the server’s state had not. We suspect this caused an error where the wrong video was published.

This code was added in https://github.com/guardian/media-atom-maker/pull/92, where it’s not currently clear whether the choice to use ASSET_REVERT_REQUEST was deliberate or an accident: I’m guessing the latter only because I can’t think of a rationale for doing it this way.

Are there any ways we could have caught this error, perhaps with some testing? Are there ways we could find other occurrences of similar errors? Could we update the app to discard writes from clients with information that is out of sync with the server?

## How to test

To reproduce the error:

1. visit a media atom with more than one asset (for example, https://video.code.dev-gutools.co.uk/videos/cc691255-4364-45e0-9241-155311f87b29/upload in CODE)
2. block the URL for activating an asset (e.g. https://video.code.dev-gutools.co.uk/api/atom/cc691255-4364-45e0-9241-155311f87b29/asset-active) in the browser console
3. activate an asset

On main, an error message will be displayed but the UI will incorrectly update to show the new asset as activated. On this branch the error message will be displayed and the UI will not show the new asset as activated.