### PR TITLE
Enable srt upload on non-youtube videos

### DIFF
--- a/public/video-ui/src/components/VideoUpload/VideoAsset.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.tsx
@@ -287,13 +287,12 @@ export function Asset({
   const subtitleFilename = metadata?.subtitleFilename;
 
   /**
-   * We support subtitles on Loops, but not Cinemagraphs (designed to be silent and decorative), and NonYoutube videos
-   * (which use the browser player).
+   * We support subtitles on Loops and NonYoutube videos, but not Cinemagraphs (designed to be silent and decorative).
    *
-   * We can't simply check for videoPlayerFormat === 'Loop' here as videoPlayerFormat is undefined on videos
+   * We can't simply check for videoPlayerFormat === 'Loop' or 'Default' here as videoPlayerFormat is undefined on videos
    * created before videoPlayerFormat was introduced.
   **/
-  const videoSupportsSubtitles = isSelfHosted && (videoPlayerFormat === 'Loop' || videoPlayerFormat === undefined);
+  const videoSupportsSubtitles = isSelfHosted && (videoPlayerFormat === 'Loop' || videoPlayerFormat === 'Default' || videoPlayerFormat === undefined);
 
   const subtitlePanel = videoSupportsSubtitles && (
     <div className="video-trail__item__subtitles">


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This pull request enables SRT subtitle file uploads for non-YouTube videos in Media Atom Maker.

## How has this change been tested?

The change has been tested by the following steps:
1. Deploy the branch
2. Create a new atom with "Non-YouTube" video type in Media Atom Maker CODE
3. Upload a video file
4. We should see the UI that allows us to upload the subtitle SRT file
5. Upload a subtitle file and wait for the video processing to finish
6. We should see that the video preview now has the subtitle as specified by the subtitle file
7. Hit the backend endpoint directly - https://video.local.dev-gutools.co.uk/api/atoms/{atom-ID}
8. Open the subtitle asset file as indicated in the response.
9. We should see the same subtitle as the subtitle file we've uploaded 

## How can we measure success?

Allow users to upload subtitle files for non-YouTube videos, which is part of our work on supporting non-YouTube video on fronts using our new video player.

## Have we considered potential risks?

The risk should be relatively low because it does not modify this feature.  It just enables it on the "Non-YouTube" type of video.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
| Before | After |
| --- | --- |
| <img width="574" height="699" alt="Screenshot 2026-04-21 at 17 07 26" src="https://github.com/user-attachments/assets/5ce18a11-5172-4f9e-b2c4-e062fff4085c" /> | <img width="504" height="731" alt="Screenshot 2026-04-22 at 09 07 05" src="https://github.com/user-attachments/assets/997404be-e92c-4c5a-bb34-c688c7747e58" /> |

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214077514458038