### PR TITLE
Force SDR colourspace for HLS video

### DIFF
--- a/uploader/src/main/resources/cfn-template.yaml
+++ b/uploader/src/main/resources/cfn-template.yaml
@@ -265,6 +265,9 @@ Resources:
                 NameModifier: "hls"
                 VideoDescription:
                   Height: 720
+                  VideoPreprocessors:
+                    ColorCorrector:
+                      ColorSpaceConversion: FORCE_709 #Convert to Rec.709 colourspace as per HLS spec pt. 1.24
                   Sharpness: 100 # Sharpest possible
                   CodecSettings:
                     Codec: H_264

--- a/uploader/src/main/resources/cfn-template.yaml
+++ b/uploader/src/main/resources/cfn-template.yaml
@@ -266,8 +266,8 @@ Resources:
                 VideoDescription:
                   Height: 720
                   VideoPreprocessors:
-                    ColorCorrector:
-                      ColorSpaceConversion: FORCE_709 #Convert to Rec.709 colourspace as per HLS spec pt. 1.24
+                    ColorCorrector: # NOTE: only needed for m3u8
+                      ColorSpaceConversion: FORCE_709 # Convert to Rec.709 SDR colourspace as per HLS spec pt. 1.24 
                   Sharpness: 100 # Sharpest possible
                   CodecSettings:
                     Codec: H_264


### PR DESCRIPTION
## What does this change?

We (currently!) only provide one video track for HLS. As per HTTP Live Streaming (HLS) authoring [specification](https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices#:~:text=For%20backward%20compatibility%2C%20SDR%20streams%20MUST%20be%20provided), at least one SDR track MUST be provided.

While extremely unlikely in practice, it is technically possible for users to upload HDR video content. Such m3u8 works outside Apple, but fails on some Apple devices as it fails to satisfy this spec requirement.

This PR forces all videos uploaded to be converted to standard SDR colourspcae: Rec. 709.

When we (finally!) have more video tracks in HLS, we should leave (at least some) free to passthrough HDR content and only leave this one forcing SDR.
 
While it would be more consistent to apply the same change to naked mp4 track, I left it out as it’s not strictly required there (including when this naked asset is played in the same Safari…).

## How to test

Try playing m3u8 produced by uploading HDR video without and with this change. Only the latter should play eg. in Safari.

Successfully tested on CODE:
https://uploads.guimcode.co.uk/2025/10/02/HDR_test--dff9bf2a-c099-44e0-8e16-9f460347e570-1.0.m3u8

## How can we measure success?

We are less likely to silently not play on some devices in an unlikely scenario of someone uploading HDR content.

## Have we considered potential risks?

That’s why we are doing it.