### PR TITLE
feat: Update content bundle map

### DIFF
--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -47,7 +47,8 @@ package object youtube {
     "science" -> "gdnpfpscience",
     "athletics" -> "gdnpfpsportother",
     "basketball" -> "gdnpfpsportus",
-    "sport-2-0" -> "gdnpfpsport20"
+    "sport-2-0" -> "gdnpfpsport20",
+    "full-story-podcast" -> "gdnpfpausfullstorypodcast"
   )
 
   case class YouTubeVideoCategory(id: Int, title: String)


### PR DESCRIPTION
## What does this change?
Updates the content bundle introduced in https://github.com/guardian/media-atom-maker/pull/464, adding a new `full-story-podcast` entry as requested by Tom Duffett.