### PR TITLE
Update sbt to 1.10.11

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.10.11


### PR DESCRIPTION
## What does this change?

This commit updates media-atom-maker's use of sbt from [version 1.9.8](https://github.com/sbt/sbt/releases/v1.9.8) (from December 2023) to [version 1.10.11](https://github.com/sbt/sbt/releases/v1.10.11) (from March 2025). We might as well be on a newer version, and some developers have reported this version of sbt as not working on their machines.

## How to test

I think if CI passes we should be fine to merge: we don’t expect sbt version updates to cause subtle breakage.