### PR TITLE
Build should fail if ffmpeg cannot be downloaded

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -202,8 +202,8 @@ lazy val uploader = (project in file("uploader"))
         IO.createDirectory(ffmpegFolder)
         import scala.sys.process.*
         val archive = target.value / "ffmpeg" / "ffmpeg-release-amd64-static.tar.xz"
-        s"wget -q https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz -O $archive".!
-        (s"tar xOf $archive ffmpeg-7.0.2-amd64-static/ffmpeg" #> binary).!
+        s"wget -nv https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz -O $archive".!!
+        (s"tar xOf $archive ffmpeg-7.0.2-amd64-static/ffmpeg" #> binary).!!
       }
 
       binary -> "bin/ffmpeg"


### PR DESCRIPTION
A build recently completed despite ffmpeg not being downloaded. This resulted in a very unexpected runtime failure. Let's make the build fail instead.

This also switches from running wget in "quiet" mode to merely "not verbose". This should provide us with more information if the build fails at this point.
