### PR TITLE
always allow editing embargo, only prevent new schedules

### DIFF
--- a/public/video-ui/src/components/ScheduledLaunch/ScheduledLaunch.jsx
+++ b/public/video-ui/src/components/ScheduledLaunch/ScheduledLaunch.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import DatePicker from '../FormFields/DatePicker';
 import Icon from '../Icon';
@@ -153,8 +154,10 @@ class ScheduledLaunch extends React.Component {
   /* Render functions */
 
   renderScheduleOptions = (video, videoEditOpen, scheduledLaunch, embargo) => {
-    const hasPreventedPublication = embargo && embargo >= impossiblyDistantDate;
-    // We don't currently allow setting of embargo dates
+    const hasPreventedPublication = embargo && moment(embargo).isSameOrAfter(impossiblyDistantDate);
+
+    const canSchedule = !this.getNoScheduleReason();
+
     return (
       <ul className="scheduleOptions">
         {!hasPreventedPublication && (
@@ -162,10 +165,12 @@ class ScheduledLaunch extends React.Component {
             <button
               className="btn btn--list-item"
               onClick={() => this.onSelectOption(datesProperties.selectedScheduleDate)}
-              disabled={!video || videoEditOpen}
+              disabled={!video || videoEditOpen || !canSchedule}
+              data-tip={this.getNoScheduleReason()}
             >
               {scheduledLaunch ? 'Edit scheduled date' : 'Schedule'}
             </button>
+            <ReactTooltip />
           </li>
         )}
         {!hasPreventedPublication && embargo && (
@@ -264,13 +269,9 @@ class ScheduledLaunch extends React.Component {
   );
 
   renderSchedulerButton = (showScheduleOptions) => {
-
-    const notAbleToScheduleReason = this.getNoScheduleReason();
-
     return (
-      <div data-tip={notAbleToScheduleReason}>
+      <div>
         <button
-          disabled={!!notAbleToScheduleReason}
           className="btn btn--list"
           onClick={() =>
             this.setState({
@@ -320,13 +321,13 @@ class ScheduledLaunch extends React.Component {
         {!showDatePicker && (
             <div className="scheduleOptionsWrapper">
             {this.renderSchedulerButton(showScheduleOptions)}
-              {showScheduleOptions &&
-                this.renderScheduleOptions(
-                  video,
-                  videoEditOpen,
-                  scheduledLaunch,
-                  embargo
-                )}
+            {showScheduleOptions &&
+              this.renderScheduleOptions(
+                video,
+                videoEditOpen,
+                scheduledLaunch,
+                embargo
+              )}
             </div>
           )}
         {showDatePicker && this.renderSaveButton(propertyName, selectedScheduleDate, selectedEmbargoDate, invalidDateError)}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We've had one atom that was simultaneously published (ie. the Composer page had been published, so a usage was listed) and embargoed. Since it had been published, the UI would not allow users to enter the menu to remove the embargo. 

Update to always allow entering the scheduling/embargoing menu, and only prevent editing of the _launch schedule_. Users can always prevent publication (or remove the embargo).

## How has this change been tested?

Tested on CODE. Created a video page, then embargoed the atom. Then launched the composer page to produce a usage. The atom could still be unembargoed to allow publish.

## How can we measure success?

Users can get themselves out of similar sticky situations.

