### PR TITLE
Adds logging for YouTubes reported video duration

### DIFF
--- a/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeVideos.scala
@@ -42,6 +42,9 @@ trait YouTubeVideos { this: YouTubeAccess with Logging =>
         // YouTube API returns duration is in ISO 8601 format
         // https://developers.google.com/youtube/v3/docs/videos#contentDetails.duration
         val iso8601Duration = video.getContentDetails.getDuration
+
+        log.info(s"YouTube reported a duration of $iso8601Duration for asset: $youtubeId")
+
         Some(ISO8601Duration.toSeconds(iso8601Duration))
       }
       case None => {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Adds logging to help identify issues where videos asset have a zero duration after an asset has been activated.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Testable locally,  should look like:

```
{"@timestamp":"2025-10-06T17:07:24.240+01:00","@version":"1","message":"YouTube reported a duration of PT5S for asset: RJzDEZCpO5Q","logger_name":"util.YouTube$$anon$1","thread_name":"application-pekko.actor.default-dispatcher-7","level":"INFO","level_value":20000,"application.home":"/Users/Sam_Hession/Code/media-atom-maker"}
```
