### PR TITLE
convert to java 21

### DIFF
--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: 
+  workflow_dispatch:
 jobs:
   dependency-graph:
     runs-on: ubuntu-latest
@@ -11,15 +11,8 @@ jobs:
       - name: Checkout branch
         id: checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - name: Install Java
-        id: java
-        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.2.0
-        with:
-          distribution: corretto
-          java-version: 17
-      - name: Install sbt
-        id: sbt
-        uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
+      - name: Install Java/Scala/sbt
+        uses: guardian/setup-scala@v1
       - name: Submit dependencies
         id: submit
         uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java corretto-11.0.22.7.1
+java corretto-21.0.3.9.1

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val jacksonVersion = "2.19.1"
 
 lazy val commonSettings = Seq(
   ThisBuild / scalaVersion := "2.13.16",
-  scalacOptions ++= Seq("-feature", "-deprecation", "-release:11"),
+  scalacOptions ++= Seq("-feature", "-deprecation", "-release:21"),
   ThisBuild / organization := "com.gu",
 
   resolvers ++= Resolver.sonatypeOssRepos("releases"),

--- a/cloudformation/media-atom-maker-dev.yml
+++ b/cloudformation/media-atom-maker-dev.yml
@@ -319,7 +319,7 @@ Resources:
           CONFIG_KEY: !FindInMap [LambdaConfig, Expirer, DEV]
       MemorySize: 256
       Role: !GetAtt ExpirerRole.Arn
-      Runtime: "java11"
+      Runtime: "java21"
       Timeout: 300
 
   SchedulerLambda:
@@ -340,8 +340,9 @@ Resources:
           CONFIG_KEY: !FindInMap [LambdaConfig, Scheduler, DEV]
       MemorySize: 256
       Role: !GetAtt SchedulerRole.Arn
-      Runtime: "java11"
+      Runtime: "java21"
       Timeout: 300
+
   ExpirerLambdaTrigger:
     Type: "AWS::Events::Rule"
     Properties:

--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -13,7 +13,7 @@ deployments:
       app: media-atom-maker
       parameters:
         amiTags:
-          Recipe: editorial-tools-jammy-java11
+          Recipe: editorial-tools-jammy-java21
           AmigoStage: PROD
   media-atom-maker:
     type: autoscaling

--- a/uploader/src/main/resources/lambda-template.yaml
+++ b/uploader/src/main/resources/lambda-template.yaml
@@ -27,5 +27,5 @@
         MEDIA_CONVERT_ROLE: !GetAtt MediaConvertRole.Arn
     MemorySize: 512
     Role: !GetAtt LambdaExecutionRole.Arn
-    Runtime: "java11"
+    Runtime: "java21"
     Timeout: {{timeout}}


### PR DESCRIPTION
Upgrade the repo, app and lambdas to run on java 21.

Requires https://github.com/guardian/editorial-tools-platform/pull/989