### PR TITLE
Consistent typing for activatingAssetNumber as `number | undefined`

### DIFF
--- a/public/video-ui/src/components/VideoUpload/VideoAsset.test.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.test.tsx
@@ -18,7 +18,7 @@ const defaultProps = {
   startSubtitleFileUpload: jest.fn(),
   deleteSubtitle: jest.fn(),
   permissions: {},
-  activatingAssetNumber: undefined as number
+  activatingAssetNumber: undefined as number | undefined
 };
 
 const defaultVideoAsset: VideoAsset = {

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.tsx
@@ -47,7 +47,7 @@ function AssetControls({
   selectAsset: { (): void };
   deleteAsset: { (): void };
   children: ReactNode;
-  activatingAssetNumber: number;
+  activatingAssetNumber?: number;
   isActivating: boolean;
   isUploadInProgress?: boolean;
 }) {
@@ -272,7 +272,7 @@ export function Asset({
   selectAsset: { (): void };
   deleteAsset: { (): void };
   permissions: Record<string, boolean>;
-  activatingAssetNumber: number;
+  activatingAssetNumber?: number;
 }) {
   const dispatch = useDispatch<AppDispatch>();
 

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.tsx
@@ -13,7 +13,7 @@ type Props = {
   uploads: Upload[];
   setAsset: (version: number) => void;
   permissions: Record<string, boolean>;
-  activatingAssetNumber: number;
+  activatingAssetNumber?: number;
 };
 
 export const VideoTrail = ({


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

`activatingAssetNumber` is typed as `number | undefined` in the store, but some of the consuming components have it typed as a `number`. I haven't been able to spot any type narrowing earlier in the component tree, and there are places where we seem to be assuming that it could be undefined (e.g. [typeof activatingAssetNumber === 'number'](https://github.com/guardian/media-atom-maker/blob/d28c295529da5fb118e47d46e03ecd29a6b7b9b8/public/video-ui/src/components/VideoUpload/VideoAsset.tsx#L59)) so it seems sensible to make downstream consumers of this value share the same typing as the store.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
