### PR TITLE
allow adding videos from some specified "external" channels as imported urls

### DIFF
--- a/app/model/commands/AddAssetCommand.scala
+++ b/app/model/commands/AddAssetCommand.scala
@@ -93,6 +93,8 @@ case class AddAssetCommand(
 
     def ensureIsGuardianChannel(videoChannel: String) = {
       if (youTube.channels.exists(_.id == videoChannel)) Some(videoChannel)
+      else if (youTube.externalChannels.contains(videoChannel))
+        Some(videoChannel)
       else IncorrectYouTubeChannel
     }
 

--- a/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
+++ b/common/src/main/scala/com/gu/media/youtube/YouTubeAccess.scala
@@ -72,6 +72,11 @@ trait YouTubeAccess extends Settings with Logging {
   }.toSet
   val allChannels = channelConfig.keySet
 
+  // Youtube channels that aren't part of the Guardian's Youtube Content Management org,
+  // so we can't automatically manage metadata, thumbnails, rights, etc. but we are happy
+  // for eds to import videos as urls.
+  val externalChannels = getStringSet("youtube.channels.external")
+
   val disallowedVideos: Set[String] = getStringSet("youtube.videos.disallowed")
   val usePartnerApi: Boolean =
     getString("youtube.usePartnerApi").forall(_.toBoolean)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

New bit of config: allow nominating some channels as "external" - they're not part of the guardian content management group of channels, so we can't manage them through the API, but we can allow them to be imported into an atom.

## How has this change been tested?

Tested on CODE - adding the channel ID for the new channel to this new list, then importing to an atom in CODE and doing the work to publish it. All worked fine, despite the channel not yet being linked to the Content Manager in Youtube.
