### PR TITLE
Don't allow vtt subtitle upload

### DIFF
--- a/public/video-ui/src/components/VideoUpload/VideoAsset.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.tsx
@@ -185,10 +185,9 @@ function SubtitleActions({
     if (!file) return;
     const isSRT =
       file.name.endsWith('.srt') || file.type === 'application/x-subrip';
-    const isVTT = file.name.endsWith('.vtt') || file.type === 'text/vtt';
 
-    if (!isSRT && !isVTT) {
-      alert('Invalid file type. Please upload a .srt or .vtt subtitle file.');
+    if (!isSRT) {
+      alert('Invalid file type. Please upload a .srt subtitle file.');
       input.value = '';
       return;
     }
@@ -199,11 +198,8 @@ function SubtitleActions({
 
       const isSRTFormat =
         /\d{2}:\d{2}:\d{2},\d{3} --> \d{2}:\d{2}:\d{2},\d{3}/.test(text);
-      const isVTTFormat =
-        /^WEBVTT/m.test(text) &&
-        /\d{2}:\d{2}:\d{2}\.\d{3} --> \d{2}:\d{2}:\d{2}\.\d{3}/.test(text);
 
-      if ((isSRT && !isSRTFormat) || (isVTT && !isVTTFormat)) {
+      if (isSRT && !isSRTFormat) {
         alert('The file content does not match the expected subtitle format.');
         input.value = '';
         return;
@@ -225,7 +221,7 @@ function SubtitleActions({
       <input
         type="file"
         ref={fileInputRef}
-        accept=".srt,.vtt"
+        accept=".srt"
         style={{ display: 'none' }}
         onChange={handleFileChange}
       />


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We currently only support the SRT file type for subtitle processing in the transcoder, but the UI implies that VTT files would be accepted (which causes a transcoding error).

We could probably make the transcoder accept either, but for now this is not needed.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Upload a subtitle file - the file filter should only allow .srt files.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
