### PR TITLE
Add cookie-based switch for whether or not to show Iconik UI

### DIFF
--- a/app/controllers/IconikController.scala
+++ b/app/controllers/IconikController.scala
@@ -6,7 +6,13 @@ import com.gu.pandahmac.HMACAuthActions
 import com.typesafe.config.Config
 import data.{DataStores, UnpackedDataStores}
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+import play.api.mvc.{
+  Action,
+  AnyContent,
+  BaseController,
+  ControllerComponents,
+  Cookie
+}
 import util.AWSConfig
 
 class IconikController(
@@ -20,7 +26,15 @@ class IconikController(
     with JsonRequestParsing
     with Logging {
 
-  import authActions.{APIAuthAction, APIHMACAuthAction}
+  import authActions.{APIAuthAction, APIHMACAuthAction, AuthAction}
+
+  def switchShowIconikUiOn(): Action[AnyContent] = AuthAction { implicit req =>
+    Redirect("/", FOUND).withCookies(Cookie("showIconik", "true"))
+  }
+
+  def switchShowIconikUiOff(): Action[AnyContent] = AuthAction { implicit req =>
+    Redirect("/", FOUND).withCookies(Cookie("showIconik", "false"))
+  }
 
   def getWorkingGroup(groupId: String): Action[AnyContent] = APIAuthAction {
     stores.iconikDataStore.getWorkingGroup(groupId) match {

--- a/app/controllers/VideoUIApp.scala
+++ b/app/controllers/VideoUIApp.scala
@@ -8,7 +8,13 @@ import com.gu.pandomainauth.model.User
 import model.{ClientConfig, Presence}
 import play.api.Configuration
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+import play.api.mvc.{
+  Action,
+  AnyContent,
+  BaseController,
+  ControllerComponents,
+  Cookie
+}
 import util.{AWSConfig, TrainingMode}
 import views.html.helper.CSRF
 
@@ -30,6 +36,11 @@ class VideoUIApp(
 
   def index(id: String = ""): Action[AnyContent] = AuthAction { implicit req =>
     val isTrainingMode = isInTrainingMode(req)
+    val shouldShowIconikUi = req.cookies.get("showIconik") match {
+      case Some(cookie) if cookie.value == "true"  => true
+      case Some(cookie) if cookie.value == "false" => false
+      case None => conf.get[String]("stage") != "PROD"
+    }
 
     val jsFileName = "video-ui/build/app.js"
 
@@ -61,7 +72,7 @@ class VideoUIApp(
       workflowUrl = awsConfig.workflowUrl,
       targetingUrl = awsConfig.targetingUrl,
       tagManagerUrl = awsConfig.tagManagerUrl,
-      showIconik = conf.get[String]("stage") != "PROD"
+      showIconik = shouldShowIconikUi
     )
 
     Ok(

--- a/conf/routes
+++ b/conf/routes
@@ -80,3 +80,7 @@ GET            /healthcheck                                     controllers.Heal
 
 #static assets
 GET            /assets/*file                                    controllers.Assets.versioned(path="/public", file: Asset)
+
+
+GET           /switches/iconik/off                              controllers.IconikController.switchShowIconikUiOff()
+GET           /switches/iconik/on                               controllers.IconikController.switchShowIconikUiOn()


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Previously, the Iconik UI was just being shown on non-PROD stages. This branch adds a couple of endpoints for setting a 'showIconik' cookie that will be used to determine whether or not to show the user the Iconik UI (using stage as a fallback if the cookie isn't set).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

If the Iconik UI switch is 'off', then the Iconik tab in a video page should say: `Iconik integration is not currently enabled.`

Run locally, then:

- [x] go to the Iconik tab for a video and check that the Iconik UI is enabled
- [x] visit `/switches/iconik/off` and check the Iconik UI is not enabled
- [x] visit `/switches/iconik/on` and check that it is enabled now

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

### Not enabled

<img width="877" height="119" alt="image" src="https://github.com/user-attachments/assets/c02dc792-e5b8-4950-8946-d70975bc56a4" />


### Enabled

<img width="952" height="120" alt="image" src="https://github.com/user-attachments/assets/1c8dc8a2-94d8-4002-b304-d260a012b99b" />

or

<img width="950" height="249" alt="image" src="https://github.com/user-attachments/assets/77c4fbcd-3388-4878-b946-5ce5196b6570" />



<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
