### PR TITLE
Revert "Place self-hosted upload form first"

### DIFF
--- a/public/video-ui/src/pages/Upload/index.jsx
+++ b/public/video-ui/src/pages/Upload/index.jsx
@@ -41,12 +41,6 @@ class VideoUpload extends React.Component {
                   />
                 </div>
               </div>
-              <AddSelfHostedAsset
-                video={this.props.video || {}}
-                permissions={getStore().getState().config.permissions}
-                uploading={uploading}
-                startUpload={this.props.uploadActions.startVideoUpload}
-              />
               <YoutubeUpload
                 video={this.props.video || {}}
                 categories={this.props.youtube.categories}
@@ -58,6 +52,12 @@ class VideoUpload extends React.Component {
               <AddAssetFromURL
                 video={this.props.video}
                 createAsset={this.props.videoActions.createAsset}
+              />
+              <AddSelfHostedAsset
+                video={this.props.video || {}}
+                permissions={getStore().getState().config.permissions}
+                uploading={uploading}
+                startUpload={this.props.uploadActions.startVideoUpload}
               />
             </div>
             <VideoTrail


### PR DESCRIPTION
## What does this change?

This reverts #1365. 

Users were getting confused between upload methods. As a result videos intended for Youtube (70% of our audience) were being uploaded as Loops. Sometimes we would realise and have to re-upload, other times we didn't even spot it.


| Before | After |
| ----------- | ---------- |
![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/1a78a46a-941d-43d6-a298-c21bb13f0565
[after]: https://github.com/user-attachments/assets/9e6c2d62-38ba-4628-af29-b99cf83fdcf9