### PR TITLE
Reveal all of thumbnail, and reduce margins in grid

### DIFF
--- a/public/video-ui/styles/layout/_grid.scss
+++ b/public/video-ui/styles/layout/_grid.scss
@@ -31,9 +31,10 @@
   border-top: 1px solid $brandColor;
 
   width: 300px;
-  height: 200px;
+  height: 240px;
 
-  margin: 8px;
+  margin-top: 4px;
+  margin-left: 8px;
 
   white-space: wrap;
   overflow: hidden;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We were losing 1/6th of the image behind the title field. Increase the size of grid items to accommodate the entire thumbnail, and reduce the gaps between items slightly to compensate slightly.

Before

<img width="1268" height="660" alt="image" src="https://github.com/user-attachments/assets/907113cc-9dec-46bd-8e37-23fd39c11505" />

After

<img width="1267" height="763" alt="image" src="https://github.com/user-attachments/assets/c2ea6ee3-d8d9-4434-8774-0278ac443af5" />


## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
