### PR TITLE
Fixes asset upload state not updating on older atoms

### DIFF
--- a/public/video-ui/src/components/VideoUpload/VideoTrail.jsx
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.jsx
@@ -6,9 +6,7 @@ export default class VideoTrail extends React.Component {
   polling = null;
 
   componentWillReceiveProps() {
-    const isRecentlyModified = VideoUtils.isRecentlyModified(this.props.video);
-
-    if (!this.polling && isRecentlyModified) {
+    if (!this.polling) {
       this.polling = setInterval(() => this.pollIfRequired(), 5000);
     }
   }

--- a/public/video-ui/src/util/video.js
+++ b/public/video-ui/src/util/video.js
@@ -102,15 +102,6 @@ export default class VideoUtils {
     return atom.duration > 0 && atom.duration >= minDurationForAds;
   }
 
-  static isRecentlyModified({ contentChangeDetails }) {
-    if (contentChangeDetails && contentChangeDetails.lastModified) {
-      const lastModified = moment(contentChangeDetails.lastModified.date);
-      const diff = moment().diff(lastModified, 'days');
-      return diff < 1;
-    }
-    return false;
-  }
-
   static canUploadToYouTube({ youtubeCategoryId, channelId, privacyStatus }) {
     return !!youtubeCategoryId && !!channelId && !!privacyStatus;
   }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
The `isRecentlyModified` check in the Video Trail component introduces an edge case where older atom will not poll for changes to an asset's upload status. it appears the check was [introduced to avoid unnecessary network requests](https://github.com/guardian/media-atom-maker/pull/640), however, given the poll also checks if an uploads status (`upload.processing`), this seems excessive. Therefore the PR removes this check. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Try uploading an asset on an atom which has not been modified in the last day. The upload bar should fill up as expected and progress through the various states,

