### PR TITLE
Fixes MAM with published usages not being able to publish

### DIFF
--- a/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.jsx
+++ b/public/video-ui/src/components/VideoPublishBar/VideoPublishBar.jsx
@@ -43,7 +43,7 @@ export default class VideoPublishBar extends React.Component {
 
       this.props.updateVideoPage(
         this.props.video,
-        this.props.usages,
+        this.props.usages.data,
         'published'
       );
     }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR fixes an issue atoms getting into a state where they can't be launched. This would occur when an atom:

- had published usages
- was published itself 
- was trying to publish further edits

This was difficult to spot locally due to how usages are setup, but possible to see in CODE. It was introduced by https://github.com/guardian/media-atom-maker/pull/1316

The issue was that an argument to a function should have been passing it's nested `data` attribute instead.  TypeScript would have easily caught, however, we were crossing the boundary between JavaScript and TypeScript. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Testable in CODE, trying edit and launching changes to an atom with a published usage! 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users can launch published atoms! 

## Images

User console error:

<img width="541" height="128" alt="image" src="https://github.com/user-attachments/assets/a2f19db3-ba0a-4746-9e73-5975ece20a95" />
