### PR TITLE
Don’t squash thumbnails

### DIFF
--- a/public/video-ui/styles/layout/_common.scss
+++ b/public/video-ui/styles/layout/_common.scss
@@ -4,6 +4,7 @@
   width: 100%;
   height: 0;
   padding-top: 56.25%; // 16:9 ratio
+  object-fit: contain;
 
   :first-child {
     position: absolute;


### PR DESCRIPTION
## What does this change?

Squashing (or squishing?) images is a crime against humanity and should happen under no circumstances. Turns out, it was happening to every single thumbnail, but only slightly. With the introduction of off-16:9 ratios, this became (more than) noticeable.

Will also help to tell if loop asset is correctly 5:4.

## How to test

I don’t know. See a GIF and trust me CSS chops.

## How can we measure success?

It’s gonna make us rich and successful in the ideas market. 

## Have we considered potential risks?

We are terrified of risks. That’s why we never do anything major. Or – anything.
## Images

![fit](https://github.com/user-attachments/assets/befab07c-3fd1-4de1-b1f7-a4411fb9aaa9)

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
