### PR TITLE
Include commissioning only

### DIFF
--- a/public/video-ui/src/components/FormFields/TagPicker.jsx
+++ b/public/video-ui/src/components/FormFields/TagPicker.jsx
@@ -94,7 +94,7 @@ class TagPicker extends React.Component {
         searchResultTags: []
       });
     } else {
-      getTagsByType(this.props.tagManagerUrl, searchText, tagTypes)
+      getTagsByType(this.props.tagManagerUrl, searchText, tagTypes, this.props.tagSubType)
         .then(response => {
 
           const tags = response.data.reduce((tags, {data}) => {

--- a/public/video-ui/src/components/VideoData/VideoData.jsx
+++ b/public/video-ui/src/components/VideoData/VideoData.jsx
@@ -142,7 +142,7 @@ export default class VideoData extends React.Component {
               isRequired={canonicalVideoPageExists}
               inputPlaceholder="Search commissioning info (type '*' to show all)"
             >
-              <TagPicker disableTextInput />
+              <TagPicker disableTextInput tagSubType="commissioningdesk" />
             </ManagedField>
         }
         {

--- a/public/video-ui/src/services/tagmanager.ts
+++ b/public/video-ui/src/services/tagmanager.ts
@@ -1,9 +1,10 @@
 import { apiRequest } from './apiRequest';
 import { getStore } from '../util/storeAccessor';
 
-export function getTagsByType(tagManagerUrl: string, query: string, types: string[]) {
+export function getTagsByType(tagManagerUrl: string, query: string, types: string[], subType?: string) {
+  const subTypeQuery = subType ? `&subType=${subType}` : '';
   return apiRequest({
-    url: `${tagManagerUrl}/hyper/tags?query=${query}&limit=150&type=${types.join(",")}`
+    url: `${tagManagerUrl}/hyper/tags?query=${query}&limit=150&type=${types.join(",")}${subTypeQuery}`
   });
 }
 


### PR DESCRIPTION
## What does this change?

Limits the commissioning desk dropdown to only include commissioning desk tags.

~It also adds types to the tag picker.~

## Images

### Before

Note the dcroptout (platformfunctional) tag.

<img width="930" height="330" alt="Screenshot 2026-04-28 at 12 30 05" src="https://github.com/user-attachments/assets/e5b36aa1-8e9a-4af5-a3a7-9cd6313a1338" />

### After

Note the absence of the dcroptout tag.

<img width="930" height="330" alt="Screenshot 2026-04-28 at 12 30 19" src="https://github.com/user-attachments/assets/70e9ca51-c5bc-45dc-ab56-7dfbddfbb043" />

 