### PR TITLE
Prevents setPublishedVideo from overwriting video state acidentally

### DIFF
--- a/public/video-ui/src/actions/VideoActions/publishVideo.ts
+++ b/public/video-ui/src/actions/VideoActions/publishVideo.ts
@@ -2,7 +2,7 @@ import VideosApi from '../../services/VideosApi';
 import { setPublishing } from '../../slices/saveState';
 import { showError } from '../../slices/error';
 import { AppDispatch } from '../../util/setupStore';
-import { setPublishedVideo } from '../../slices/video';
+import { setVideoAndPublishedVideo } from '../../slices/video';
 
 export function publishVideo(videoId: string) {
   return (dispatch: AppDispatch) => {
@@ -10,7 +10,7 @@ export function publishVideo(videoId: string) {
     return VideosApi.publishVideo(videoId)
       .then(res => {
         dispatch(setPublishing(false));
-        dispatch(setPublishedVideo(res));
+        dispatch(setVideoAndPublishedVideo(res));
       })
       .catch(error => dispatch(showError(error.responseText, error)));
   };

--- a/public/video-ui/src/slices/video.ts
+++ b/public/video-ui/src/slices/video.ts
@@ -20,6 +20,9 @@ const video = createSlice({
       state.video = { ...blankVideoData, ...payload };
     },
     setPublishedVideo: (state, { payload }: PayloadAction<Video>) => {
+      state.publishedVideo = { ...blankVideoData, ...payload };
+    },
+    setVideoAndPublishedVideo: (state, { payload }: PayloadAction<Video>) => {
       state.video = { ...blankVideoData, ...payload };
       state.publishedVideo = { ...state.video };
     },
@@ -53,6 +56,7 @@ export default video.reducer;
 export const {
   setVideo,
   setPublishedVideo,
+  setVideoAndPublishedVideo,
   setVideoBlank,
   setActiveAsset,
   setAssets


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR fixes a pernicious bug which could cause the published video state to overwrite the draft state. This could leave to some confusing UI bugs where draft entries would sometimes appear but sometimes be overwritten by preview. 

Introduced by https://github.com/guardian/media-atom-maker/pull/1331/files#diff-ae6115d5403f4a600bbd09142ee2a78b1acf83a0e3cd13468e74149438d84c88.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Testable locally on a published atom. Makes changes to an atom after publish, refresh the page and notice sometimes the preview state is displayed and sometimes the draft state is displayed.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Solves a nasty UI bug. 
