### PR TITLE
Use quality level instead of bitrate for MP4 transcoding step

### DIFF
--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/SharedCodecSettings.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/SharedCodecSettings.scala
@@ -8,16 +8,9 @@ case class BitrateSetting(max: Int, maxAverage: Int)
 object SharedCodecSettings {
 
   /** Migrated from Elastic Transcoder */
-  val highBitrate: BitrateSetting = BitrateSetting(4_800_000, 2_400_000);
+  val bitrate: BitrateSetting = BitrateSetting(4_800_000, 2_400_000);
 
-  /** Used for Mobile videos at 480px width. We want to keep the number of
-    * bits-per-pixel. This is calculated as (270^2/720^2) * current bitrate.
-    * This is 14% of the current bitrate. i.e. maxBitrate is 675000 &
-    * maxAverageBitrate is 337500.
-    */
-  val lowBitrate: BitrateSetting = BitrateSetting(675_000, 337_500)
-
-  def h264Settings(bitrate: BitrateSetting): H264Settings =
+  def h264Settings(bitrate: BitrateSetting, qualityLevel: Option[Int] = None, qualityLevelFineTune: Option[Double] = None): H264Settings =
     H264Settings
       .builder()
       .rateControlMode(H264RateControlMode.QVBR) // Best quality
@@ -29,8 +22,8 @@ object SharedCodecSettings {
           .maxAverageBitrate(
             bitrate.maxAverage
           ) // Twice average to give room for encoder's decisions
-          .qvbrQualityLevel(8) // 1-10, 10 is best quality
-          .qvbrQualityLevelFineTune(0.66) // Fine-tuned through manual testing
+          .qvbrQualityLevel(qualityLevel.map(int2Integer).getOrElse(8) )// 1-10, 10 is best quality
+          .qvbrQualityLevelFineTune(qualityLevelFineTune.map(double2Double).getOrElse(0.66)) // Fine-tuned through manual testing
           .build()
       )
       .framerateControl(

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/SharedCodecSettings.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/SharedCodecSettings.scala
@@ -10,9 +10,7 @@ object SharedCodecSettings {
   /** Migrated from Elastic Transcoder */
   val bitrate: BitrateSetting = BitrateSetting(4_800_000, 2_400_000);
 
-  def h264Settings(
-      bitrate: BitrateSetting
-  ): H264Settings =
+  def h264Settings: H264Settings =
     H264Settings
       .builder()
       .rateControlMode(H264RateControlMode.QVBR) // Best quality

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/SharedCodecSettings.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/SharedCodecSettings.scala
@@ -10,7 +10,11 @@ object SharedCodecSettings {
   /** Migrated from Elastic Transcoder */
   val bitrate: BitrateSetting = BitrateSetting(4_800_000, 2_400_000);
 
-  def h264Settings(bitrate: BitrateSetting, qualityLevel: Option[Int] = None, qualityLevelFineTune: Option[Double] = None): H264Settings =
+  def h264Settings(
+      bitrate: BitrateSetting,
+      qualityLevel: Option[Int] = None,
+      qualityLevelFineTune: Option[Double] = None
+  ): H264Settings =
     H264Settings
       .builder()
       .rateControlMode(H264RateControlMode.QVBR) // Best quality
@@ -22,8 +26,12 @@ object SharedCodecSettings {
           .maxAverageBitrate(
             bitrate.maxAverage
           ) // Twice average to give room for encoder's decisions
-          .qvbrQualityLevel(qualityLevel.map(int2Integer).getOrElse(8) )// 1-10, 10 is best quality
-          .qvbrQualityLevelFineTune(qualityLevelFineTune.map(double2Double).getOrElse(0.66)) // Fine-tuned through manual testing
+          .qvbrQualityLevel(
+            qualityLevel.map(int2Integer).getOrElse(8)
+          ) // 1-10, 10 is best quality
+          .qvbrQualityLevelFineTune(
+            qualityLevelFineTune.map(double2Double).getOrElse(0.66)
+          ) // 8.66 as a default has fine-tuned through manual testing
           .build()
       )
       .framerateControl(

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/SharedCodecSettings.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/SharedCodecSettings.scala
@@ -11,9 +11,7 @@ object SharedCodecSettings {
   val bitrate: BitrateSetting = BitrateSetting(4_800_000, 2_400_000);
 
   def h264Settings(
-      bitrate: BitrateSetting,
-      qualityLevel: Option[Int] = None,
-      qualityLevelFineTune: Option[Double] = None
+      bitrate: BitrateSetting
   ): H264Settings =
     H264Settings
       .builder()
@@ -26,12 +24,10 @@ object SharedCodecSettings {
           .maxAverageBitrate(
             bitrate.maxAverage
           ) // Twice average to give room for encoder's decisions
-          .qvbrQualityLevel(
-            qualityLevel.map(int2Integer).getOrElse(8)
-          ) // 1-10, 10 is best quality
+          .qvbrQualityLevel(8) // 1-10, 10 is best quality
           .qvbrQualityLevelFineTune(
-            qualityLevelFineTune.map(double2Double).getOrElse(0.66)
-          ) // 8.66 as a default has fine-tuned through manual testing
+            0
+          ) // 8.0 outputs just shy of our bitrate maximums
           .build()
       )
       .framerateControl(

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/SharedCodecSettings.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/SharedCodecSettings.scala
@@ -27,7 +27,7 @@ object SharedCodecSettings {
           .qvbrQualityLevel(8) // 1-10, 10 is best quality
           .qvbrQualityLevelFineTune(
             0
-          ) // 8.0 outputs just shy of our bitrate maximums
+          ) // 8.0 outputs just shy of our bitrate maximums for 16:9 video at 720p. Videos that are larger than 1280x720 will probably fail to achieve this desired quality due to the bitrate cap.
           .build()
       )
       .framerateControl(

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/MP4Output.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/MP4Output.scala
@@ -2,8 +2,12 @@ package com.gu.media.upload.mediaconvert.file
 
 import com.gu.contentatom.thrift.atom.media.AssetType
 import com.gu.media.model.VideoSource
-import com.gu.media.upload.mediaconvert.{BitrateSetting, OutputDefinition}
-import com.gu.media.upload.mediaconvert.SharedCodecSettings.{aacAudioDescription, bitrate, h264Settings}
+import com.gu.media.upload.mediaconvert.OutputDefinition
+import com.gu.media.upload.mediaconvert.SharedCodecSettings.{
+  aacAudioDescription,
+  bitrate,
+  h264Settings
+}
 import software.amazon.awssdk.services.mediaconvert.model._
 case class Dimensions(width: Option[Int], height: Option[Int])
 
@@ -24,7 +28,7 @@ object Resolution {
 
   case object Low extends ResolutionConfig {
     val dimensions = Dimensions(Some(480), None)
-    val qualityLevel = Some(6)
+    val qualityLevel = Some(7)
     val qualityLevelFineTune = Some(0)
     val nameModifier = "_480w"
   }
@@ -57,7 +61,13 @@ object MP4Output {
                 VideoCodecSettings
                   .builder()
                   .codec(VideoCodec.H_264)
-                  .h264Settings(h264Settings(bitrate, config.qualityLevel, config.qualityLevelFineTune))
+                  .h264Settings(
+                    h264Settings(
+                      bitrate,
+                      config.qualityLevel,
+                      config.qualityLevelFineTune
+                    )
+                  )
                   .build()
               )
               .build()

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/MP4Output.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/MP4Output.scala
@@ -3,31 +3,29 @@ package com.gu.media.upload.mediaconvert.file
 import com.gu.contentatom.thrift.atom.media.AssetType
 import com.gu.media.model.VideoSource
 import com.gu.media.upload.mediaconvert.{BitrateSetting, OutputDefinition}
-import com.gu.media.upload.mediaconvert.SharedCodecSettings.{
-  aacAudioDescription,
-  h264Settings,
-  highBitrate,
-  lowBitrate
-}
+import com.gu.media.upload.mediaconvert.SharedCodecSettings.{aacAudioDescription, bitrate, h264Settings}
 import software.amazon.awssdk.services.mediaconvert.model._
 case class Dimensions(width: Option[Int], height: Option[Int])
 
 sealed trait ResolutionConfig {
   def dimensions: Dimensions
-  def bitrate: BitrateSetting
+  def qualityLevel: Option[Int]
+  def qualityLevelFineTune: Option[Double]
   def nameModifier: String
 }
 
 object Resolution {
   case object High extends ResolutionConfig {
     val dimensions = Dimensions(None, Some(720))
-    val bitrate = highBitrate
+    val qualityLevel = None
+    val qualityLevelFineTune = None
     val nameModifier = "_720h"
   }
 
   case object Low extends ResolutionConfig {
     val dimensions = Dimensions(Some(480), None)
-    val bitrate = lowBitrate
+    val qualityLevel = Some(6)
+    val qualityLevelFineTune = Some(0)
     val nameModifier = "_480w"
   }
 }
@@ -59,7 +57,7 @@ object MP4Output {
                 VideoCodecSettings
                   .builder()
                   .codec(VideoCodec.H_264)
-                  .h264Settings(h264Settings(config.bitrate))
+                  .h264Settings(h264Settings(bitrate, config.qualityLevel, config.qualityLevelFineTune))
                   .build()
               )
               .build()

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/MP4Output.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/MP4Output.scala
@@ -13,23 +13,17 @@ case class Dimensions(width: Option[Int], height: Option[Int])
 
 sealed trait ResolutionConfig {
   def dimensions: Dimensions
-  def qualityLevel: Option[Int]
-  def qualityLevelFineTune: Option[Double]
   def nameModifier: String
 }
 
 object Resolution {
   case object High extends ResolutionConfig {
     val dimensions = Dimensions(None, Some(720))
-    val qualityLevel = None
-    val qualityLevelFineTune = None
     val nameModifier = "_720h"
   }
 
   case object Low extends ResolutionConfig {
     val dimensions = Dimensions(Some(480), None)
-    val qualityLevel = Some(7)
-    val qualityLevelFineTune = Some(0)
     val nameModifier = "_480w"
   }
 }
@@ -63,9 +57,7 @@ object MP4Output {
                   .codec(VideoCodec.H_264)
                   .h264Settings(
                     h264Settings(
-                      bitrate,
-                      config.qualityLevel,
-                      config.qualityLevelFineTune
+                      bitrate
                     )
                   )
                   .build()

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/MP4Output.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/MP4Output.scala
@@ -5,7 +5,6 @@ import com.gu.media.model.VideoSource
 import com.gu.media.upload.mediaconvert.OutputDefinition
 import com.gu.media.upload.mediaconvert.SharedCodecSettings.{
   aacAudioDescription,
-  bitrate,
   h264Settings
 }
 import software.amazon.awssdk.services.mediaconvert.model._
@@ -55,11 +54,7 @@ object MP4Output {
                 VideoCodecSettings
                   .builder()
                   .codec(VideoCodec.H_264)
-                  .h264Settings(
-                    h264Settings(
-                      bitrate
-                    )
-                  )
+                  .h264Settings(h264Settings)
                   .build()
               )
               .build()

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/VideoOutput.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/VideoOutput.scala
@@ -4,7 +4,6 @@ import com.gu.media.model.VideoSource
 import com.gu.media.upload.mediaconvert.OutputDefinition
 import com.gu.media.upload.mediaconvert.SharedCodecSettings.{
   aacAudioDescription,
-  bitrate,
   h264Settings
 }
 import software.amazon.awssdk.services.mediaconvert.model._
@@ -47,7 +46,7 @@ object VideoOutput {
               VideoCodecSettings
                 .builder()
                 .codec(VideoCodec.H_264)
-                .h264Settings(h264Settings(bitrate))
+                .h264Settings(h264Settings)
                 .build()
             )
             .build()

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/VideoOutput.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/VideoOutput.scala
@@ -2,11 +2,7 @@ package com.gu.media.upload.mediaconvert.hls
 
 import com.gu.media.model.VideoSource
 import com.gu.media.upload.mediaconvert.OutputDefinition
-import com.gu.media.upload.mediaconvert.SharedCodecSettings.{
-  aacAudioDescription,
-  h264Settings,
-  highBitrate
-}
+import com.gu.media.upload.mediaconvert.SharedCodecSettings.{aacAudioDescription, bitrate, h264Settings}
 import software.amazon.awssdk.services.mediaconvert.model._
 
 object VideoOutput {
@@ -47,7 +43,7 @@ object VideoOutput {
               VideoCodecSettings
                 .builder()
                 .codec(VideoCodec.H_264)
-                .h264Settings(h264Settings(highBitrate))
+                .h264Settings(h264Settings(bitrate))
                 .build()
             )
             .build()

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/VideoOutput.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/VideoOutput.scala
@@ -2,7 +2,11 @@ package com.gu.media.upload.mediaconvert.hls
 
 import com.gu.media.model.VideoSource
 import com.gu.media.upload.mediaconvert.OutputDefinition
-import com.gu.media.upload.mediaconvert.SharedCodecSettings.{aacAudioDescription, bitrate, h264Settings}
+import com.gu.media.upload.mediaconvert.SharedCodecSettings.{
+  aacAudioDescription,
+  bitrate,
+  h264Settings
+}
 import software.amazon.awssdk.services.mediaconvert.model._
 
 object VideoOutput {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Following on from: https://github.com/guardian/media-atom-maker/pull/1505

> At the moment the bitrate does not consider the aspect ratio of the video. For example, a 16:9 video with a fixed height of 720px has a lot more pixels than a 9:16 video with a fixed height of 720px. Conversely, a 16:9 video with a fixed width of 480px has a lot fewer pixels than a 9:16 video with a fixed width of 480px.

Ticket: https://app.asana.com/1/1210045093164357/project/1213691890059143/task/1213993598163920?focus=true

This PR attempts to improve the consistency of transcoded MP4 videos in different aspect ratios by moving away from a [max bitrate](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/mediaconvert/model/H265Settings.html#maxBitrate()) limiting approach, instead relying on the [quality level setting](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/mediaconvert/model/H265QvbrSettings.html#qvbrQualityLevel()). 

### Investigation

The initial investigation led us to suspect that although we are using a quality setting of 8.66 for the high resolution video, this is often limited by the bitrate and our actual quality setting is ~8. If we want a consistent experience between high and low resolution versions of the video, we can set the quality setting consistently at 8.

In order to determine an appropriate quality setting, I examined the outputs of several production videos transcoded with various quality settings. 

### Methodology

> Determine which quality setting the high resolution video is actually outputting by using several test videos and creating transcoded versions stepping down. We can determine the quality by the point at which we see the bit rate dipping below 2400 kb/s. We can then use this score for both the Low resolution and High resolution to provide a consistent experience. 

### Result

<details><summary>Investigation results</summary>
<p>

## Doctors Video

Atom ID: `d73c760-ae27-45d8-8f1d-2c7f6e4cdc48`

### Original

| Resolution | Bitrate (kb/s) | Size |
|------------|----------------|------|
| 1350 x 1080 | 2630 | 3.6 mb |

### PROD

| Output | Bitrate (kb/s) | Size |
|--------|----------------|------|
| 480w | 343 | 612 kb |
| 720h | 2409 | 3.1 mb |

### 900 x 720

| Quality | Bitrate (kb/s) | Size |
|---------|----------------|------|
| 8 66 | 2409 | 3.1 mb |
| 8 33 | 2409 | 3.1 mb |
| 8 | 2401 | 3.1 mb |
| 7 66 | 2271 | 2.9 mb |
| 7 33 | 1980 | 2.6 mb |
| 7 | 1791 | 2.3 mb |

### 480 x 384

| Quality | Bitrate (kb/s) | Size |
|---------|----------------|------|
| 8 66 | 1327 | 1.6 mb |
| 8 33 | 1327 | 1.6 mb |
| 8 | 1170 | 1.4 mb |
| 7 66 | 1045 | 1.3 mb |
| 7 33 | 916 | 1.1 mb |
| 7 | 857 | 1 mb |

---

## ZSL Portrait Video

Atom ID: `c8e10b95-8156-49c6-a499-b58ae04e66aa`

Example: 

https://uploads.guim.co.uk/2026/04/18/London_zoo_by_David_Levene--c8e10b95-8156-49c6-a499-b58ae04e66aa-1.0_720h.mp4#t=0.001

### Original

| Resolution | Bitrate (kb/s) | Size |
|------------|----------------|------|
| 2000 x 2500 | 21090 | 16.6 mb |

### PROD

| Output | Bitrate (kb/s) | Size |
|--------|----------------|------|
| 480w | 337 | 262 kb |
| 720h | 1217 | 940 kb |

### 576 x 720

| Quality | Bitrate (kb/s) | Size |
|---------|----------------|------|
| 8 66 | 1217 | 940 kb |
| 8 33 | 1217 | 940 kb |
| 8 | 1113 | 860 kb |
| 7 66 | 947 | 732 kb |
| 7 33 | 864 | 668 kb |
| 7 | 770 | 596 kb |

### 480 x 600

| Quality | Bitrate (kb/s) | Size |
|---------|----------------|------|
| 8 66 | 902 | 698 kb |
| 8 33 | 902 | 698 kb |
| 8 | 839 | 649 kb |
| 7 66 | 730 | 565 kb |
| 7 33 | 673 | 521 kb |
| 7 | 610 | 473 kb |

---

## Robot Marathon

Atom ID: `a6ce554a-64af-4053-b50b-cd286d2535f2`

Example: 

https://www.theguardian.com/sport/video/2026/apr/19/humanoid-robots-race-past-humans-in-beijing-half-marathon-video

### Original

| Resolution | Bitrate (kb/s) | Size |
|------------|----------------|------|
| 1920 x 1080 | 13005 | 60.8 mb |

### PROD

| Output | Bitrate (kb/s) | Size |
|--------|----------------|------|
| 480w | 341 | 2.3 mb |
| 720h | 2409 | 11.7 mb |

### 1280 x 720

| Quality | Bitrate (kb/s) | Size |
|---------|----------------|------|
| 8 66 | 2409 | 11 mb |
| 8 33 | 2409 | 11 mb |
| 8 | 2401 | 11 mb |
| 7 66 | 2037 | 9.3 mb |
| 7 33 | 1737 | 7.9 mb |
| 7 | 1519 | 6.9 mb |

### 480 x 270

| Quality | Bitrate (kb/s) | Size |
|---------|----------------|------|
| 8 66 | 777 | 3.6 mb |
| 8 33 | 777 | 3.6 mb |
| 8 | 686 | 3.1 mb |
| 7 66 | 584 | 2.7 mb |
| 7 33 | 508 | 2.3 mb |
| 7 | 451 | 2.1 mb |



</p>
</details> 

### Intended outcome

Specifying a consistent output quality of 8, should provide a consistent look and feel across resolution and aspect ratios. The bitrate maximums will continue to provide a sensible ceiling we wouldn't wish to exceed. The quality of 480 width resolution vidoes should be increased, at the expense of files size and therefore Fastly costs.

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->
This change has been tested using the DEV stack and setting up custom transcoder jobs and reviewing the outputs. Further testing can be done by releasing the changes to CODE, uploading videos via MAM CODE and checking the outputted videos match expectations of resolution, file size and quality.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Low resolution videos are more consistent in quality regardless of aspect ratio. The overall quality of low resolution videos should also be higher.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Increasing the size of low resolution videos will likely increase Fastly costs. 
