### PR TITLE
Add a 'createdAt' time when persisting new Iconik projects

### DIFF
--- a/app/data/IconikStore.scala
+++ b/app/data/IconikStore.scala
@@ -10,6 +10,8 @@ import com.gu.media.iconik.{
 }
 import com.gu.media.logging.Logging
 
+import java.time.LocalDateTime
+
 class IconikStore[E](
     projectStore: IconikDataStoreWithParentIndex[IconikProject, E],
     commissionStore: IconikDataStoreWithParentIndex[IconikCommission, E],
@@ -44,8 +46,11 @@ class IconikStore[E](
   def listWorkingGroups(): Either[E, List[IconikWorkingGroup]] =
     workingGroupStore.list
 
-  def upsertIconikData(request: IconikUpsertRequest): IconikProject = {
-    val project = IconikProject.fromUpsertRequest(request)
+  def upsertIconikData(
+      request: IconikUpsertRequest,
+      createdAtDateTime: Option[LocalDateTime] = None
+  ): IconikProject = {
+    val project = IconikProject.fromUpsertRequest(request, createdAtDateTime)
     projectStore.upsert(project)
     commissionStore.upsert(IconikCommission.fromUpsertRequest(request))
     workingGroupStore.upsert(IconikWorkingGroup.fromUpsertRequest(request))

--- a/app/data/IconikStore.scala
+++ b/app/data/IconikStore.scala
@@ -46,11 +46,37 @@ class IconikStore[E](
   def listWorkingGroups(): Either[E, List[IconikWorkingGroup]] =
     workingGroupStore.list
 
+  def localDateTimeOption(
+      dateTimeStr: String
+  ): Option[LocalDateTime] =
+    try {
+      Some(LocalDateTime.parse(dateTimeStr))
+    } catch {
+      case e: Exception =>
+        log.error(
+          s"Error parsing date time string '$dateTimeStr': ${e.getMessage}"
+        )
+        None
+    }
+
   def upsertIconikData(
       request: IconikUpsertRequest,
-      createdAtDateTime: Option[LocalDateTime] = None
+      createdAtDateTimeOverride: Option[LocalDateTime] = None
   ): IconikProject = {
-    val project = IconikProject.fromUpsertRequest(request, createdAtDateTime)
+    val maybeExistingProject = projectStore.getById(request.id) match {
+      case Right(Some(project)) => Some(project)
+      case Right(None)          => None
+      case Left(err) =>
+        log.error(
+          s"Error checking for existing project with id ${request.id}: $err"
+        )
+        None
+    }
+    val project = IconikProject.fromUpsertRequest(
+      request,
+      maybeExistingProject,
+      createdAtDateTimeOverride
+    )
     projectStore.upsert(project)
     commissionStore.upsert(IconikCommission.fromUpsertRequest(request))
     workingGroupStore.upsert(IconikWorkingGroup.fromUpsertRequest(request))

--- a/common/src/main/scala/com/gu/media/iconik/IconikInMemoryStore.scala
+++ b/common/src/main/scala/com/gu/media/iconik/IconikInMemoryStore.scala
@@ -12,7 +12,11 @@ class IconikInMemoryStore[T <: IconikItem, E] extends IconikDataStore[T, E] {
 
   override def list: Either[E, List[T]] = Right(store.toList)
 
-  override def upsert(item: T): Unit = store.addOne(item)
+  override def upsert(item: T): Unit = {
+    val maybeExistingItem = store.find(_.id == item.id)
+    maybeExistingItem.foreach(existingItem => store -= existingItem)
+    store += item
+  }
 
   override def deleteById(id: String): Unit = store.filterInPlace(_.id != id)
 }

--- a/common/src/main/scala/com/gu/media/iconik/IconikModels.scala
+++ b/common/src/main/scala/com/gu/media/iconik/IconikModels.scala
@@ -6,6 +6,8 @@ import org.scanamo.DynamoFormat
 import org.scanamo.generic.semiauto._
 import play.api.libs.json._
 
+import java.time.LocalDateTime
+
 abstract class IconikItem {
   val id: String
   val title: String
@@ -69,7 +71,8 @@ case class IconikProject(
     status: String,
     workingGroupId: String,
     commissionId: String,
-    masterPlaceholderId: Option[String]
+    masterPlaceholderId: Option[String],
+    createdAt: Option[String]
 ) extends IconikItemWithParentId {
   val parentId: String = commissionId
 }
@@ -81,15 +84,25 @@ object IconikProject {
   implicit def dynamoFormat: DynamoFormat[IconikProject] =
     deriveDynamoFormat
 
-  def fromUpsertRequest(req: IconikUpsertRequest): IconikProject =
+  def fromUpsertRequest(
+      req: IconikUpsertRequest,
+      createdAtDateTime: Option[LocalDateTime] = None
+  ): IconikProject = {
+    val createdAt = createdAtDateTime.getOrElse(LocalDateTime.now())
+
     IconikProject(
       id = req.id,
       title = req.title,
       status = req.status,
       workingGroupId = req.workingGroupId,
       commissionId = req.commissionId,
-      masterPlaceholderId = req.masterPlaceholderId
+      masterPlaceholderId = req.masterPlaceholderId,
+      createdAt = Some(
+        createdAt
+          .format(java.time.format.DateTimeFormatter.ISO_DATE_TIME)
+      )
     )
+  }
 }
 
 // This represents the payload the `iconik-message-ingestion` lambda sends,

--- a/common/src/main/scala/com/gu/media/iconik/IconikModels.scala
+++ b/common/src/main/scala/com/gu/media/iconik/IconikModels.scala
@@ -86,9 +86,21 @@ object IconikProject {
 
   def fromUpsertRequest(
       req: IconikUpsertRequest,
-      createdAtDateTime: Option[LocalDateTime] = None
+      maybeExistingProject: Option[IconikProject] = None,
+      createdAtDateTimeOverride: Option[LocalDateTime] = None
   ): IconikProject = {
-    val createdAt = createdAtDateTime.getOrElse(LocalDateTime.now())
+
+    val createdAt = createdAtDateTimeOverride
+      .map(_.format(java.time.format.DateTimeFormatter.ISO_DATE_TIME))
+      .getOrElse(
+        maybeExistingProject
+          .flatMap(_.createdAt)
+          .getOrElse(
+            LocalDateTime
+              .now()
+              .format(java.time.format.DateTimeFormatter.ISO_DATE_TIME)
+          )
+      )
 
     IconikProject(
       id = req.id,
@@ -99,7 +111,6 @@ object IconikProject {
       masterPlaceholderId = req.masterPlaceholderId,
       createdAt = Some(
         createdAt
-          .format(java.time.format.DateTimeFormatter.ISO_DATE_TIME)
       )
     )
   }

--- a/test/data/IconikDataStoreSpec.scala
+++ b/test/data/IconikDataStoreSpec.scala
@@ -11,6 +11,8 @@ import com.gu.media.iconik.{
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.time.LocalDateTime
+
 class IconikDataStoreSpec extends AnyFlatSpec with Matchers {
 
   behavior of "IconikStore"
@@ -28,6 +30,9 @@ class IconikDataStoreSpec extends AnyFlatSpec with Matchers {
       commissionStore,
       workingGroupStore
     )
+
+    val createdAt = LocalDateTime.now()
+
     store.upsertIconikData(
       IconikUpsertRequest(
         id = "proj1",
@@ -38,7 +43,8 @@ class IconikDataStoreSpec extends AnyFlatSpec with Matchers {
         workingGroupTitle = "Working Group 1",
         status = "active",
         masterPlaceholderId = Some("mp1")
-      )
+      ),
+      createdAtDateTime = Some(createdAt)
     )
     projectStore.store should have size 1
     projectStore.store.head shouldEqual IconikProject(
@@ -47,7 +53,9 @@ class IconikDataStoreSpec extends AnyFlatSpec with Matchers {
       status = "active",
       commissionId = "comm1",
       workingGroupId = "wg1",
-      masterPlaceholderId = Some("mp1")
+      masterPlaceholderId = Some("mp1"),
+      createdAt =
+        Some(createdAt.format(java.time.format.DateTimeFormatter.ISO_DATE_TIME))
     )
     commissionStore.store should have size 1
     commissionStore.store.head shouldEqual IconikCommission(

--- a/test/data/IconikDataStoreSpec.scala
+++ b/test/data/IconikDataStoreSpec.scala
@@ -44,7 +44,7 @@ class IconikDataStoreSpec extends AnyFlatSpec with Matchers {
         status = "active",
         masterPlaceholderId = Some("mp1")
       ),
-      createdAtDateTime = Some(createdAt)
+      createdAtDateTimeOverride = Some(createdAt)
     )
     projectStore.store should have size 1
     projectStore.store.head shouldEqual IconikProject(
@@ -67,6 +67,42 @@ class IconikDataStoreSpec extends AnyFlatSpec with Matchers {
     workingGroupStore.store.head shouldEqual IconikWorkingGroup(
       id = "wg1",
       title = "Working Group 1"
+    )
+
+    store.upsertIconikData(
+      IconikUpsertRequest(
+        id = "proj1",
+        title = "Project 1-updated",
+        commissionId = "comm1",
+        commissionTitle = "Commission 1-updated",
+        workingGroupId = "wg1",
+        workingGroupTitle = "Working Group 1-updated",
+        status = "active",
+        masterPlaceholderId = Some("mp1-updated")
+      )
+    )
+
+    projectStore.store should have size 1
+    projectStore.store.head shouldEqual IconikProject(
+      id = "proj1",
+      title = "Project 1-updated",
+      status = "active",
+      commissionId = "comm1",
+      workingGroupId = "wg1",
+      masterPlaceholderId = Some("mp1-updated"),
+      createdAt =
+        Some(createdAt.format(java.time.format.DateTimeFormatter.ISO_DATE_TIME))
+    )
+    commissionStore.store should have size 1
+    commissionStore.store.head shouldEqual IconikCommission(
+      workingGroupId = "wg1",
+      id = "comm1",
+      title = "Commission 1-updated"
+    )
+    workingGroupStore.store should have size 1
+    workingGroupStore.store.head shouldEqual IconikWorkingGroup(
+      id = "wg1",
+      title = "Working Group 1-updated"
     )
   }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add a 'created at' time when we store new Iconik projects. This is an optional field, so it shouldn't cause any issues for existing projects. The main use-case that we're anticipating at the moment is that it will allow ordering or filtering by time created. Generally speaking, the value in this is to surface the most recent projects first. So that means we can afford to defer the question of whether/how to backfill the creation date for old projects.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

- [x] Deploy to CODE, create a project, verify that its 'created at' date is populated in the DynamoDB table.

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
