### PR TITLE
Fixes CanCancel YouTube furniture console error and functionality

### DIFF
--- a/public/video-ui/src/pages/Video/tabs/YoutubeFurniture.jsx
+++ b/public/video-ui/src/pages/Video/tabs/YoutubeFurniture.jsx
@@ -25,6 +25,7 @@ export class YoutubeFurnitureTabPanel extends React.Component {
     onSave: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
     canSave: PropTypes.func.isRequired,
+    canCancel: PropTypes.func.isRequired,
     video: PropTypes.object.isRequired,
     updateVideo: PropTypes.func.isRequired,
     updateErrors: PropTypes.func.isRequired,
@@ -38,6 +39,7 @@ export class YoutubeFurnitureTabPanel extends React.Component {
       onSave,
       onCancel,
       canSave,
+      canCancel,
       video,
       updateVideo,
       updateErrors,
@@ -53,6 +55,7 @@ export class YoutubeFurnitureTabPanel extends React.Component {
           onSave={onSave}
           onCancel={onCancel}
           canSave={canSave}
+          canCancel={canCancel}
         />
         <YoutubeFurniture
           video={video}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Introduced in #1256, this PR promoted a warning highlighting an oversight in the original fix:

Error message:
<img width="3418" height="536" alt="image" src="https://github.com/user-attachments/assets/b63345fb-278f-46ed-be95-9dceb0cb03ed" />

The YouTubeFurniture component was no propagating the prop to the EditSaveCancel component, resulting in a bug in which you can cancel a YouTube furniture change inflight: 

![2025-09-01 14 17 27](https://github.com/user-attachments/assets/23e49f42-e139-4e92-8c60-81b35b38464e)


## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Possible to the different between local and CODE. In local when a request is inflight, the cancel button should become disabled. You can slow requests using browser network throttling to see the difference. 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
User's can't cancel YouTube furniture save requests mid-flight as this is likely to result in unexpected behaviour. 
