### PR TITLE
Order video preview by mime type and size

### DIFF
--- a/public/video-ui/src/components/VideoPreview/VideoPreview.jsx
+++ b/public/video-ui/src/components/VideoPreview/VideoPreview.jsx
@@ -24,7 +24,7 @@ export default class VideoPreview extends React.Component {
     }
 
     const sources = active.map(asset => {
-      return { src: asset.id, mimeType: asset.mimeType };
+      return { src: asset.id, mimeType: asset.mimeType, height: asset.height, width: asset.width };
     });
 
     if (this.props.video.posterImage && this.props.video.posterImage.assets.length > 0) {

--- a/public/video-ui/src/components/VideoPreview/VideoPreview.jsx
+++ b/public/video-ui/src/components/VideoPreview/VideoPreview.jsx
@@ -24,7 +24,12 @@ export default class VideoPreview extends React.Component {
     }
 
     const sources = active.map(asset => {
-      return { src: asset.id, mimeType: asset.mimeType, height: asset.height, width: asset.width };
+      return {
+        src: asset.id,
+        mimeType: asset.mimeType,
+        height: asset.dimensions?.height ?? 0,
+        width: asset.dimensions?.width ?? 0
+      };
     });
 
     if (this.props.video.posterImage && this.props.video.posterImage.assets.length > 0) {

--- a/public/video-ui/src/components/utils/VideoEmbed.tsx
+++ b/public/video-ui/src/components/utils/VideoEmbed.tsx
@@ -64,8 +64,8 @@ function prepareSources(assets: SelfHostedSource[]) {
       if (sourcesByType.length) {
         const sourcesOrderedByWidthDescending = sourcesByType.sort(
           (a, b) =>
-            Number(b.width) -
-            Number(a.width)
+            Number(b.width ?? 0) -
+            Number(a.width ?? 0)
         );
         acc.push(...sourcesOrderedByWidthDescending);
       }

--- a/public/video-ui/src/components/utils/VideoEmbed.tsx
+++ b/public/video-ui/src/components/utils/VideoEmbed.tsx
@@ -18,7 +18,6 @@ export function VideoEmbed({ sources, posterUrl }: { sources: SelfHostedSource[]
     return <video src={sources[0].src} {...props} />;
   } else {
     const videoSources = prepareSources(sources);
-
     return (
       <video {...props}>
         {videoSources.map(source => {
@@ -40,12 +39,34 @@ export function VideoEmbed({ sources, posterUrl }: { sources: SelfHostedSource[]
   }
 }
 
-function prepareSources(sources: SelfHostedSource[]) {
-  const videoSources = sources.filter(source => source.mimeType !== "text/vtt");
+/**
+* Order is important here - the browser will use the first type it supports.
+*/
+export const supportedVideoFileTypes = [
+  'video/mp4', // MP4 format
+  'application/x-mpegURL', // HLS format
+  'application/vnd.apple.mpegurl' // Alternative HLS format
+] as const;
 
-  // if m3u8 and mp4 are both present, put mp4 first
-  const m3u8 = videoSources.find(source => source.mimeType === "application/vnd.apple.mpegurl");
-  const mp4 = videoSources.find(source => source.mimeType === "video/mp4");
+/**
+ * Ensure sources are ordered by the order that MIME types are specified in
+ * `supportedVideoFileTypes` and then by size in descending order.
+ */
 
-  return (m3u8 && mp4) ? [mp4, ...videoSources.filter(source => source !== mp4)] : videoSources;
+function prepareSources(assets: SelfHostedSource[]) {
+  return supportedVideoFileTypes
+    .reduce<typeof assets>((acc, type) => {
+      const sourcesByType = assets.filter(
+        ({ mimeType }) => mimeType === type
+      );
+      if (sourcesByType.length) {
+        const sourcesOrderedByWidthDescending = sourcesByType.sort(
+          (a, b) =>
+            Number(b.width ?? 0) -
+            Number(a.width ?? 0)
+        );
+        acc.push(...sourcesOrderedByWidthDescending);
+      }
+      return acc;
+    }, [])
 }

--- a/public/video-ui/src/components/utils/VideoEmbed.tsx
+++ b/public/video-ui/src/components/utils/VideoEmbed.tsx
@@ -17,7 +17,7 @@ export function VideoEmbed({ sources, posterUrl }: { sources: SelfHostedSource[]
     // to appease Safari
     return <video src={sources[0].src} {...props} />;
   } else {
-    const videoSources = prepareSources(sources);
+    const videoSources = orderSources(sources);
     return (
       <video {...props}>
         {videoSources.map(source => {
@@ -55,10 +55,10 @@ export const supportedVideoFileTypes = [
  * `supportedVideoFileTypes` and then by size in descending order.
  */
 
-function prepareSources(assets: SelfHostedSource[]) {
+function orderSources(sources: SelfHostedSource[]) {
   return supportedVideoFileTypes
-    .reduce<typeof assets>((acc, type) => {
-      const sourcesByType = assets.filter(
+    .reduce<SelfHostedSource[]>((acc, type) => {
+      const sourcesByType = sources.filter(
         ({ mimeType }) => mimeType === type
       );
       if (sourcesByType.length) {

--- a/public/video-ui/src/components/utils/VideoEmbed.tsx
+++ b/public/video-ui/src/components/utils/VideoEmbed.tsx
@@ -70,5 +70,5 @@ function orderSources(sources: SelfHostedSource[]) {
         acc.push(...sourcesOrderedByWidthDescending);
       }
       return acc;
-    }, [])
+    }, []);
 }

--- a/public/video-ui/src/components/utils/VideoEmbed.tsx
+++ b/public/video-ui/src/components/utils/VideoEmbed.tsx
@@ -48,6 +48,8 @@ export const supportedVideoFileTypes = [
   'application/vnd.apple.mpegurl' // Alternative HLS format
 ] as const;
 
+
+
 /**
  * Ensure sources are ordered by the order that MIME types are specified in
  * `supportedVideoFileTypes` and then by size in descending order.
@@ -62,8 +64,8 @@ function prepareSources(assets: SelfHostedSource[]) {
       if (sourcesByType.length) {
         const sourcesOrderedByWidthDescending = sourcesByType.sort(
           (a, b) =>
-            Number(b.width ?? 0) -
-            Number(a.width ?? 0)
+            Number(b.width) -
+            Number(a.width)
         );
         acc.push(...sourcesOrderedByWidthDescending);
       }

--- a/public/video-ui/src/slices/s3Upload.ts
+++ b/public/video-ui/src/slices/s3Upload.ts
@@ -11,7 +11,7 @@ import { showError } from './error';
 import { getUploads } from './uploads';
 
 export type YouTubeAsset = { id: string; sources?: undefined };
-export type SelfHostedSource = { src: string; mimeType: string };
+export type SelfHostedSource = { src: string; mimeType: string, height?: number, width?: number };
 export type SelfHostedAsset = {
   id?: undefined;
   sources: SelfHostedSource[];

--- a/public/video-ui/src/slices/s3Upload.ts
+++ b/public/video-ui/src/slices/s3Upload.ts
@@ -11,7 +11,12 @@ import { showError } from './error';
 import { getUploads } from './uploads';
 
 export type YouTubeAsset = { id: string; sources?: undefined };
-export type SelfHostedSource = { src: string; mimeType: string, height?: number, width?: number };
+export type SelfHostedSource = {
+  src: string;
+  mimeType: string,
+  height?: number,
+  width?: number
+};
 export type SelfHostedAsset = {
   id?: undefined;
   sources: SelfHostedSource[];


### PR DESCRIPTION
## What does this change?
Orders video sources by mimetype and size, in descending order. This is because the previous implementation of finding the first mp4 and using that did not account for multiple resolutions. As a consequence, the lower resolution 480w version was being displayed in preview.

This PR ports the DCR implementation introduced here https://github.com/guardian/dotcom-rendering/commit/36f340f8d2912e7b51cee0c6212706fa789c70db

## How has this change been tested?
Deploying to CODE to ensure 720h videos are played when available instead of 480w

## How can we measure success?
Users see the highest resolution video

## Have we considered potential risks?
This will always now show the highest quality available. This therefore hides any other quality videos which may still be representative of video quality on platform, depending on device, and so preview is now not a complete representation of the video atom. A mitigation for this would be to allow the user to view multiple video resolutions. This would be future work and is not included in this PR. 

## Images

### Before
<img width="817" height="195" alt="Screenshot 2026-04-08 at 16 25 23" src="https://github.com/user-attachments/assets/d849ac6a-d62e-42c2-8508-ebbfdfe76566" />

### After
<img width="722" height="178" alt="Screenshot 2026-04-09 at 11 04 48" src="https://github.com/user-attachments/assets/1bb12855-612f-464b-adec-ced1e76272ef" />

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
