### PR TITLE
Fixes a regression which allowed the client to go back to read-only on save failure

### DIFF
--- a/public/video-ui/src/actions/VideoActions/saveVideo.ts
+++ b/public/video-ui/src/actions/VideoActions/saveVideo.ts
@@ -16,18 +16,15 @@ export const saveVideo = (video: Video) => async (dispatch: AppDispatch) => {
   dispatch(setSaving(true));
   dispatch(setVideo(video));
 
-  const savedVideo: Video | undefined = await VideosApi.saveVideo(video.id, video)
+  const savedVideo: Video = await VideosApi.saveVideo(video.id, video)
     .catch(error => {
       const message = error.status === 409
         ? errorMessages.saveVideoConflict
         : errorMessages.saveVideoDefault;
       dispatch(showError(message, error));
-      return undefined;
+      throw error;
     });
-  if (!savedVideo) {
-    dispatch(setSaving(false));
-    return;
-  }
+
   dispatch(setVideo(savedVideo));
 
   const usageData: UsageData | undefined = await dispatch(fetchUsages(video.id)).unwrap().catch(error => {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Reintroduces a feature from #1232 and regressed in #1316. This change prevents the UI from leaving the editing state if the video fails to update. In does permit failure to update usages inline with the original PR.

| Before | After |
|--------|--------|
| ![2025-10-07 09 35 48](https://github.com/user-attachments/assets/535659f0-ceb1-493d-bb4d-0ca420711bfe) | ![2025-10-07 09 34 36](https://github.com/user-attachments/assets/8068c655-43f6-47d6-b80a-af4a0a34a9c5) | 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Testable locally, try saving furniture updates whilst in offline mode or blocking traffic. See how the edit state remains open until a save succeeds. 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Clearer to users that saves have failed and a chance to attempt them again. 
