### PR TITLE
Sh/display is live duration checkbox

### DIFF
--- a/app/model/commands/ActiveAssetCommand.scala
+++ b/app/model/commands/ActiveAssetCommand.scala
@@ -33,10 +33,9 @@ case class ActiveAssetCommand(
     val assetsToActivate = mediaAtom.assets.filter(_.version == activateAssetRequest.version)
 
     if (assetsToActivate.nonEmpty) {
-      val duration = assetsToActivate.find(_.platform == Youtube) match {
-        case Some(asset) => youtube.getDuration(asset.id)
-        case None => mediaAtom.duration
-      }
+      val duration = assetsToActivate.find(_.platform == Youtube)
+        .flatMap(asset => youtube.getDuration(asset.id))
+        .orElse(mediaAtom.duration)
 
       val updatedAtom = mediaAtom.copy(
         activeVersion = Some(activateAssetRequest.version),

--- a/app/model/commands/ActiveAssetCommand.scala
+++ b/app/model/commands/ActiveAssetCommand.scala
@@ -33,6 +33,7 @@ case class ActiveAssetCommand(
     val assetsToActivate = mediaAtom.assets.filter(_.version == activateAssetRequest.version)
 
     if (assetsToActivate.nonEmpty) {
+      // Attempt to get atom duration from YouTube otherwise use the current value
       val duration = assetsToActivate.find(_.platform == Youtube)
         .flatMap(asset => youtube.getDuration(asset.id))
         .orElse(mediaAtom.duration)

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -38,6 +38,9 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
 
   def getDuration(youtubeId: String): Option[Long] = {
     getVideo(youtubeId, List("contentDetails")) match {
+      case Some(video) if Option(video.getSnippet.getLiveBroadcastContent).isDefined => {
+        Some(0L)
+      }
       case Some(video) => {
         // YouTube API returns duration is in ISO 8601 format
         // https://developers.google.com/youtube/v3/docs/videos#contentDetails.duration

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -44,7 +44,10 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
         val iso8601Duration = video.getContentDetails.getDuration
         Some(ISO8601Duration.toSeconds(iso8601Duration))
       }
-      case None => None
+      case None => {
+        log.info(s"Failed to get duration for YouTube asset: $youtubeId")
+        None
+      }
     }
   }
 

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -38,9 +38,6 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
 
   def getDuration(youtubeId: String): Option[Long] = {
     getVideo(youtubeId, List("contentDetails")) match {
-      case Some(video) if Option(video.getSnippet.getLiveBroadcastContent).isDefined => {
-        Some(0L)
-      }
       case Some(video) => {
         // YouTube API returns duration is in ISO 8601 format
         // https://developers.google.com/youtube/v3/docs/videos#contentDetails.duration

--- a/public/video-ui/src/components/FormFields/DurationInput.jsx
+++ b/public/video-ui/src/components/FormFields/DurationInput.jsx
@@ -25,7 +25,8 @@ const DurationInput = props => {
   useEffect(() => {
     const minsInt = parseInt(mins ?? mins, 10);
     const secsInt = parseInt(secs ?? secs, 10);
-    props.onUpdateField(minsInt * 60 + secsInt);
+    const seconds = minsInt * 60 + secsInt;
+    props.onUpdateField(!isNaN(seconds) ? seconds : 0)
   }, [mins, secs, props.onUpdateField])
 
   const updateMins = mins => {

--- a/public/video-ui/src/components/FormFields/DurationInput.jsx
+++ b/public/video-ui/src/components/FormFields/DurationInput.jsx
@@ -14,6 +14,8 @@ const getStateFromProps = props => {
 };
 
 const DurationInput = props => {
+  const isLive = props.rawFieldValue === 0;
+
   const [state, setState] = useState(() => getStateFromProps(props));
 
   useEffect(() => {
@@ -51,17 +53,23 @@ const DurationInput = props => {
       <div>
         <div>
           <p className="details-list__title">{props.fieldName}</p>
-          <p
-            className={
-              'details-list__field ' +
-              (props.displayPlaceholder(props.placeholder, props.fieldValue)
-                ? 'details-list__empty'
-                : '')
-            }
-          >
-            {' '}
-            {secondsToDurationStr(props.rawFieldValue)}
-          </p>
+          {isLive ? (
+            <p className="details-list__field">Live video – zero duration</p>
+          ) : (
+            <>
+              <p
+                className={
+                  'details-list__field ' +
+                  (props.displayPlaceholder(props.placeholder, props.fieldValue)
+                    ? 'details-list__empty'
+                    : '')
+                }
+              >
+                {' '}
+                {secondsToDurationStr(props.rawFieldValue)}
+              </p>
+            </>
+          )}
         </div>
       </div>
     );
@@ -81,7 +89,7 @@ const DurationInput = props => {
                 id={props.fieldId || props.fieldLocation}
                 type="checkbox"
                 disabled={!props.editable}
-                checked={props.rawFieldValue === 0}
+                checked={isLive}
                 onChange={e => {
                   props.onUpdateField(e.target.checked ? 0 : 1);
                 }}
@@ -101,9 +109,7 @@ const DurationInput = props => {
               incorrectly (i.e. 0:00)
             </em>
           </div>
-          <div
-            className={props.rawFieldValue === 0 ? 'form-element--hidden' : ''}
-          >
+          <div className={isLive ? 'form-element--hidden' : ''}>
             <input
               type="text"
               size="3"
@@ -112,7 +118,7 @@ const DurationInput = props => {
                 (hasError ? 'form__field--error' : '')
               }
               value={state.mins}
-              disabled={props.rawFieldValue === 0}
+              disabled={isLive}
               onChange={e => {
                 updateMins(e.target.value);
               }}
@@ -126,7 +132,7 @@ const DurationInput = props => {
                 (hasError ? 'form__field--error' : '')
               }
               value={state.secs}
-              disabled={props.rawFieldValue === 0}
+              disabled={isLive}
               onChange={e => {
                 updateSecs(e.target.value);
               }}

--- a/public/video-ui/src/components/FormFields/DurationInput.jsx
+++ b/public/video-ui/src/components/FormFields/DurationInput.jsx
@@ -16,27 +16,23 @@ const getStateFromProps = props => {
 const DurationInput = props => {
   const isLive = props.rawFieldValue === 0;
 
-  const [state, setState] = useState(() => getStateFromProps(props));
+  const [{mins, secs}, setState] = useState(() => getStateFromProps(props));
 
   useEffect(() => {
     setState(getStateFromProps(props));
   }, [props.rawFieldValue]);
 
-  const updateDuration = useCallback(
-    (mins, secs) => {
-      const minsInt = parseInt(mins ?? state.mins, 10);
-      const secsInt = parseInt(secs ?? state.secs, 10);
-      props.onUpdateField(minsInt * 60 + secsInt);
-    },
-    [state.mins, state.secs, props]
-  );
+  useEffect(() => {
+    const minsInt = parseInt(mins ?? mins, 10);
+    const secsInt = parseInt(secs ?? secs, 10);
+    props.onUpdateField(minsInt * 60 + secsInt);
+  }, [mins, secs, props.onUpdateField])
 
   const updateMins = mins => {
     setState(prevState => ({
       ...prevState,
       mins
     }));
-    updateDuration(mins);
   };
 
   const updateSecs = secs => {
@@ -45,7 +41,6 @@ const DurationInput = props => {
       ...prevState,
       secs: newSecs
     }));
-    updateDuration(undefined, newSecs);
   };
 
   if (!props.editable) {
@@ -81,7 +76,10 @@ const DurationInput = props => {
     <div>
       <div className="form__row">
         <label className="form__label">{props.fieldName}</label>
-
+        <p className="form__message form__message--display">
+            Use this to edit videos where the duration is being reported
+            incorrectly
+        </p>
         <div>
           <div className="details-list__labeled-filter">
             <div>
@@ -101,45 +99,37 @@ const DurationInput = props => {
             </p>
           </div>
         </div>
+        <div className={isLive ? 'form-element--hidden' : ''}>
+          <input
+            type="text"
+            size="3"
+            className={
+              'form__field form__field--inline ' +
+              (hasError ? 'form__field--error' : '')
+            }
+            value={mins}
+            disabled={isLive}
+            onChange={e => {
+              updateMins(e.target.value);
+            }}
+          />
+          <span style={{ margin: '0 5px' }}>mins</span>
+          <input
+            type="text"
+            size="3"
+            className={
+              'form__field form__field--inline ' +
+              (hasError ? 'form__field--error' : '')
+            }
+            value={secs}
+            disabled={isLive}
+            onChange={e => {
+              updateSecs(e.target.value);
+            }}
+          />
+          <span style={{ margin: '0 5px' }}>secs</span>
+        </div>
 
-        <>
-          <div className="form__description">
-            <em>
-              Use this to edit videos where the duration is being reported
-              incorrectly (i.e. 0:00)
-            </em>
-          </div>
-          <div className={isLive ? 'form-element--hidden' : ''}>
-            <input
-              type="text"
-              size="3"
-              className={
-                'form__field form__field--inline ' +
-                (hasError ? 'form__field--error' : '')
-              }
-              value={state.mins}
-              disabled={isLive}
-              onChange={e => {
-                updateMins(e.target.value);
-              }}
-            />
-            <span style={{ margin: '0 5px' }}>mins</span>
-            <input
-              type="text"
-              size="3"
-              className={
-                'form__field form__field--inline ' +
-                (hasError ? 'form__field--error' : '')
-              }
-              value={state.secs}
-              disabled={isLive}
-              onChange={e => {
-                updateSecs(e.target.value);
-              }}
-            />
-            <span style={{ margin: '0 5px' }}>secs</span>
-          </div>
-        </>
 
         {hasError ? (
           <p className="form__message form__message--error">

--- a/public/video-ui/src/components/FormFields/DurationInput.test.jsx
+++ b/public/video-ui/src/components/FormFields/DurationInput.test.jsx
@@ -1,0 +1,234 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { userEvent } from '@testing-library/user-event';
+import DurationInput from './DurationInput';
+
+const defaultProps = {
+  fieldName: 'Duration',
+  rawFieldValue: 125, // 2 minutes and 5 seconds
+  editable: true,
+  onUpdateField: jest.fn(),
+  hasError: jest.fn(() => false),
+  displayPlaceholder: jest.fn(() => false)
+};
+
+describe('DurationInput', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Non-editable mode', () => {
+    const nonEditableProps = {
+      ...defaultProps,
+      editable: false
+    };
+
+    it('renders non-editable duration with formatted time display', () => {
+      render(<DurationInput {...nonEditableProps} />);
+
+      expect(screen.getByText('Duration')).toBeInTheDocument();
+      expect(screen.getByText('2:05')).toBeInTheDocument();
+
+      // Should not show input fields
+      expect(screen.queryByDisplayValue('2')).not.toBeInTheDocument();
+      expect(screen.queryByDisplayValue('5')).not.toBeInTheDocument();
+    });
+
+    it('renders live video display when duration is 0', () => {
+      render(<DurationInput {...nonEditableProps} rawFieldValue={0} />);
+
+      expect(screen.getByText('Live video – zero duration')).toBeInTheDocument();
+      expect(screen.queryByText('0:00')).not.toBeInTheDocument();
+    });
+
+    it('shows placeholder styling when displayPlaceholder returns true', () => {
+      const propsWithPlaceholder = {
+        ...nonEditableProps,
+        displayPlaceholder: jest.fn(() => true)
+      };
+
+      render(<DurationInput {...propsWithPlaceholder} />);
+
+      const fieldElement = screen.getByText('2:05');
+      expect(fieldElement).toHaveClass('details-list__empty');
+    });
+  });
+
+  describe('Editable mode', () => {
+    it('renders editable duration inputs with initial values', () => {
+      render(<DurationInput {...defaultProps} />);
+
+      // Check form elements are present
+      expect(screen.getByText('Duration')).toBeInTheDocument();
+
+      // Check input fields
+      const minsInput = screen.getByDisplayValue('2');
+      const secsInput = screen.getByDisplayValue('5');
+
+      expect(minsInput).toBeInTheDocument();
+      expect(secsInput).toBeInTheDocument();
+      expect(minsInput).not.toBeDisabled();
+      expect(secsInput).not.toBeDisabled();
+    });
+
+    it('renders live video checkbox unchecked for regular videos', () => {
+      render(<DurationInput {...defaultProps} />);
+
+      const liveCheckbox = screen.getByRole('checkbox');
+      expect(liveCheckbox).toBeInTheDocument();
+      expect(liveCheckbox).not.toBeChecked();
+      expect(liveCheckbox).not.toBeDisabled();
+      expect(screen.getByText('Live video')).toBeInTheDocument();
+    });
+
+    it('renders live video checkbox checked when duration is 0', () => {
+      render(<DurationInput {...defaultProps} rawFieldValue={0} />);
+
+      const liveCheckbox = screen.getByRole('checkbox');
+      expect(liveCheckbox).toBeChecked();
+
+      // Input fields should be hidden and disabled
+      const inputsContainer = document.querySelector('.form-element--hidden');
+      expect(inputsContainer).toBeInTheDocument();
+    });
+
+    it('shows error state when hasError returns true', () => {
+      const errorProps = {
+        ...defaultProps,
+        hasError: jest.fn(() => true),
+        notification: { message: 'Invalid duration' }
+      };
+
+      render(<DurationInput {...errorProps} />);
+
+      const minsInput = screen.getByDisplayValue('2');
+      const secsInput = screen.getByDisplayValue('5');
+
+      expect(minsInput).toHaveClass('form__field--error');
+      expect(secsInput).toHaveClass('form__field--error');
+      expect(screen.getByText('Invalid duration')).toBeInTheDocument();
+    });
+  });
+
+  describe('User interactions', () => {
+    it('updates minutes input and calls onUpdateField', async () => {
+      const user = userEvent.setup();
+      render(<DurationInput {...defaultProps} />);
+
+      const minsInput = screen.getByDisplayValue('2');
+
+      await user.clear(minsInput);
+      await user.type(minsInput, '3');
+
+      // Should call onUpdateField with new total seconds (3 * 60 + 5 = 185)
+      expect(defaultProps.onUpdateField).toHaveBeenCalledWith(185);
+    });
+
+    it('updates seconds input and calls onUpdateField', async () => {
+      const user = userEvent.setup();
+      render(<DurationInput {...defaultProps} />);
+
+      const secsInput = screen.getByDisplayValue('5');
+
+      await user.clear(secsInput);
+      await user.type(secsInput, '30');
+
+      // Should call onUpdateField with new total seconds (2 * 60 + 30 = 150)
+      expect(defaultProps.onUpdateField).toHaveBeenCalledWith(150);
+    });
+
+    it('limits seconds input to maximum of 59', async () => {
+      const user = userEvent.setup();
+      render(<DurationInput {...defaultProps} />);
+
+      const secsInput = screen.getByDisplayValue('5');
+
+      await user.clear(secsInput);
+      await user.type(secsInput, '75');
+
+      // Should be capped at 59
+      expect(secsInput).toHaveValue('59');
+      expect(defaultProps.onUpdateField).toHaveBeenCalledWith(179); // 2 * 60 + 59
+    });
+
+    it('handles empty seconds input by defaulting to 0', async () => {
+      const user = userEvent.setup();
+      render(<DurationInput {...defaultProps} />);
+
+      const secsInput = screen.getByDisplayValue('5');
+
+      await user.clear(secsInput);
+
+      expect(secsInput).toHaveValue('0');
+      expect(defaultProps.onUpdateField).toHaveBeenCalledWith(120); // 2 * 60 + 0
+    });
+
+    it('toggles live video checkbox and updates duration', async () => {
+      const user = userEvent.setup();
+      render(<DurationInput {...defaultProps} />);
+
+      const liveCheckbox = screen.getByRole('checkbox');
+
+      await user.click(liveCheckbox);
+
+      expect(defaultProps.onUpdateField).toHaveBeenCalledWith(0);
+    });
+
+    it('toggles live video checkbox off and sets duration to 1', async () => {
+      const user = userEvent.setup();
+      render(<DurationInput {...defaultProps} rawFieldValue={0} />);
+
+      const liveCheckbox = screen.getByRole('checkbox');
+
+      await user.click(liveCheckbox);
+
+      expect(defaultProps.onUpdateField).toHaveBeenCalledWith(1);
+    });
+
+    it('disables input fields when live video is selected', () => {
+      render(<DurationInput {...defaultProps} rawFieldValue={0} />);
+
+      const allInputs = screen.getAllByDisplayValue('0');
+      const minsInput = allInputs[0]; // First input with value '0'
+      const secsInput = allInputs[1]; // Second input with value '0'
+
+      expect(minsInput).toBeDisabled();
+      expect(secsInput).toBeDisabled();
+    });
+
+    it('handles undefined rawFieldValue', () => {
+      render(<DurationInput {...defaultProps} rawFieldValue={undefined} />);
+
+      expect(screen.getAllByDisplayValue('0')).toHaveLength(2); // Both mins and secs inputs show '0'
+    });
+
+    it('handles zero minutes and seconds', () => {
+      render(<DurationInput {...defaultProps} rawFieldValue={0} />);
+
+      const liveCheckbox = screen.getByRole('checkbox');
+      expect(liveCheckbox).toBeChecked();
+    });
+
+    it('handles large duration values', () => {
+      const largeValue = 7265; // 121 minutes and 5 seconds
+      render(<DurationInput {...defaultProps} rawFieldValue={largeValue} />);
+
+      expect(screen.getByDisplayValue('121')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('5')).toBeInTheDocument();
+    });
+
+    it('handles non-numeric input gracefully', async () => {
+      const user = userEvent.setup();
+      render(<DurationInput {...defaultProps} />);
+
+      const minsInput = screen.getByDisplayValue('2');
+
+      await user.clear(minsInput);
+      await user.type(minsInput, 'abc');
+
+      // When parseInt('abc', 10) returns NaN, NaN * 60 + 5 = NaN
+      expect(defaultProps.onUpdateField).toHaveBeenLastCalledWith(0);
+    });
+  });
+});

--- a/public/video-ui/src/constants/blankVideoData.ts
+++ b/public/video-ui/src/constants/blankVideoData.ts
@@ -5,7 +5,7 @@ export const blankVideoData: Video = {
   title: '',
   description: '',
   category: 'News',
-  duration: 0,
+  duration: 1,
   channelId: '',
   youtubeTitle: '',
   youtubeCategoryId: '',

--- a/public/video-ui/src/constants/blankVideoData.ts
+++ b/public/video-ui/src/constants/blankVideoData.ts
@@ -5,7 +5,7 @@ export const blankVideoData: Video = {
   title: '',
   description: '',
   category: 'News',
-  duration: 1,
+  duration: 0,
   channelId: '',
   youtubeTitle: '',
   youtubeCategoryId: '',

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -430,4 +430,7 @@ progress::-moz-progress-bar {
 
 .form-element--hidden {
   opacity: 0.4;
+  input {
+    cursor: not-allowed;
+  }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

<img width="225" height="69" alt="image" src="https://github.com/user-attachments/assets/74f1b114-fbc4-49e5-b77a-3a0e40a14277" />

![2025-09-24 10 18 38](https://github.com/user-attachments/assets/1c282c47-151e-4977-90f1-91ccc3a641b8)


## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
