### PR TITLE
Run eslint for .jsx and .tsx files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,14 +1,13 @@
 module.exports = {
   parser: '@typescript-eslint/parser',
-  extends: [
-    'plugin:react/recommended',
-  ],
+  extends: ['plugin:react/recommended'],
+
   parserOptions: {
     ecmaVersion: 2020,
     sourceType: 'module',
     ecmaFeatures: {
       jsx: true
-    },
+    }
   },
   plugins: ['react', 'prettier'],
   rules: {
@@ -22,5 +21,10 @@ module.exports = {
     react: {
       version: 'detect'
     }
-  }
+  },
+  overrides: [
+    {
+      files: ['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx']
+    }
+  ]
 };

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "scripts": {
     "build": "tsc && vite build",
     "client-dev": "vite",
-    "lint": "eslint public/video-ui/src/**/** --ext .js,.ts --no-error-on-unmatched-pattern",
-    "test": "jest"
+    "lint": "eslint public/video-ui/src/**/** --no-error-on-unmatched-pattern",
+    "lint:fix": "eslint public/video-ui/src/**/** --fix --no-error-on-unmatched-pattern",
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
   },
   "jest": {
     "roots": [

--- a/public/video-ui/src/components/FormFields/CheckBox.jsx
+++ b/public/video-ui/src/components/FormFields/CheckBox.jsx
@@ -15,7 +15,7 @@ export default class CheckBox extends React.Component {
           onChange={e => {
             this.props.onUpdateField(e.target.checked);
           }}
-          className='form-checkbox'
+          className="form-checkbox"
         />
       </div>
     );

--- a/public/video-ui/src/components/FormFields/ExpireNow.tsx
+++ b/public/video-ui/src/components/FormFields/ExpireNow.tsx
@@ -38,5 +38,5 @@ export const ExpireNowComponent = (props:ExpireNowComponentProps ) => {
       </div>
     </div>
   );
-}
+};
 

--- a/public/video-ui/src/components/FormFields/PureTagPicker.jsx
+++ b/public/video-ui/src/components/FormFields/PureTagPicker.jsx
@@ -16,16 +16,16 @@ class PureTagPicker extends React.Component {
     inputClearCount: PropTypes.number.isRequired,
     inputPlaceholder: PropTypes.string.isRequired,
     updateSideEffects: PropTypes.func
-  }
+  };
 
   state = {
-    inputString: '',
+    inputString: ''
   };
 
   componentDidUpdate(prevProps) {
     if (prevProps.inputClearCount !== this.props.inputClearCount) {
       this.setState({
-        inputString: '',
+        inputString: ''
       });
     }
   }
@@ -37,7 +37,7 @@ class PureTagPicker extends React.Component {
     this.setState({
       inputString: searchText
     });
-  }
+  };
 
   selectNewTag = (newFieldValue) => {
 
@@ -46,7 +46,7 @@ class PureTagPicker extends React.Component {
       });
 
       this.props.onUpdate(newFieldValue);
-  }
+  };
 
   render() {
 

--- a/public/video-ui/src/components/FormFields/RichTextField.tsx
+++ b/public/video-ui/src/components/FormFields/RichTextField.tsx
@@ -24,7 +24,7 @@ type EditorProps = {
 
 export default class RichTextField extends React.Component<EditorProps, EditorState> {
   state: EditorState = {
-    wordCount: 0,
+    wordCount: 0
   };
 
   componentDidMount() {

--- a/public/video-ui/src/components/FormFields/SelectBox.jsx
+++ b/public/video-ui/src/components/FormFields/SelectBox.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const pleaseSelect = "Please select..."
+const pleaseSelect = "Please select...";
 
 export default class SelectBox extends React.Component {
   getClassName = () => {

--- a/public/video-ui/src/components/FormFields/TagPicker.jsx
+++ b/public/video-ui/src/components/FormFields/TagPicker.jsx
@@ -84,7 +84,7 @@ class TagPicker extends React.Component {
       webTitle: tag.externalName,
       detailedTitle: tag.internalName
     };
-  }
+  };
 
   fetchTags = searchText => {
     const tagTypes = this._getTagTypes();
@@ -112,9 +112,9 @@ class TagPicker extends React.Component {
           });
         });
     }
-  }
+  };
 
-  debouncedFetchTags = debounce(this.fetchTags, 500)
+  debouncedFetchTags = debounce(this.fetchTags, 500);
 
   onUpdate = newValue => {
     this.setState({
@@ -169,13 +169,13 @@ class TagPicker extends React.Component {
     this.setState({
       inputClearCount: this.state.inputClearCount + 1
     });
-  }
+  };
 
   tagsToVisible = () => {
     this.setState({
       tagsVisible: true
     });
-  }
+  };
 
   onKeyDown = (e) => {
 
@@ -223,7 +223,7 @@ class TagPicker extends React.Component {
 
       this.onUpdate(newFieldValue);
     }
-  }
+  };
 
   renderSelectedTags = () => {
 
@@ -240,7 +240,7 @@ class TagPicker extends React.Component {
         removeFn={this.removeFn}
       />
     );
-  }
+  };
 
   renderTag = (tag, index) => {
     return (
@@ -257,7 +257,7 @@ class TagPicker extends React.Component {
         </span>
       </div>
     );
-  }
+  };
 
   renderTagPicker() {
 

--- a/public/video-ui/src/components/FormFields/TagPicker.test.jsx
+++ b/public/video-ui/src/components/FormFields/TagPicker.test.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Provider } from 'react-redux'
+import { Provider } from 'react-redux';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { userEvent } from '@testing-library/user-event';
 import { setupStore } from '../../util/setupStore';
 import { setConfig } from '../../slices/config';
 
-let mockedGetTagsByType = jest.fn();
+const mockedGetTagsByType = jest.fn();
 jest.mock('../../services/tagmanager', () => ({
   __esModule: true,
   getTagsByType: mockedGetTagsByType
@@ -23,7 +23,7 @@ const defaultProps = {
 	hasWarning: () => false,
 	hasError: () => false,
 	notification: { message: '' },
-	inputPlaceholder: 'Search for tags...',
+	inputPlaceholder: 'Search for tags...'
 };
 
 const store = setupStore();
@@ -38,7 +38,7 @@ describe('TagPicker', () => {
       mockedGetTagsByType.mockResolvedValue({
         data: [
           { data: { path: 'keyword/first-tag', externalName: 'Tag first external', internalName: 'Tag first (internal)' } },
-          { data: { path: 'keyword/second-tag', externalName: 'Tag second external', internalName: 'Tag second (internal)' } },
+          { data: { path: 'keyword/second-tag', externalName: 'Tag second external', internalName: 'Tag second (internal)' } }
         ]
       });
 

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.jsx
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
 import { PropTypes } from 'prop-types';
+import React from 'react';
 import { keyCodes } from '../../constants/keyCodes';
-import UserActions from '../../constants/UserActions';
 import TagTypes from '../../constants/TagTypes';
-import TagSearch from '../TagSearch/TagSearch';
+import UserActions from '../../constants/UserActions';
 import removeStringTagDuplicates from '../../util/removeStringTagDuplicates';
+import TagSearch from '../TagSearch/TagSearch';
 
 export default class TextInputTagPicker extends React.Component {
 
@@ -29,7 +29,7 @@ export default class TextInputTagPicker extends React.Component {
     lastAction: UserActions.other
   };
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.inputClearCount !== nextProps.inputClearCount) {
       this.setState({
         inputString: ''

--- a/public/video-ui/src/components/FormFields/TextInputTagPicker.jsx
+++ b/public/video-ui/src/components/FormFields/TextInputTagPicker.jsx
@@ -26,13 +26,13 @@ export default class TextInputTagPicker extends React.Component {
 
   state = {
     inputString: '',
-    lastAction: UserActions.other,
+    lastAction: UserActions.other
   };
 
   componentWillReceiveProps(nextProps) {
     if (this.props.inputClearCount !== nextProps.inputClearCount) {
       this.setState({
-        inputString: '',
+        inputString: ''
       });
     }
   }
@@ -109,7 +109,7 @@ export default class TextInputTagPicker extends React.Component {
           this.props.onUpdate(newFieldValue)
           .then(() => {
             this.setState({
-              inputString: '',
+              inputString: ''
             });
           });
         }

--- a/public/video-ui/src/components/ManagedForm/ManagedField.jsx
+++ b/public/video-ui/src/components/ManagedForm/ManagedField.jsx
@@ -61,7 +61,7 @@ export class ManagedField extends React.Component {
       this.props.isDesired,
       this.props.customValidation,
       composerValidation,
-      this.props.maxLength,
+      this.props.maxLength
     );
 
     if (this.props.updateFormErrors) {

--- a/public/video-ui/src/components/ScheduledLaunch/ScheduledLaunch.jsx
+++ b/public/video-ui/src/components/ScheduledLaunch/ScheduledLaunch.jsx
@@ -148,7 +148,7 @@ class ScheduledLaunch extends React.Component {
     }
 
     return null;
-  }
+  };
 
   /* Render functions */
 
@@ -225,7 +225,7 @@ class ScheduledLaunch extends React.Component {
           : selectedEmbargoDate
       }
     />
-  )
+  );
 
   renderSaveButton = (propertyName, selectedScheduleDate, selectedEmbargoDate, invalidDateError) => (
     <button
@@ -239,7 +239,7 @@ class ScheduledLaunch extends React.Component {
     >
       Save
     </button>
-  )
+  );
 
   renderRemoveButton = propertyName => (
     <button
@@ -248,7 +248,7 @@ class ScheduledLaunch extends React.Component {
     >
       Remove
     </button>
-  )
+  );
 
   renderCancelButton = () => (
     <button
@@ -261,7 +261,7 @@ class ScheduledLaunch extends React.Component {
     >
       Cancel
     </button>
-  )
+  );
 
   renderSchedulerButton = (showScheduleOptions) => {
 
@@ -285,7 +285,7 @@ class ScheduledLaunch extends React.Component {
         </button>
       </div>
     );
-  }
+  };
 
   render() {
     const {

--- a/public/video-ui/src/components/TagSearch/TagSearch.jsx
+++ b/public/video-ui/src/components/TagSearch/TagSearch.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 class TagSearch extends React.Component {
   constructor(props) {
     super(props);
+    this.listNodeRef = React.createRef();
   }
 
   componentDidUpdate(prevProps) {
@@ -12,10 +13,9 @@ class TagSearch extends React.Component {
       nextProps.selectedTagIndex !== null &&
       prevProps.selectedTagIndex !== nextProps.selectedTagIndex
     ) {
-      const listNode = this.refs.list;
-      const elementHeight = listNode.children[0].offsetHeight;
-      if (listNode) {
-        listNode.scrollTop =
+      if (this.listNodeRef.current) {
+        const elementHeight = this.listNodeRef.current.children[0].offsetHeight;
+        this.listNodeRef.current.scrollTop =
           elementHeight *
           (nextProps.selectedTagIndex === 0
             ? 0
@@ -62,11 +62,13 @@ class TagSearch extends React.Component {
     if (this.props.searchResultTags.length !== 0 && this.props.showTags) {
       return (
         <ul
-          ref="list"
+          ref={this.listNodeRef}
           className="form__field__tags"
           onMouseDown={this.props.tagsToVisible}
         >
-          {this.props.searchResultTags.map((tag, index) => this.renderTags(tag, index))}
+          {this.props.searchResultTags.map((tag, index) =>
+            this.renderTags(tag, index)
+          )}
         </ul>
       );
     }

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.jsx
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { Asset } from './VideoAsset';
-import VideoUtils from '../../util/video';
 
 export default class VideoTrail extends React.Component {
   polling = null;
 
-  componentWillReceiveProps() {
+  UNSAFE_componentWillReceiveProps() {
     if (!this.polling) {
       this.polling = setInterval(() => this.pollIfRequired(), 5000);
     }
@@ -29,13 +28,16 @@ export default class VideoTrail extends React.Component {
   getAssets = () => {
     const ret = [];
 
-    if (this.props.s3Upload.status === "complete") {
+    if (this.props.s3Upload.status === 'complete') {
       this.props.getUploads();
       this.props.s3UploadPostProcessing(); // reset status to 'post processing'
     }
-    if (this.props.uploads.every(upload => {
-      return !upload.processing;
-    }) && this.props.s3Upload.status === "post-processing") {
+    if (
+      this.props.uploads.every(upload => {
+        return !upload.processing;
+      }) &&
+      this.props.s3Upload.status === 'post-processing'
+    ) {
       this.props.getVideo(this.props.video.id);
       this.props.s3UploadReset();
     }
@@ -57,7 +59,7 @@ export default class VideoTrail extends React.Component {
       // prevent duplication by omitting currently uploading item
       // s3Upload.id: <atomId>-<version>
       // upload.id: <version>
-      const id = this.props.video.id + "-" + upload.id;
+      const id = this.props.video.id + '-' + upload.id;
       if (id !== this.props.s3Upload.id) {
         ret.push(upload);
       }
@@ -67,14 +69,13 @@ export default class VideoTrail extends React.Component {
   };
 
   render() {
-    const deleteAssetsInUpload = async (asset) => {
+    const deleteAssetsInUpload = async asset => {
       if (asset.id) {
         // if "asset.id" property exists, it should be a Youtube video asset.
         // There should be one asset for Youtube video and we can delete
         // it from the atom with this "asset.id"
         this.props.deleteAssets(this.props.video, [asset.id]);
-      }
-      else {
+      } else {
         // if "asset.id" property does not exist, it should be a self-hosting
         // video asset.  There may be multiple assets for a self-hosted video.
         // We can extract the asset IDs from the "src" property of each member
@@ -93,7 +94,7 @@ export default class VideoTrail extends React.Component {
           upload={upload}
           isActive={parseInt(upload.id) === this.props.activeVersion}
           selectAsset={() => {
-            if (typeof this.props.activatingAssetNumber=== "number") {
+            if (typeof this.props.activatingAssetNumber === 'number') {
               return;
             }
             return this.props.selectAsset(Number(upload.id));

--- a/public/video-ui/src/components/VideoUsages/VideoUsages.jsx
+++ b/public/video-ui/src/components/VideoUsages/VideoUsages.jsx
@@ -77,7 +77,7 @@ export default class VideoUsages extends React.Component {
 
       return (
         <div key={`${state}-usages`}>
-          <p className='details-list__title'>{`${state.charAt(0).toUpperCase() + state.slice(1)} (Total: ${totalUsages})`}</p>
+          <p className="details-list__title">{`${state.charAt(0).toUpperCase() + state.slice(1)} (Total: ${totalUsages})`}</p>
           {totalUsages === 0
             ? <p className="usage--none details-list__field">{`No ${state} usages found`}</p>
             : <ul className="detail__list">

--- a/public/video-ui/src/components/YoutubeFurniture/index.jsx
+++ b/public/video-ui/src/components/YoutubeFurniture/index.jsx
@@ -87,7 +87,7 @@ class YoutubeFurniture extends React.Component {
       editable,
       updateVideo,
       updateErrors,
-      updateWarnings,
+      updateWarnings
     } = this.props;
 
     const { categories } = this.props.youtube;

--- a/public/video-ui/src/components/utils/YouTubeEmbed.jsx
+++ b/public/video-ui/src/components/utils/YouTubeEmbed.jsx
@@ -5,7 +5,7 @@ import { getStore } from '../../util/storeAccessor';
 export const getYouTubeEmbedUrl = (id) => {
   const embedUrl = getStore().getState().config.youtubeEmbedUrl;
   return `${embedUrl}${id}?showinfo=0&rel=0`;
-}
+};
 export function YouTubeEmbed({ id, className, largePreview }) {
   return (
     <iframe

--- a/public/video-ui/src/pages/Upload/index.jsx
+++ b/public/video-ui/src/pages/Upload/index.jsx
@@ -1,17 +1,17 @@
 import React from 'react';
-import VideoTrail from '../../components/VideoUpload/VideoTrail';
-import { getStore } from '../../util/storeAccessor';
-import AddAssetFromURL from '../../components/VideoUpload/AddAssetFromURL';
-import { PlutoProjectPicker } from '../../components/Pluto/PlutoProjectPicker';
-import AddSelfHostedAsset from '../../components/VideoUpload/AddSelfHostedAsset';
-import YoutubeUpload from '../../components/VideoUpload/YoutubeUpload';
 import PlutoProjectLink from '../../components/Pluto/PlutoProjectLink';
+import { PlutoProjectPicker } from '../../components/Pluto/PlutoProjectPicker';
+import AddAssetFromURL from '../../components/VideoUpload/AddAssetFromURL';
+import AddSelfHostedAsset from '../../components/VideoUpload/AddSelfHostedAsset';
+import VideoTrail from '../../components/VideoUpload/VideoTrail';
+import YoutubeUpload from '../../components/VideoUpload/YoutubeUpload';
+import { getStore } from '../../util/storeAccessor';
 
 class VideoUpload extends React.Component {
   hasCategories = () => this.props.youtube?.categories?.length !== 0;
   hasChannels = () => this.props.youtube?.channels?.length !== 0;
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.props.videoActions.getVideo(this.props.params.id);
     if (!this.hasCategories()) {
       this.props.youtubeActions.fetchCategories();
@@ -84,7 +84,9 @@ class VideoUpload extends React.Component {
                 this.props.uploadActions.s3UploadPostProcessing
               }
               s3UploadReset={this.props.uploadActions.s3UploadReset}
-              activatingAssetNumber={this.props.saveState?.activatingAssetNumber}
+              activatingAssetNumber={
+                this.props.saveState?.activatingAssetNumber
+              }
               getVideo={this.props.videoActions.getVideo}
             />
           </div>
@@ -97,15 +99,21 @@ class VideoUpload extends React.Component {
 //REDUX CONNECTIONS
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import * as getVideo from '../../actions/VideoActions/getVideo';
-import * as saveVideo from '../../actions/VideoActions/saveVideo';
 import * as createAsset from '../../actions/VideoActions/createAsset';
-import * as revertAsset from '../../actions/VideoActions/revertAsset';
 import * as allDeleteAssetActions from '../../actions/VideoActions/deleteAsset';
+import * as getVideo from '../../actions/VideoActions/getVideo';
+import * as revertAsset from '../../actions/VideoActions/revertAsset';
+import * as saveVideo from '../../actions/VideoActions/saveVideo';
+import {
+  deleteSubtitle,
+  resetS3UploadState,
+  setS3UploadStatusToPostProcessing,
+  startSubtitleFileUpload,
+  startVideoUpload
+} from '../../slices/s3Upload';
+import { getUploads } from '../../slices/uploads';
+import { selectVideo } from '../../slices/video';
 import { fetchCategories, fetchChannels } from '../../slices/youtube';
-import {setS3UploadStatusToPostProcessing, resetS3UploadState, startVideoUpload, startSubtitleFileUpload, deleteSubtitle} from "../../slices/s3Upload";
-import {selectVideo} from "../../slices/video";
-import {getUploads} from "../../slices/uploads";
 
 function mapStateToProps(state) {
   return {

--- a/public/video-ui/src/pages/Video/tabs/Pluto.jsx
+++ b/public/video-ui/src/pages/Video/tabs/Pluto.jsx
@@ -48,7 +48,7 @@ export class PlutoTabPanel extends React.Component {
 
 const ReadOnlyPlutoItem = ({id, itemType}) => {
 
-  const [ title, setTitle ] = useState(id ? "Loading..." : "")
+  const [ title, setTitle ] = useState(id ? "Loading..." : "");
 
   if(id) {
     useEffect(() => {
@@ -56,8 +56,8 @@ const ReadOnlyPlutoItem = ({id, itemType}) => {
         const errorMessage = `Failed to lookup ${itemType} with ID '${id}'`;
         console.error(errorMessage, e);
         setTitle(errorMessage);
-      })}, [])
+      });}, []);
   }
 
-  return <p className="details-list__field">{title}</p>
-}
+  return <p className="details-list__field">{title}</p>;
+};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

I realised that the `yarn lint` command was only applying to files with `.js` and `.ts` extensions. This PR removes the list of extensions from the lint command, and adds a new list to the `.eslintrc.js` file, which now includes `.jxs` and `.tsx` as well.

I subsequently ran eslint with the `--fix` flag, which fixed a number of issues (largely formatting ones). There were then a handful of errors remaining, which I've fixed manually. I've tried to keep the manual fixes as minimal as possible, so for the deprecated methods I've just updated their names to `UNSAFE_*` rather than trying to refactor the component to not use the method anymore. (Refactoring will be required before upgrading to React 17, just fyi.)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
