### PR TITLE
Stop Activate button showing when video is already active

### DIFF
--- a/public/video-ui/src/components/VideoUpload/VideoAsset.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.tsx
@@ -299,6 +299,7 @@ export function Asset({
         <div className="video-trail__item__details">
           <AssetControls
             user={user}
+            isActive={isActive}
             selectAsset={selectAsset}
             deleteAsset={deleteAsset}
             isUploadInProgress={false}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Noticed during demo that Activate and Delete buttons show on an active video during processing of a subtitle upload.  The `isActive` flag is missing from the code for the reprocessing state.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Upload and activate a video.  Then upload subtitles.  The Activate and Delete buttons should not be shown.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Video is already active...
<img width="400" src="https://github.com/user-attachments/assets/a5a0ada3-71b2-4d8c-b8e8-8e7c1e6b86d6" />

But shows Active and Delete buttons during subtitle processing:
<img width="400" src="https://github.com/user-attachments/assets/2e0e0c79-95c6-417a-b50f-9f86fd9565f5" />

Fixed in CODE:
<img width="400" src="https://github.com/user-attachments/assets/e41d3d74-c992-4d46-bdc9-6b459debedb1" />


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
