### PR TITLE
Explicitly set vtt extension to avoid AWS bug

### DIFF
--- a/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
@@ -201,7 +201,7 @@ class AddAssetToAtom
       assetType,
       version,
       urlEncodeSource(
-        new URI(correctFilepath(filePath, mimeType)).getPath.drop(1),
+        new URI(filePath).getPath.drop(1),
         selfHostedOrigin
       ),
       ThriftPlatform.Url,
@@ -220,16 +220,6 @@ class AddAssetToAtom
 
   private def first[T](collection: List[T]) =
     collection.headOption
-
-  // MediaConvert events don't include the .vtt extension for subtitle files event even though the object in S3 has this extension
-  private def correctFilepath(filePath: String, mimeType: String) = {
-    if (mimeType == VideoSource.mimeTypeVtt && !filePath.endsWith(".vtt")) {
-      log.warn(
-        s"MediaConvert output file path $filePath does not end with .vtt extension for a subtitle file. Correcting the file path to include the extension."
-      )
-      filePath + ".vtt"
-    } else filePath
-  }
 
   private def ratio(outputDetails: MediaConvertOutputDetails) =
     for {

--- a/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
@@ -224,6 +224,9 @@ class AddAssetToAtom
   // MediaConvert events don't include the .vtt extension for subtitle files event even though the object in S3 has this extension
   private def correctFilepath(filePath: String, mimeType: String) = {
     if (mimeType == VideoSource.mimeTypeVtt && !filePath.endsWith(".vtt")) {
+      log.warn(
+        s"MediaConvert output file path $filePath does not end with .vtt extension for a subtitle file. Correcting the file path to include the extension."
+      )
       filePath + ".vtt"
     } else filePath
   }

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/WebVTTOutput.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/WebVTTOutput.scala
@@ -34,6 +34,7 @@ object WebVTTOutput {
             )
             .build()
         )
+        .extension("vtt") // explicitly setting the extension avoids an AWS bug where the extension isn't included in the media convert complete event
         .build()
   )
 }


### PR DESCRIPTION
Without explicitly setting the vtt extension, vtt files are written to S3 with `.vtt` extension, but the MediaConvert complete event omits the extension. 

We've previously worked around this by re-writing the filepath based on the expected mimetype which works but isn't great.

AWS support identified that if we explicitly set the `Extension` property on our `Output`, the file will be written with the extension and the event will also have the extension. This seems like a nicer fix.
