### PR TITLE
Add has audio flag to atom

### DIFF
--- a/app/model/commands/DeleteCommand.scala
+++ b/app/model/commands/DeleteCommand.scala
@@ -36,7 +36,7 @@ case class DeleteCommand(
 
   private def makeYouTubeVideosPrivate(assets: List[Asset]): Unit =
     assets.collect {
-      case Asset(_, _, videoId, Youtube, _, _, _)
+      case Asset(_, _, videoId, Youtube, _, _, _, _, _)
           if youTube.isManagedVideo(videoId) =>
         val privacyStatusUpdate =
           youTube.setStatus(videoId, PrivacyStatus.Private)

--- a/app/util/UploadBuilder.scala
+++ b/app/util/UploadBuilder.scala
@@ -43,7 +43,8 @@ object UploadBuilder {
       ),
       originalFilename = Some(request.filename),
       version = Some(assetVersion),
-      startTimestamp = currentTimestamp
+      startTimestamp = currentTimestamp,
+      hasAudio = None
     )
 
     val progress = UploadProgress(

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import scala.sys.process.*
 val scroogeVersion = "4.12.0"
 val awsV2Version = "2.42.24"
 val pandaVersion = "13.0.0"
-val atomMakerVersion = "9.0.0"
+val atomMakerVersion = "10.0.0"
 val typesafeConfigVersion =
   "1.4.0" // to match what we get from Play transitively
 val scanamoVersion = "1.0.0-M28"

--- a/common/src/main/scala/com/gu/media/model/Asset.scala
+++ b/common/src/main/scala/com/gu/media/model/Asset.scala
@@ -12,7 +12,9 @@ case class Asset(
     platform: Platform,
     mimeType: Option[String],
     dimensions: Option[ImageAssetDimensions],
-    aspectRatio: Option[String]
+    aspectRatio: Option[String],
+    duration: Option[Long],
+    hasAudio: Option[Boolean]
 ) {
   def asThrift = ThriftAsset.apply(
     assetType.asThrift,
@@ -21,7 +23,9 @@ case class Asset(
     platform.asThrift,
     mimeType,
     dimensions.map(_.asThrift),
-    aspectRatio
+    aspectRatio,
+    duration,
+    hasAudio
   )
 }
 
@@ -34,6 +38,8 @@ object Asset {
     Platform.fromThrift(asset.platform),
     asset.mimeType,
     asset.dimensions.map(ImageAssetDimensions.fromThrift),
-    asset.aspectRatio
+    asset.aspectRatio,
+    asset.duration,
+    asset.hasAudio
   )
 }

--- a/common/src/main/scala/com/gu/media/model/ClientAsset.scala
+++ b/common/src/main/scala/com/gu/media/model/ClientAsset.scala
@@ -67,9 +67,9 @@ object ClientAsset {
 
   def videoFromAssets(assets: List[Asset]): (Long, VideoAsset) = {
     assets.headOption match {
-      case Some(Asset(_, version, _, Platform.Url, _, _, _)) =>
+      case Some(Asset(_, version, _, Platform.Url, _, _, _, _, _)) =>
         val sources = assets.collect {
-          case Asset(_, _, id, _, Some(mimeType), dimensions, _) =>
+          case Asset(_, _, id, _, Some(mimeType), dimensions, _, _, _) =>
             VideoSource(
               id,
               mimeType,
@@ -80,7 +80,7 @@ object ClientAsset {
 
         (version, SelfHostedAsset(sources))
 
-      case Some(Asset(_, version, id, Platform.Youtube, _, _, _)) =>
+      case Some(Asset(_, version, id, Platform.Youtube, _, _, _, _, _)) =>
         (version, YouTubeAsset(id))
 
       case other =>

--- a/common/src/main/scala/com/gu/media/util/JsonConversions.scala
+++ b/common/src/main/scala/com/gu/media/util/JsonConversions.scala
@@ -56,7 +56,9 @@ object JsonConversions {
       (__ \ "assetType").write[String] and
       (__ \ "mimeType").writeNullable[String] and
       (__ \ "dimensions").writeNullable[ImageAssetDimensions] and
-      (__ \ "aspectRatio").writeNullable[String]
+      (__ \ "aspectRatio").writeNullable[String] and
+      (__ \ "duration").writeNullable[Long] and
+      (__ \ "hasAudio").writeNullable[Boolean]
   ) { asset: Asset =>
     asset match {
       case Asset(
@@ -66,7 +68,9 @@ object JsonConversions {
             platform,
             mimeType,
             dimensions,
-            aspectRatio
+            aspectRatio,
+            duration,
+            hasAudio
           ) =>
         (
           id,
@@ -75,7 +79,9 @@ object JsonConversions {
           assetType.name,
           mimeType,
           dimensions,
-          aspectRatio
+          aspectRatio,
+          duration,
+          hasAudio
         )
     }
   }

--- a/common/src/main/scala/com/gu/media/util/MediaAtomImplicits.scala
+++ b/common/src/main/scala/com/gu/media/util/MediaAtomImplicits.scala
@@ -60,7 +60,7 @@ trait MediaAtomImplicits extends AtomImplicits[MediaAtom] {
 
         case assets =>
           val sources = assets.collect {
-            case Asset(_, _, id, _, Some(mimeType), _, _) =>
+            case Asset(_, _, id, _, Some(mimeType), _, _, _, _) =>
               VideoSource(id, mimeType)
           }
 

--- a/test/controllers/UploadControllerTest.scala
+++ b/test/controllers/UploadControllerTest.scala
@@ -342,7 +342,9 @@ class UploadControllerTest extends AnyFlatSpec with Matchers {
       Platform.Url,
       Some("video/mp4"),
       Some(ImageAssetDimensions(1280, 720)),
-      Some("16:9")
+      Some("16:9"),
+      Some(90L), // 1 min 30 sec
+      Some(true)
     ),
     Asset(
       AssetType.Video,
@@ -351,7 +353,9 @@ class UploadControllerTest extends AnyFlatSpec with Matchers {
       Platform.Url,
       Some("application/vnd.apple.mpegurl"),
       Some(ImageAssetDimensions(1280, 720)),
-      Some("16:9")
+      Some("16:9"),
+      Some(90L), // 1 min 30 sec
+      Some(true)
     )
   )
 

--- a/test/model/ClientAssetTest.scala
+++ b/test/model/ClientAssetTest.scala
@@ -8,7 +8,17 @@ import org.scalatest.matchers.must.Matchers
 
 class ClientAssetTest extends AnyFunSuite with Matchers {
   val ytAsset =
-    Asset(AssetType.Video, 1, "12345", Platform.Youtube, None, None, None)
+    Asset(
+      AssetType.Video,
+      1,
+      "12345",
+      Platform.Youtube,
+      None,
+      None,
+      None,
+      None,
+      None
+    )
   val ytProcessing = YouTubeProcessingStatus("1", "processing", 0, 0, 0, None)
 
   val mp4 =
@@ -19,7 +29,9 @@ class ClientAssetTest extends AnyFunSuite with Matchers {
       Platform.Url,
       Some("video/mp4"),
       Some(ImageAssetDimensions(1280, 720)),
-      Some("16:9")
+      Some("16:9"),
+      Some(90L), // 1 min 30 sec
+      Some(true)
     )
   val m3u8 =
     Asset(
@@ -29,7 +41,9 @@ class ClientAssetTest extends AnyFunSuite with Matchers {
       Platform.Url,
       Some("application/vnd.apple.mpegurl"),
       Some(ImageAssetDimensions(1280, 720)),
-      Some("16:9")
+      Some("16:9"),
+      Some(90L), // 1 min 30 sec
+      Some(true)
     )
   val selfHostedAsset = SelfHostedAsset(
     List(

--- a/test/model/commands/ActiveAssetCommandTest.scala
+++ b/test/model/commands/ActiveAssetCommandTest.scala
@@ -185,7 +185,9 @@ class ActiveAssetCommandTest extends AnyFlatSpec with Matchers {
       Url,
       Some("video/mp4"),
       Some(ImageAssetDimensions(1280, 720)),
-      Some("16:9")
+      Some("16:9"),
+      Some(90L), // 1 min 30 sec
+      Some(true)
     ),
     Asset(
       AssetType.Video,
@@ -194,7 +196,9 @@ class ActiveAssetCommandTest extends AnyFlatSpec with Matchers {
       Url,
       Some("video/mp4"),
       Some(ImageAssetDimensions(1280, 720)),
-      Some("16:9")
+      Some("16:9"),
+      Some(90L), // 1 min 30 sec
+      Some(true)
     )
   )
 
@@ -206,6 +210,8 @@ class ActiveAssetCommandTest extends AnyFlatSpec with Matchers {
       Youtube,
       Some("video/mp4"),
       None,
+      None,
+      None,
       None
     ),
     Asset(
@@ -214,6 +220,8 @@ class ActiveAssetCommandTest extends AnyFlatSpec with Matchers {
       "xyz789",
       Youtube,
       Some("video/mp4"),
+      None,
+      None,
       None,
       None
     )

--- a/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
@@ -139,14 +139,20 @@ class AddAssetToAtom
     val outputGroupsSettings = JobSettingsBuilder.getOutputGroups(hasAudio)
     val outputGroupsResults = completeEvent.detail.outputGroupDetails
 
-    outputGroupAssets(outputGroupsSettings, outputGroupsResults, version) ++
-      outputAssets(outputGroupsSettings, outputGroupsResults, version)
+    outputGroupAssets(
+      outputGroupsSettings,
+      outputGroupsResults,
+      version,
+      hasAudio
+    ) ++
+      outputAssets(outputGroupsSettings, outputGroupsResults, version, hasAudio)
   }
 
   private def outputGroupAssets(
       outputGroupsSettings: List[OutputGroupDefinition],
       outputGroupsResults: List[MediaConvertOutputGroupDetails],
-      version: Long
+      version: Long,
+      hasAudio: Boolean
   ) =
     for {
       (settings, results) <- outputGroupsSettings.zip(outputGroupsResults)
@@ -167,13 +173,15 @@ class AddAssetToAtom
       // HLS playlists can include multiple renditions with different resolutions, so we can't provide dimensions for the asset at this level
       dimensions = None,
       // HLS playlist videos may have different resolutions, but they should have the same aspect ratio.
-      ratio(results.outputDetails.head)
+      ratio(results.outputDetails.head),
+      hasAudio = Some(hasAudio)
     )
 
   private def outputAssets(
       outputGroupsSettings: List[OutputGroupDefinition],
       outputGroupsResults: List[MediaConvertOutputGroupDetails],
-      version: Long
+      version: Long,
+      hasAudio: Boolean
   ) =
     for {
       (outputGroupSettings, outputGroupResults) <- outputGroupsSettings.zip(
@@ -195,7 +203,8 @@ class AddAssetToAtom
       ThriftPlatform.Url,
       Some(mimeType),
       dimensions(outputResults),
-      ratio(outputResults)
+      ratio(outputResults),
+      hasAudio = Some(hasAudio)
     )
 
   private def first[T](collection: Option[List[T]]) =

--- a/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
@@ -174,7 +174,7 @@ class AddAssetToAtom
       dimensions = None,
       // HLS playlist videos may have different resolutions, but they should have the same aspect ratio.
       ratio(results.outputDetails.head),
-      hasAudio = Some(hasAudio)
+      hasAudio = supportsAudio(mimeType, hasAudio)
     )
 
   private def outputAssets(
@@ -204,8 +204,15 @@ class AddAssetToAtom
       Some(mimeType),
       dimensions(outputResults),
       ratio(outputResults),
-      hasAudio = Some(hasAudio)
+      hasAudio = supportsAudio(mimeType, hasAudio)
     )
+
+  private def supportsAudio(mimeType: String, hasAudio: Boolean) = {
+    mimeType match {
+      case VideoSource.mimeTypeMp4 | VideoSource.mimeTypeM3u8 => Some(hasAudio)
+      case _                                                  => None
+    }
+  }
 
   private def first[T](collection: Option[List[T]]) =
     collection.flatMap(_.headOption)

--- a/uploader/src/main/scala/com/gu/media/upload/SendToTranscoderV2.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/SendToTranscoderV2.scala
@@ -58,8 +58,7 @@ class SendToTranscoderV2
       upload.metadata.copy(
         runtime = SelfHostedUploadMetadata(
           jobs = Some(List(jobs))
-        ),
-        hasAudio = Some(hasAudio)
+        )
       )
 
     upload.copy(
@@ -89,7 +88,8 @@ class SendToTranscoderV2
       .userMetadata(
         Map(
           "stage" -> stage,
-          "executionId" -> executionId
+          "executionId" -> executionId,
+          "hasAudio" -> hasAudio.toString
         ).asJava
       )
       .settings(jobSettings)

--- a/uploader/src/main/scala/com/gu/media/upload/TranscoderComplete.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/TranscoderComplete.scala
@@ -65,10 +65,15 @@ class TranscoderComplete
         case metadata: SelfHostedUploadMetadata => metadata
       } getOrElse SelfHostedUploadMetadata()
 
+      hasAudio = data.detail.userMetadata
+        .get("hasAudio")
+        .flatMap(_.toBooleanOption)
+
       output = upload.copy(
         metadata = upload.metadata.copy(
           asset = updatedAsset,
-          runtime = existingMetadata.copy(completeEvent = Some(data))
+          runtime = existingMetadata.copy(completeEvent = Some(data)),
+          hasAudio = hasAudio
         ),
         progress = upload.progress.copy(retries = 0, fullyTranscoded = true)
       )


### PR DESCRIPTION
## What does this change?
Stores hasAudio boolean flag on each asset. This will allow consumers downstream to read if the atom has audio without having to detect from audio tracks. 

The hasAudio state is derived from the same state that is used to determine if audio tracks should be stripped from the asset during transcoding, which is detected in sendToTranscoderV2 using ffmpeg. 

The state machine is event-driven, rather than polling-based. It uses [TaskTokens](https://docs.aws.amazon.com/sdk-for-swift/latest/api/awssfn/documentation/awssfn/sendtaskfailureinput/tasktoken/) to pause execution whilst the transcoder step is processed. `TranscoderComplete` is then triggered and provides the output for the step. More detail on the implementation can be found here: https://github.com/guardian/media-atom-maker/pull/1487. As such, input is immutable during the state machine execution and can only be updated on output, once the MediaConvert job has completed. In order to persist the state of audio tracks discovered prior to transcoding, this is stored as user metadata on the MediaConvert job, which is carried through to the completion event and read by TranscoderComplete to set hasAudio on each asset.


## How has this change been tested?
- Deployed this branch to MAM to CODE
- Deployed https://github.com/guardian/content-api/pull/3336 to Porter
- Tested uploading videos with and without audio 
- Confirm that the atom has the correct output via querying the atom in Dynamodb and inspecting the step function output. 
- Confirming that the atom output json had the correct value on hasAudio in Cerebro. Accessing Cerebro requires assistance from the Articles and Publishing team.

## How can we measure success?
Platforms can read if an atom has audio and render controls as appropriate.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="996" height="168" alt="Screenshot 2026-04-21 at 12 41 00" src="https://github.com/user-attachments/assets/5ca0cbdb-3a79-47b3-8770-175e71fc3a77" />

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
