### PR TITLE
E2E : Add audio detection functionality using FfMpeg

### DIFF
--- a/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
@@ -24,7 +24,8 @@ case class UploadMetadata(
     originalFilename: Option[String] = None,
     startTimestamp: Long, // unix timestamp
     subtitleSource: Option[VideoSource] = None,
-    subtitleVersion: Option[Long] = None
+    subtitleVersion: Option[Long] = None,
+    hasAudio: Option[Boolean] = None
 )
 
 sealed abstract class RuntimeUploadMetadata

--- a/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
@@ -108,7 +108,11 @@ class AddAssetToAtom
         assetsFromYoutubeEvent(asset, version)
 
       case (_, SelfHostedUploadMetadata(_, Some(completeEvent))) =>
-        assetsFromCompleteEvent(completeEvent, version)
+        assetsFromCompleteEvent(
+          completeEvent,
+          version,
+          upload.metadata.hasAudio.getOrElse(true)
+        )
 
       case _ =>
         throw new IllegalStateException("Missing asset")
@@ -129,9 +133,10 @@ class AddAssetToAtom
 
   private def assetsFromCompleteEvent(
       completeEvent: MediaConvertEvent,
-      version: Long
+      version: Long,
+      hasAudio: Boolean
   ): List[ThriftAsset] = {
-    val outputGroupsSettings = JobSettingsBuilder.outputGroups
+    val outputGroupsSettings = JobSettingsBuilder.getOutputGroups(hasAudio)
     val outputGroupsResults = completeEvent.detail.outputGroupDetails
 
     outputGroupAssets(outputGroupsSettings, outputGroupsResults, version) ++

--- a/uploader/src/main/scala/com/gu/media/upload/FfMpeg.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/FfMpeg.scala
@@ -1,7 +1,6 @@
 package com.gu.media.upload
 
 import com.gu.media.logging.Logging
-
 import java.nio.file.Path
 import scala.sys.process.{Process, ProcessLogger, stdout}
 import scala.collection.mutable

--- a/uploader/src/main/scala/com/gu/media/upload/SendToTranscoderV2.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/SendToTranscoderV2.scala
@@ -4,6 +4,7 @@ import software.amazon.awssdk.services.mediaconvert.model.CreateJobRequest
 import com.gu.media.aws.MediaConvertAccess
 import com.gu.media.lambda.{LambdaBase, LambdaWithParams}
 import com.gu.media.logging.Logging
+import com.gu.media.upload.FfMpeg.checkAudioExists
 import com.gu.media.upload.mediaconvert.JobSettingsBuilder
 import com.gu.media.upload.model.{
   SelfHostedUploadMetadata,
@@ -18,11 +19,22 @@ class SendToTranscoderV2
     extends LambdaWithParams[WaitOnUpload, Upload]
     with LambdaBase
     with MediaConvertAccess
+    with S3Helpers
     with Logging {
   override def handle(data: WaitOnUpload): Upload = {
     val upload = data.input
     val videoInput = Upload.videoInputUri(upload)
     val maybeSubtitlesInput = Upload.subtitleInputUri(upload)
+
+    // Presign a GET URL so ffmpeg can read the video directly over HTTPS
+    val presignedUrl = generatePresignedDownloadUrl(
+      bucket = videoInput.bucket,
+      key = videoInput.key
+    )
+
+    // validate audio boolean using:
+    val hasAudio = checkAudioExists(presignedUrl.toString)
+    println(s"Video ${videoInput.toString} has audio: $hasAudio")
 
     val key = TranscoderOutputKey(
       upload.metadata.title,
@@ -43,7 +55,11 @@ class SendToTranscoderV2
     )
 
     val metadata =
-      upload.metadata.copy(runtime = SelfHostedUploadMetadata(Some(List(jobs))))
+      upload.metadata.copy(runtime =
+        SelfHostedUploadMetadata(
+          jobs = Some(List(jobs))
+        )
+      )
 
     upload.copy(
       metadata = metadata,

--- a/uploader/src/main/scala/com/gu/media/upload/SendToTranscoderV2.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/SendToTranscoderV2.scala
@@ -33,8 +33,8 @@ class SendToTranscoderV2
     )
 
     // validate audio boolean using:
-    val hasAudio = checkAudioExists(presignedUrl.toString)
-    println(s"Video ${videoInput.toString} has audio: $hasAudio")
+    val hasAudio = checkAudioExists(presignedUrl)
+    println(s"Video ${videoInput} has audio: $hasAudio")
 
     val key = TranscoderOutputKey(
       upload.metadata.title,

--- a/uploader/src/main/scala/com/gu/media/upload/SendToTranscoderV2.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/SendToTranscoderV2.scala
@@ -34,7 +34,6 @@ class SendToTranscoderV2
 
     // validate audio boolean using:
     val hasAudio = checkAudioExists(presignedUrl)
-    println(s"Video ${videoInput} has audio: $hasAudio")
 
     val key = TranscoderOutputKey(
       upload.metadata.title,
@@ -51,14 +50,16 @@ class SendToTranscoderV2
       videoInput,
       maybeSubtitlesInput,
       data.executionId,
-      destination
+      destination,
+      hasAudio
     )
 
     val metadata =
-      upload.metadata.copy(runtime =
-        SelfHostedUploadMetadata(
+      upload.metadata.copy(
+        runtime = SelfHostedUploadMetadata(
           jobs = Some(List(jobs))
-        )
+        ),
+        hasAudio = Some(hasAudio)
       )
 
     upload.copy(
@@ -71,13 +72,15 @@ class SendToTranscoderV2
       videoInput: UploadUri,
       maybeSubtitlesInput: Option[UploadUri],
       executionId: String,
-      destination: String
+      destination: String,
+      hasAudio: Boolean
   ): String = {
 
     val jobSettings = JobSettingsBuilder.build(
       videoInput.toString,
       maybeSubtitlesInput.map(_.toString),
-      destination
+      destination,
+      hasAudio
     )
 
     val createJobRequest = CreateJobRequest

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/JobSettingsBuilder.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/JobSettingsBuilder.scala
@@ -33,18 +33,18 @@ object JobSettingsBuilder {
         .build()
     ).asJava
 
-    val jobInput = Input
+    val jobInputBuilder = Input
       .builder()
       .fileInput(videoInput)
       .captionSelectors(captionSelectors(subtitlesInput))
       .timecodeSource(InputTimecodeSource.ZEROBASED)
 
-    val jobInputBuild = if (hasAudio) {
-      jobInput
+    val jobInput = if (hasAudio) {
+      jobInputBuilder
         .dynamicAudioSelectors(dynamicAudioSelectors)
         .build()
     } else {
-      jobInput.build()
+      jobInputBuilder.build()
     }
 
     val timecodeConfig = TimecodeConfig
@@ -55,7 +55,7 @@ object JobSettingsBuilder {
     JobSettings
       .builder()
       .timecodeConfig(timecodeConfig)
-      .inputs(jobInputBuild)
+      .inputs(jobInput)
       .outputGroups(
         outputGroups.map(_.outputGroup(destination)): _*
       )

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/JobSettingsBuilder.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/JobSettingsBuilder.scala
@@ -17,13 +17,14 @@ object SelectorNames {
 
 object JobSettingsBuilder {
 
-  val outputGroups: List[OutputGroupDefinition] =
-    List(FileOutputGroup(), HLSOutputGroup())
+  def getOutputGroups(hasAudio: Boolean): List[OutputGroupDefinition] =
+    List(FileOutputGroup(hasAudio), HLSOutputGroup(hasAudio))
 
   def build(
       videoInput: String,
       subtitlesInput: Option[String],
-      destination: String
+      destination: String,
+      hasAudio: Boolean
   ): JobSettings = {
 
     val dynamicAudioSelectors = Map(
@@ -35,20 +36,26 @@ object JobSettingsBuilder {
     val jobInput = Input
       .builder()
       .fileInput(videoInput)
-      .dynamicAudioSelectors(dynamicAudioSelectors)
       .captionSelectors(captionSelectors(subtitlesInput))
       .timecodeSource(InputTimecodeSource.ZEROBASED)
-      .build()
+
+    val jobInputBuild = if (hasAudio) {
+      jobInput
+        .dynamicAudioSelectors(dynamicAudioSelectors)
+        .build()
+    } else {
+      jobInput.build()
+    }
 
     val timecodeConfig = TimecodeConfig
       .builder()
       .source(TimecodeSource.ZEROBASED)
       .build()
-
+    val outputGroups = getOutputGroups(hasAudio)
     JobSettings
       .builder()
       .timecodeConfig(timecodeConfig)
-      .inputs(jobInput)
+      .inputs(jobInputBuild)
       .outputGroups(
         outputGroups.map(_.outputGroup(destination)): _*
       )

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/FileOutputGroup.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/FileOutputGroup.scala
@@ -8,11 +8,11 @@ import software.amazon.awssdk.services.mediaconvert.model.{
 }
 
 object FileOutputGroup {
-  def apply(): OutputGroupDefinition = {
+  def apply(hasAudio: Boolean): OutputGroupDefinition = {
     val outputs =
       List(
-        MP4Output(Resolution.Low),
-        MP4Output(Resolution.High),
+        MP4Output(Resolution.Low, hasAudio),
+        MP4Output(Resolution.High, hasAudio),
         JPEGOutput(),
         WebVTTOutput()
       )

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/MP4Output.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/MP4Output.scala
@@ -34,12 +34,12 @@ object Resolution {
 
 object MP4Output {
 
-  def apply(config: ResolutionConfig): OutputDefinition = {
+  def apply(config: ResolutionConfig, hasAudio: Boolean): OutputDefinition = {
     OutputDefinition(
       mimeType = Some(VideoSource.mimeTypeMp4),
       assetType = Some(AssetType.Video),
-      output = () =>
-        Output
+      output = () => {
+        val outputBuilder = Output
           .builder()
           .nameModifier(config.nameModifier)
           .containerSettings(
@@ -64,8 +64,11 @@ object MP4Output {
               )
               .build()
           )
-          .audioDescriptions(aacAudioDescription)
-          .build()
+
+        if (hasAudio)
+          outputBuilder.audioDescriptions(aacAudioDescription).build()
+        else outputBuilder.build()
+      }
     )
   }
 }

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/HLSOutputGroup.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/HLSOutputGroup.scala
@@ -11,8 +11,8 @@ import software.amazon.awssdk.services.mediaconvert.model.{
 }
 
 object HLSOutputGroup {
-  def apply(): OutputGroupDefinition = {
-    val outputs = List(VideoOutput(), CaptionsOutput())
+  def apply(hasAudio: Boolean): OutputGroupDefinition = {
+    val outputs = List(VideoOutput(hasAudio), CaptionsOutput())
     OutputGroupDefinition(
       mimeType = Some(VideoSource.mimeTypeM3u8),
       assetType = Some(

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/VideoOutput.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/VideoOutput.scala
@@ -10,12 +10,12 @@ import com.gu.media.upload.mediaconvert.SharedCodecSettings.{
 import software.amazon.awssdk.services.mediaconvert.model._
 
 object VideoOutput {
-  def apply(): OutputDefinition = OutputDefinition(
+  def apply(hasAudio: Boolean): OutputDefinition = OutputDefinition(
     mimeType = Some(VideoSource.mimeTypeM3u8),
     assetType =
       None, // Not currently used as an asset, as the m3u8 playlist which combines this and subtitles is used instead
-    output = () =>
-      Output
+    output = () => {
+      val outputBuilder = Output
         .builder()
         .containerSettings(
           ContainerSettings
@@ -52,8 +52,10 @@ object VideoOutput {
             )
             .build()
         )
-        .audioDescriptions(aacAudioDescription)
-        .build()
+
+      if (hasAudio) outputBuilder.audioDescriptions(aacAudioDescription).build()
+      else outputBuilder.build()
+    }
   )
 
 }


### PR DESCRIPTION

## What does this change?
Implements audio detection for videos prior to being transcoded. A boolean is then passed through the transcoding step to determine the use of audioDescriptions in each output group and dynamicAudioSelectors during the job output. 

## How has this change been tested?

Deployed to CODE and validated the output of the following three videos
1: Video with audio - validate that this has audio tracks available post transcoding
2: Video without audio - validate that this has been transcoded successfully and does not have audio tracks post transcoding
3: Video with silent audio tracks - validate that this has been transcoded successfully and does not have audio tracks post transcoding

These videos can be produced locally for testing using the ffmpeg with the following commands. Thanks to @davidfurey for pointing this out.

Video with no audio track:
ffmpeg -f lavfi -i testsrc -t 10 testsrc.mp4

Video with audio:
ffmpeg -f lavfi -i testsrc -f lavfi -i 'anoisesrc=a=0.1:c=white' -t 10 testsrc.mp4

Video with <-50dB audio (mean_volume: -66.1 dB, max_volume: -53.8 dB)
ffmpeg -f lavfi -i testsrc -f lavfi -i 'anoisesrc=a=0.001:c=white' -t 10 testsrc.mp4

## How can we measure success?
Only videos with sound are ouputted with audio tracks.

## Have we considered potential risks?
Videos with very quiet sound could be considered silent. We use -50db as the cut off for max volume to mitigate this. 
