### PR TITLE
Bundling tags cleanup

### DIFF
--- a/common/src/main/scala/com/gu/media/youtube/package.scala
+++ b/common/src/main/scala/com/gu/media/youtube/package.scala
@@ -13,44 +13,6 @@ import com.gu.media.util.JsonDate._
 
 package object youtube {
 
-  def contentBundlingMap: Map[String, String] = Map(
-    "uk" -> "gdnpfpnewsuk",
-    "us" -> "gdnpfpnewsus",
-    "au" -> "gdnpfpnewsau",
-    "world" -> "gdnpfpnewsworld",
-    "politics" -> "gdnpfpnewspolitics",
-    "opinion" -> "gdnpfpnewsopinion",
-    "football" -> "gdnpfpsportfootball",
-    "cricket" -> "gdnpfpsportcricket",
-    "rugby-union" -> "gdnpfpsportrugbyunion",
-    "rugby-league" -> "gdnpfpsportrugbyleague",
-    "f1" -> "gdnpfpsportf1",
-    "tennis" -> "gdnpfpsporttennis",
-    "golf" -> "gdnpfpsportgolf",
-    "cycling" -> "gdnpfpsportcycling",
-    "boxing" -> "gdnpfpsportboxing",
-    "racing" -> "gdnpfpsportracing",
-    "us-sport" -> "gdnpfpsportus",
-    "sport" -> "gdnpfpsportother",
-    "culture" -> "gdnpfpculture",
-    "film" -> "gdnpfpculturefilm",
-    "music" -> "gdnpfpculturemusic",
-    "lifestyle" -> "gdnpfplifestyle",
-    "food" -> "gdnpfplifestylefood",
-    "health-and-wellbeing" -> "gdnpfplifestylehealthfitness",
-    "business" -> "gdnpfpbusiness",
-    "money" -> "gdnpfpmoney",
-    "fashion" -> "gdnpfpfashion",
-    "environment" -> "gdnpfpenvironment",
-    "technology" -> "gdnpfptechnology",
-    "travel" -> "gdnpfptravel",
-    "science" -> "gdnpfpscience",
-    "athletics" -> "gdnpfpsportother",
-    "basketball" -> "gdnpfpsportus",
-    "sport-2-0" -> "gdnpfpsport20",
-    "full-story-podcast" -> "gdnpfpausfullstorypodcast"
-  )
-
   case class YouTubeVideoCategory(id: Int, title: String)
 
   object YouTubeVideoCategory {

--- a/public/video-ui/src/components/Flags/index.jsx
+++ b/public/video-ui/src/components/Flags/index.jsx
@@ -18,7 +18,9 @@ class Flags extends React.Component {
   composerKeywordsToYouTube = () => {
     const { video, updateVideo } = this.props;
 
-    const fullTags = addOrDropBundlingTags(video.keywords, video.tags, video.blockAds);
+    const fullTags = addOrDropBundlingTags({
+      keywords: video.keywords, tags: video.tags, blockAds: video.blockAds
+    });
     const newVideo = Object.assign({}, video, { tags: fullTags });
     updateVideo(newVideo);
   };

--- a/public/video-ui/src/components/VideoData/VideoData.jsx
+++ b/public/video-ui/src/components/VideoData/VideoData.jsx
@@ -53,7 +53,9 @@ export default class VideoData extends React.Component {
   composerKeywordsToYouTube = () => {
     const { video, updateVideo } = this.props;
 
-    const fullTags = addOrDropBundlingTags(video.keywords, video.tags, video.blockAds);
+    const fullTags = addOrDropBundlingTags({
+      keywords: video.keywords, tags: video.tags, blockAds: video.blockAds
+    });
     const newVideo = Object.assign({}, video, { tags: fullTags });
     updateVideo(newVideo);
   };

--- a/public/video-ui/src/components/YoutubeFurniture/index.jsx
+++ b/public/video-ui/src/components/YoutubeFurniture/index.jsx
@@ -64,7 +64,9 @@ class YoutubeFurniture extends React.Component {
   composerKeywordsToYouTube = () => {
     const { video, updateVideo } = this.props;
 
-    const fullTags = addOrDropBundlingTags(video.keywords, video.tags, video.blockAds);
+    const fullTags = addOrDropBundlingTags({
+      keywords: video.keywords, tags: video.tags, blockAds: video.blockAds
+    });
     const newVideo = Object.assign({}, video, { tags: fullTags });
     updateVideo(newVideo);
   };

--- a/public/video-ui/src/services/KeywordsApi.ts
+++ b/public/video-ui/src/services/KeywordsApi.ts
@@ -38,7 +38,17 @@ const contentBundlingMap: Record<string, string> = {
 
 const contentBundlingTags = new Set(Object.values(contentBundlingMap));
 
-export const addOrDropBundlingTags = (keywords: string[], tags: string[], blockAds: boolean) => {
+/**
+  * Takes the current list of composer keywords, youtube tags, and the blockAds setting,
+  * and returns the list of tags which should be applied to the piece; either adding
+  * bundling tags where there is a match, or removing them if their matching keyword/tag
+  * has been removed or the blockAds setting enabled.
+  * @param keywords - the list of *composer* tags (should be the tag's id/path, eg. `sport/cycling`)
+  * @param tags - the list of *youtube* tags added in the Youtube furniture panel
+  * @param blockAds
+  * @returns an updated list of *youtube* tags
+  */
+export const addOrDropBundlingTags = ({ keywords, tags, blockAds }: { keywords: string[], tags: string[], blockAds: boolean }) => {
   // strip all gdnpfp... tags. If the composer keyword which caused them to be added
   // is still around, they'll come back, but if it's been removed or blockAds has been
   // turned on, then they'll be stripped out.

--- a/public/video-ui/src/services/KeywordsApi.ts
+++ b/public/video-ui/src/services/KeywordsApi.ts
@@ -43,9 +43,10 @@ const contentBundlingTags = new Set(Object.values(contentBundlingMap));
   * and returns the list of tags which should be applied to the piece; either adding
   * bundling tags where there is a match, or removing them if their matching keyword/tag
   * has been removed or the blockAds setting enabled.
-  * @param keywords - the list of *composer* tags (should be the tag's id/path, eg. `sport/cycling`)
-  * @param tags - the list of *youtube* tags added in the Youtube furniture panel
-  * @param blockAds
+  * @param params - the function parameters
+  * @param params.keywords - the list of *composer* tags (should be the tag's id/path, eg. `sport/cycling`)
+  * @param params.tags - the list of *youtube* tags added in the Youtube furniture panel
+  * @param params.blockAds
   * @returns an updated list of *youtube* tags
   */
 export const addOrDropBundlingTags = ({ keywords, tags, blockAds }: { keywords: string[], tags: string[], blockAds: boolean }) => {

--- a/public/video-ui/src/test/keywordsApi.spec.ts
+++ b/public/video-ui/src/test/keywordsApi.spec.ts
@@ -3,62 +3,62 @@ import { addOrDropBundlingTags } from "../services/KeywordsApi";
 describe('keywordsApi.addOrDropBundlingTags', () => {
 
   it('if no keywords or tags in, then nothing out', () => {
-    expect(addOrDropBundlingTags([], [], false)).toEqual([]);
+    expect(addOrDropBundlingTags({ keywords: [], tags: [], blockAds: false })).toEqual([]);
   });
 
   it('if a keyword matches one of the bundling specs, then add it and the bundle tag to output tags', () => {
     const keywords = ['world/africa'];
-    expect(addOrDropBundlingTags(keywords, [], false)).toEqual(['world', 'gdnpfpnewsworld']);
+    expect(addOrDropBundlingTags({ keywords, tags: [], blockAds: false })).toEqual(['world', 'gdnpfpnewsworld']);
   });
 
   it('if a tag matches one of the bundling specs, then add it to output tags', () => {
     const tags = ['world'];
-    expect(addOrDropBundlingTags([], tags, false)).toEqual(['world', 'gdnpfpnewsworld']);
+    expect(addOrDropBundlingTags({ keywords: [], tags, blockAds: false })).toEqual(['world', 'gdnpfpnewsworld']);
   });
 
   it('if the second element of the keyword matches one of the bundling specs, add it and the bundle tag to the output tags', () => {
     const keywords = ['africa/world']; // note reversed from usual "world/africa"
-    expect(addOrDropBundlingTags(keywords, [], false)).toEqual(['world', 'gdnpfpnewsworld']);
+    expect(addOrDropBundlingTags({ keywords, tags: [], blockAds: false })).toEqual(['world', 'gdnpfpnewsworld']);
   });
 
   it('if both elements of the keyword match the bundling specs, only add the second (more specific) as bundling tag', () => {
     const keywords = ['sport/cycling'];
-    expect(addOrDropBundlingTags(keywords, [], false)).toEqual(['cycling', 'gdnpfpsportcycling']);
+    expect(addOrDropBundlingTags({ keywords, tags: [], blockAds: false })).toEqual(['cycling', 'gdnpfpsportcycling']);
   });
 
   it('if a keyword matches one of the bundling specs but the matching tag already exists, don\'t duplicate', () => {
     const keywords = ['world/africa'];
     const tags = ['world', 'gdnpfpnewsworld'];
 
-    expect(addOrDropBundlingTags(keywords, tags, false)).toEqual(tags);
+    expect(addOrDropBundlingTags({ keywords, tags, blockAds: false })).toEqual(tags);
   });
 
   it('if a bundling tag exists but the matching keyword/tag has been removed, remove it', () => {
     const keywords: string[] = [];
     const tags = ['gdnpfpnewsworld'];
 
-    expect(addOrDropBundlingTags(keywords, tags, false)).toEqual([]);
+    expect(addOrDropBundlingTags({ keywords, tags, blockAds: false })).toEqual([]);
   });
 
   it('if multiple keywords match a certain bundling spec, still only add one', () => {
     const keywords = ['world/africa', 'world/asia'];
     const tags: string[] = [];
 
-    expect(addOrDropBundlingTags(keywords, tags, false)).toEqual(['world', 'gdnpfpnewsworld']);
+    expect(addOrDropBundlingTags({ keywords, tags, blockAds: false })).toEqual(['world', 'gdnpfpnewsworld']);
   });
 
   it('if blockAds is on, do not add bundling tags', () => {
     const keywords = ['world/africa'];
     const tags: string[] = [];
 
-    expect(addOrDropBundlingTags(keywords, tags, true)).toEqual([]);
+    expect(addOrDropBundlingTags({ keywords, tags, blockAds: true })).toEqual([]);
   });
 
   it('if blockAds is on and a bundling tag exists, remove it', () => {
     const keywords = ['world/africa'];
     const tags = ['world', 'gdnpfpnewsworld'];
 
-    expect(addOrDropBundlingTags(keywords, tags, true)).toEqual(['world']);
+    expect(addOrDropBundlingTags({ keywords, tags, blockAds: true })).toEqual(['world']);
   });
 
 });


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Two small cleanups around the content bundling tags after #1500 and #1410.

First remove the lookup table from the Scala code, since that's now not needed or used.
Then update the `addOrDropBundlingTags` function to take named parameters, since it's both using two parameters of the same type (which is easy to confuse) and a boolean parameter (which is easy to get mixed up what `true` vs. `false` means) 

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
