### PR TITLE
Fixes icons following upgrade of prosemirror-editor

### DIFF
--- a/public/video-ui/styles/components/_prosemirror.scss
+++ b/public/video-ui/styles/components/_prosemirror.scss
@@ -56,13 +56,11 @@
 .prosemirror__iconBox:hover svg {
   fill: #ffbc01;
 }
+
 .ProseMirror-menuitem {
   width: 36px;
   height: 36px;
-  font-size: 16px;
   background-color: $color650Grey;
-  color: $color300Grey;
-  font-family: 'Material Icons';
   border: {
     left: 1px solid $color500Grey;
     top: 1px solid $color500Grey;
@@ -78,7 +76,10 @@
     cursor: pointer;
   }
 
-  div {
+  button {
+    color: $color300Grey;
+    font-family: 'Material Icons';
+    font-size: 16px;
     width: 100%;
     height: 100%;
     text-align: center;


### PR DESCRIPTION
## What does this change?

The bump from prosemirror-editor 1.2 to 1.3 changes menu items from `<div>` to `<button>`. This resulted in icons not displaying correctly. This PR makes minor tweaks to the CSS to fix the issue.

### Before
<img width="378" height="80" alt="Screenshot 2026-04-10 at 10 15 57" src="https://github.com/user-attachments/assets/a3cf68c2-f644-46b8-86bb-0980a63d62b1" />

### After
<img width="378" height="80" alt="Screenshot 2026-04-10 at 10 16 02" src="https://github.com/user-attachments/assets/4ae7b694-22d5-483b-89f0-2cbf58b42d4e" />


