### PR TITLE
Fixes WorkflowTabPanel cancancel attribute warning

### DIFF
--- a/public/video-ui/src/pages/Video/tabs/Workflow.jsx
+++ b/public/video-ui/src/pages/Video/tabs/Workflow.jsx
@@ -37,6 +37,7 @@ export class WorkflowTabPanel extends React.Component {
       onSave,
       onCancel,
       canSave,
+      canCancel,
       video,
       isTrackedInWorkflow,
       ...rest
@@ -50,6 +51,7 @@ export class WorkflowTabPanel extends React.Component {
           onSave={onSave}
           onCancel={onCancel}
           canSave={canSave}
+          canCancel={canCancel}
         />
         {isTrackedInWorkflow && !editing && <WorkflowLink video={video} />}
         <Workflow video={video} editable={editing} />


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
I thought I had fixed this in #1283, but I missed the Workflow tab which has the same issue. Unfortunately fixing this doesn't fix the functionality as there is no Workflow saving state. However, the stakes are pretty low. 

Error: 

<img width="1728" height="270" alt="image" src="https://github.com/user-attachments/assets/3803d03d-d4dc-4532-b865-6eea83fa1133" />


## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Running the code locally, do you see the error message above? 