### PR TITLE
Model subtitles directly on atom's sources

### DIFF
--- a/app/util/UploadBuilder.scala
+++ b/app/util/UploadBuilder.scala
@@ -73,11 +73,11 @@ object UploadBuilder {
     } else {
       // mp4 output doesn't change with subtitle processing, so s3 key stays at subtitle version 0
       val mp4Key = TranscoderOutputKey(title, atomId, assetVersion, 0, "mp4").toString
-      val mp4Source = if (includeMp4) Some(VideoSource(mp4Key, "video/mp4")) else None
+      val mp4Source = if (includeMp4) Some(VideoSource(mp4Key, VideoSource.mimeTypeMp4)) else None
 
       // m3u8 output changes when subtitles are processed, so s3 key includes a subtitle version
       val m3u8Key = TranscoderOutputKey(title, atomId, assetVersion, subtitleVersion, "m3u8").toString
-      val m3u8Source = if (includeM3u8) Some(VideoSource(m3u8Key, "application/vnd.apple.mpegurl")) else None
+      val m3u8Source = if (includeM3u8) Some(VideoSource(m3u8Key, VideoSource.mimeTypeM3u8)) else None
       val sources = mp4Source ++ m3u8Source
       Some(SelfHostedAsset(sources.toList))
     }

--- a/common/src/main/scala/com/gu/media/model/Asset.scala
+++ b/common/src/main/scala/com/gu/media/model/Asset.scala
@@ -10,7 +10,7 @@ case class Asset(assetType: AssetType,
                  id: String,
                  platform: Platform,
                  mimeType: Option[String]) {
-  def asThrift = ThriftAsset.apply(AssetType.Video.asThrift, version, id, platform.asThrift, mimeType)
+  def asThrift = ThriftAsset.apply(assetType.asThrift, version, id, platform.asThrift, mimeType)
 }
 
 object Asset {

--- a/common/src/main/scala/com/gu/media/model/AssetType.scala
+++ b/common/src/main/scala/com/gu/media/model/AssetType.scala
@@ -12,11 +12,13 @@ sealed trait AssetType {
 object AssetType {
   case object Audio extends AssetType { val name = "Audio" }
   case object Video extends AssetType { val name = "Video" }
+  case object Subtitles extends AssetType { val name = "Subtitles" }
 
   val assetTypeReads = Reads[AssetType](json => {
     json.as[String] match {
       case "Audio" => JsSuccess(Audio)
       case "Video" => JsSuccess(Video)
+      case "Subtitles" => JsSuccess(Subtitles)
     }
   })
 
@@ -26,7 +28,7 @@ object AssetType {
 
   implicit val assetTypeFormat: Format[AssetType] = Format(assetTypeReads, assetTypeWrites)
 
-  private val types = List(Audio, Video)
+  private val types = List(Audio, Video, Subtitles)
 
   def fromThrift(p: ThriftAssetType) = types.find(_.name == p.name).get
 }

--- a/common/src/main/scala/com/gu/media/model/VideoAsset.scala
+++ b/common/src/main/scala/com/gu/media/model/VideoAsset.scala
@@ -15,6 +15,8 @@ object VideoSource {
   def filename(source: VideoSource): String = source.src.split("/").last
   val mimeTypeMp4 = "video/mp4"
   val mimeTypeM3u8 = "application/vnd.apple.mpegurl"
+  val mimeTypeVtt = "text/vtt"
+  val captionsSuffix = "captions_00001.vtt"
 }
 
 object VideoAsset {

--- a/common/src/main/scala/com/gu/media/model/VideoAsset.scala
+++ b/common/src/main/scala/com/gu/media/model/VideoAsset.scala
@@ -13,6 +13,8 @@ case class SelfHostedAsset(sources: List[VideoSource]) extends VideoAsset
 object VideoSource {
   implicit val format: Format[VideoSource] = Jsonx.formatCaseClass[VideoSource]
   def filename(source: VideoSource): String = source.src.split("/").last
+  val mimeTypeMp4 = "video/mp4"
+  val mimeTypeM3u8 = "application/vnd.apple.mpegurl"
 }
 
 object VideoAsset {

--- a/common/src/main/scala/com/gu/media/util/MediaAtomHelpers.scala
+++ b/common/src/main/scala/com/gu/media/util/MediaAtomHelpers.scala
@@ -115,6 +115,12 @@ object MediaAtomHelpers {
         Asset(AssetType.Video, version, src, Platform.Url, Some(mimeType))
       }
 
-      assets
+      val subtitleAssets = sources.collect {
+        case VideoSource(src, VideoSource.mimeTypeM3u8) =>
+          val subtitleSrc = src.dropRight(5) + VideoSource.captionsSuffix
+          Asset(AssetType.Subtitles, version, subtitleSrc, Platform.Url, Some(VideoSource.mimeTypeVtt))
+      }
+
+      assets ++ subtitleAssets
   }
 }

--- a/public/video-ui/src/components/utils/VideoEmbed.jsx
+++ b/public/video-ui/src/components/utils/VideoEmbed.jsx
@@ -36,17 +36,15 @@ export function VideoEmbed({ sources, posterUrl }) {
 }
 
 function prepareSourcesAndSubtitles(sources) {
-  // if m3u8 and mp4 are both present, put m3u8 first and add subtitle track for browsers that don't support m3u8
+  // if m3u8 and mp4 are both present, put m3u8 first
   const m3u8 = sources.find(source => source.mimeType === "application/vnd.apple.mpegurl");
   const mp4 = sources.find(source => source.mimeType === "video/mp4");
   const videoSources =
     (m3u8 && mp4) ? [m3u8].concat(sources.filter(source => source !== m3u8)) : sources;
-  const subtitleTrack =
-    (m3u8 && mp4) ? <track default kind="subtitles" src={getVttName(m3u8.src)}/> : undefined;
-  return {videoSources, subtitleTrack};
-}
 
-function getVttName(m3u8Src) {
-  // captions suffix is an assumption based on MediaConvert output we've seen
-  return m3u8Src.replace(/.m3u8$/, "captions_00001.vtt");
+  // add subtitle track for browsers that don't support m3u8
+  const subtitles = sources.find(source => source.assetType === "subtitles");
+  const subtitleTrack =
+    (m3u8 && mp4 && subtitles) ? <track default kind="subtitles" src={subtitles.src}/> : undefined;
+  return {videoSources, subtitleTrack};
 }

--- a/public/video-ui/src/components/utils/VideoEmbed.jsx
+++ b/public/video-ui/src/components/utils/VideoEmbed.jsx
@@ -36,15 +36,18 @@ export function VideoEmbed({ sources, posterUrl }) {
 }
 
 function prepareSourcesAndSubtitles(sources) {
+  const videoSources = sources.filter(source => source.mimeType !== "text/vtt");
+
   // if m3u8 and mp4 are both present, put m3u8 first
-  const m3u8 = sources.find(source => source.mimeType === "application/vnd.apple.mpegurl");
-  const mp4 = sources.find(source => source.mimeType === "video/mp4");
-  const videoSources =
-    (m3u8 && mp4) ? [m3u8].concat(sources.filter(source => source !== m3u8)) : sources;
+  const m3u8 = videoSources.find(source => source.mimeType === "application/vnd.apple.mpegurl");
+  const mp4 = videoSources.find(source => source.mimeType === "video/mp4");
+
+  const sortedSources =
+    (m3u8 && mp4) ? [m3u8].concat(videoSources.filter(source => source !== m3u8)) : videoSources;
 
   // add subtitle track for browsers that don't support m3u8
-  const subtitles = sources.find(source => source.assetType === "subtitles");
+  const vtt = sources.find(source => source.mimeType === "text/vtt");
   const subtitleTrack =
-    (m3u8 && mp4 && subtitles) ? <track default kind="subtitles" src={subtitles.src}/> : undefined;
-  return {videoSources, subtitleTrack};
+    (m3u8 && mp4 && vtt) ? <track default kind="subtitles" src={vtt.src}/> : undefined;
+  return {videoSources: sortedSources, subtitleTrack};
 }

--- a/public/video-ui/src/services/VideosApi.ts
+++ b/public/video-ui/src/services/VideosApi.ts
@@ -8,7 +8,7 @@ import type { UsageData, UsageState } from '../slices/usage';
 
 export type ComposerStage = 'live' | 'preview'
 
-export type AssetType = 'Audio' | 'Video'
+export type AssetType = 'Audio' | 'Video' | 'Subtitles'
 
 export type Platform = 'Youtube' | 'Facebook' | 'Dailymotion' | 'Mainstream' | 'Url'
 

--- a/uploader/src/main/scala/com/gu/media/upload/SendToTranscoderV2.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/SendToTranscoderV2.scala
@@ -71,7 +71,7 @@ class SendToTranscoderV2 extends LambdaWithParams[Upload, Upload]
 
   private def getOutputs(sources: List[VideoSource]): List[OutputGroup] = {
     sources.map {
-      case VideoSource(output, "video/mp4") =>
+      case VideoSource(output, VideoSource.mimeTypeMp4) =>
         val filenameWithoutMp4 = if (output.endsWith(".mp4")) output.dropRight(4) else output
         val outputGroupSettings = new OutputGroupSettings()
           .withFileGroupSettings(new FileGroupSettings()
@@ -79,7 +79,7 @@ class SendToTranscoderV2 extends LambdaWithParams[Upload, Upload]
           )
         new OutputGroup().withOutputGroupSettings(outputGroupSettings)
 
-      case VideoSource(output, "application/vnd.apple.mpegurl") =>
+      case VideoSource(output, VideoSource.mimeTypeM3u8) =>
         val filenameWithoutM3u8 = if (output.endsWith(".m3u8")) output.dropRight(5) else output
         val outputGroupSettings = new OutputGroupSettings()
           .withHlsGroupSettings(new HlsGroupSettings()


### PR DESCRIPTION
## What does this change?

To allow for better backwards compatibility for downstream clients, model any potential subtitles tracks directly on the atom itself. The subtitles file is already being transcoded, but currently the only reference to it comes from within the m3u8. Now we store the location of the subtitles file as if were another source (of new `assetType`, subtitles).

## To test
With the relevant permissions, upload subtitles to a video and let it transcode. You should be able to see the subtitles correctly on the main atom preview page, and if you find the atom in CAPI, i.e. `https://content.code.dev-guardianapis.com/atom/video/[ATOM_ID]?show-elements=all&show-atoms=all&show-rights=all&show-fields=all&show-tags=all&show-blocks=all&show-references=all&format=json&api-key=[CODE-CAPI-KEY]` you will be able to see the subtitles file in the sources list. This should correspond to the correct file in S3.

### Notes
We added a new asset type, Subtitles in https://github.com/guardian/content-atom/pull/178.

We are handling this new asset type in:
* https://github.com/guardian/frontend/pull/28244
* https://github.com/guardian/dotcom-rendering/pull/14533
* https://github.com/guardian/mobile-apps-api/pull/3917
* https://github.com/guardian/facia-tool/pull/1859