### PR TITLE
Fixes local development cors error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
   },
   server: {
     origin: 'http://localhost:5173',
+    cors: {
+      origin: 'https://video.local.dev-gutools.co.uk'
+    },
     // We depend upon this port number in a few places, so fail fast if we cannot allocate it.
     strictPort: true,
     fs: {


### PR DESCRIPTION
## What does this change?

When running this project locally, I get a cors error connecting to vite. This small change to add the expected origin to the vite config resolves the issue.

This is caused by a change in behaviour introduced in [Vite 5.4.12](https://github.com/vitejs/vite/blob/v5.4.21/packages/vite/CHANGELOG.md#5412-2025-01-20): default server.cors to false to disallow fetching from untrusted origins.

We recently upgraded from Vite 5.4.11 to 5.4.21.