### PR TITLE
Don't have progress bar and status overlapping each other

### DIFF
--- a/public/video-ui/src/components/VideoUpload/VideoAsset.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.tsx
@@ -309,8 +309,8 @@ export function Asset({
     return (
       <div className="video-trail__item">
         <div className="video-trail__upload">
-          <AssetProgress {...processing} />
           <div>{processing.status}</div>
+          <AssetProgress {...processing} />
         </div>
         <div className="video-trail__item__details">
           <AssetControls

--- a/public/video-ui/styles/components/_video-trail.scss
+++ b/public/video-ui/styles/components/_video-trail.scss
@@ -1,13 +1,11 @@
-
 .video-trail__item {
-  position:relative;
+  position: relative;
   border-top: 1px solid $brandColor;
   width: 400px;
   margin: 8px;
-
 }
 
-.video-trail__asset{
+.video-trail__asset {
   display: flex;
   height: 250px;
   width: 100%;
@@ -18,26 +16,29 @@
   height: 100%;
 }
 
-
-.video-trail__upload{
+.video-trail__upload {
   display: flex;
   justify-content: center;
   align-items: center;
   flex-direction: column;
   height: 250px;
   row-gap: 20px;
+
+  & progress {
+    position: relative;
+  }
 }
 
 .video-trail__status__overlay {
-    position: absolute;
-    right: 5px;
-    top: 10px
+  position: absolute;
+  right: 5px;
+  top: 10px;
 }
 
 .video-trail__item__details {
   width: 100%;
   background-color: $color700Grey;
-  height:80px
+  height: 80px;
 }
 .video-trail__item__subtitles {
   border-top: 1px solid $brandColor;
@@ -51,7 +52,7 @@
   align-items: center;
   justify-content: center;
   margin-right: 5px;
-  width:40px;
+  width: 40px;
   border-radius: 50%;
   color: $color600Grey;
   background-color: $cWhite;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fix the styling for the progress bar on uploading assets. Previously it was occupying the same vertical space as the progress status text.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

|Before|After|
|-|-|
|<img width="417" height="347" alt="image" src="https://github.com/user-attachments/assets/c6e09c49-1a66-454e-bf4b-c5ed3cb1f64a" />|<img width="423" height="348" alt="image" src="https://github.com/user-attachments/assets/de8c8168-ee4d-4d52-bbde-4b8928d573ff" />|

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
