### PR TITLE
Just log when receiving a Pluto deletion message; don't delete

### DIFF
--- a/app/util/PlutoMessageConsumer.scala
+++ b/app/util/PlutoMessageConsumer.scala
@@ -64,15 +64,9 @@ case class PlutoMessageConsumer(val stores: DataStores, awsConfig: AWSConfig)
     (bodyJson \ "Message").validate[PlutoMessage] match {
       case JsSuccess(plutoMessage, _) => {
 
-        awsConfig.s3Client.deleteObject(
-          awsConfig.userUploadBucket,
-          plutoMessage.s3Key
+        log.info(
+          s"Received deletion message from Pluto for asset: ${plutoMessage.s3Key}. Deletion is no longer honoured, to avoid conflict with Iconik."
         )
-
-        stores.pluto.get(plutoMessage.s3Key) match {
-          case Some(upload) => stores.pluto.delete(plutoMessage.s3Key)
-          case _            =>
-        }
 
       }
       case undefined =>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We're moving from Pluto to a new media asset manager (Iconik).

The Pluto deletion message path was intended for Pluto to be able to tell media-atom-maker that it has ingested files that had been manually uploaded to media-atom-maker, so that the latter could delete its copy of the original upload. As far as we can see, this mechanism hasn't been working as expected for some time, so files haven't actually been deleted. The change here is just to make sure that Pluto _can't_ delete files, now that we're moving to the new system. 

I've added some logging so that we can see whether requests are in fact being sent, although as mentioned above the monitoring that we have on the Pluto table and the Kinesis streams suggest that they aren't being.

Once this has been tested and the deprecation of Pluto has advanced, we should come back and clear up the rest of the message processing code.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
