### PR TITLE
Fixes create video failure messaging and behaviour

### DIFF
--- a/public/video-ui/src/actions/VideoActions/createVideo.ts
+++ b/public/video-ui/src/actions/VideoActions/createVideo.ts
@@ -14,6 +14,9 @@ export function createVideo(video: Video) {
         dispatch(setSaving(false));
         dispatch(setVideo(res));
       })
-      .catch(error => dispatch(showError('Could not create video', error)));
+      .catch(error => {
+        dispatch(showError('Could not create video', error));
+        throw error;
+      });
   };
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR resolves an issue which would causes furniture data to become inaccessible after a save failure on atom creation:

| Before | After |
|--------|--------|
| ![2025-09-29 13 46 50](https://github.com/user-attachments/assets/37d1f086-b0e6-4ac6-add2-8e56f091536d) | ![2025-09-29 13 45 50](https://github.com/user-attachments/assets/b8a35375-be42-4f3a-856e-ba4822b16c55) | 

The new behaviour allows a user to reattempt a save but also save the form inputs if needed. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Attempt to make a save when creating a new atom. Use the browser tools to cause the save to fail i.e. going offline or removing auth cookies. Observe the new functionality allows you to reattempt a save. 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
User's don't lose their changes entirely and can attempt to save an atom again. 