### PR TITLE
Add error boundary

### DIFF
--- a/public/video-ui/src/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/public/video-ui/src/components/ErrorBoundary/ErrorBoundary.jsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+export class ErrorBoundary extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { hasError: false };
+    }
+    static getDerivedStateFromError(error) {
+        return { hasError: true };
+    }
+    render() {
+        if (this.state.hasError) {
+            return <p>Error</p>;
+        }
+
+        return this.props.children;
+    }
+}

--- a/public/video-ui/src/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/public/video-ui/src/components/ErrorBoundary/ErrorBoundary.jsx
@@ -1,15 +1,19 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 export class ErrorBoundary extends React.Component {
+    static propTypes = {
+        fallback: PropTypes.object.isRequired
+      };
     constructor(props) {
         super(props);
         this.state = { hasError: false };
     }
-    static getDerivedStateFromError(error) {
+    static getDerivedStateFromError() {
         return { hasError: true };
     }
     render() {
         if (this.state.hasError) {
-            return <p>Error</p>;
+            return this.props.fallback;
         }
 
         return this.props.children;

--- a/public/video-ui/src/components/VideoItem/VideoItemError.jsx
+++ b/public/video-ui/src/components/VideoItem/VideoItemError.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default class VideoItemError extends React.Component {
+    render(){
+        return(
+            <li className="grid__item">   
+                <div className="grid__image__placeholder error">
+                    <p>Unexpected error rendering this video</p>
+                </div>
+            </li>
+        );
+    }
+}

--- a/public/video-ui/src/components/VideoItem/index.jsx
+++ b/public/video-ui/src/components/VideoItem/index.jsx
@@ -49,6 +49,9 @@ export default class VideoItem extends React.Component {
 
   render() {
     const video = this.props.video;
+    if(video.id === '2c11d9bb-920c-499a-81dc-df822ae8d8f0') {
+      throw Error("oops!!");
+    }
     const platform = VideoUtils.getPlatformFromSummary(video);
     const scheduledLaunch = VideoUtils.getScheduledLaunch(video);
     const scheduledLaunchMoment = moment(scheduledLaunch);

--- a/public/video-ui/src/components/VideoItem/index.jsx
+++ b/public/video-ui/src/components/VideoItem/index.jsx
@@ -49,9 +49,6 @@ export default class VideoItem extends React.Component {
 
   render() {
     const video = this.props.video;
-    if(video.id === '2c11d9bb-920c-499a-81dc-df822ae8d8f0') {
-      throw Error("oops!!");
-    }
     const platform = VideoUtils.getPlatformFromSummary(video);
     const scheduledLaunch = VideoUtils.getScheduledLaunch(video);
     const scheduledLaunchMoment = moment(scheduledLaunch);

--- a/public/video-ui/src/pages/Search/index.tsx
+++ b/public/video-ui/src/pages/Search/index.tsx
@@ -3,6 +3,8 @@ import VideoItem from '../../components/VideoItem';
 import { frontPageSize } from '../../constants/frontPageSize';
 import { Presence, PresenceClient, PresenceConfig, PresenceData, safelyStartPresence } from '../../services/presence';
 import { getStore } from '../../util/storeAccessor';
+import { ErrorBoundary } from '../../components/ErrorBoundary/ErrorBoundary';
+import VideoItemError from '../../components/VideoItem/VideoItemError';
 
 type Video = {
   id: string
@@ -130,7 +132,7 @@ const Videos = ({ videos, total, search: {searchTerm, shouldUseCreatedDateForSor
       <div className="grid">
         {videos.length ? <ul className="grid__list">
           {videos.map(video => (
-            <ErrorBoundary key={video.id} fallback={<p>error fallback</p>}>
+            <ErrorBoundary key={video.id} fallback={<VideoItemError/>}>
               <VideoItem video={video} presences={getPresencesForVideo(video.id)} />
             </ErrorBoundary>
           ))}
@@ -150,7 +152,6 @@ import * as reportPresenceClientError from '../../actions/PresenceActions/report
 import { fetchVideos } from '../../slices/videos';
 import { AppDispatch } from "../../util/setupStore";
 import { Search } from "../../slices/search";
-import { ErrorBoundary } from '../../components/ErrorBoundary/ErrorBoundary';
 
 function mapStateToProps(state: { videos: { entries: number, total: number, limit: number }, search: Search}) {
   return {

--- a/public/video-ui/src/pages/Search/index.tsx
+++ b/public/video-ui/src/pages/Search/index.tsx
@@ -130,8 +130,8 @@ const Videos = ({ videos, total, search: {searchTerm, shouldUseCreatedDateForSor
       <div className="grid">
         {videos.length ? <ul className="grid__list">
           {videos.map(video => (
-            <ErrorBoundary key={video.id}>
-              <VideoItem  video={video} presences={getPresencesForVideo(video.id)} />
+            <ErrorBoundary key={video.id} fallback={<p>error fallback</p>}>
+              <VideoItem video={video} presences={getPresencesForVideo(video.id)} />
             </ErrorBoundary>
           ))}
         </ul> : <p className="grid__message">No videos found</p>

--- a/public/video-ui/src/pages/Search/index.tsx
+++ b/public/video-ui/src/pages/Search/index.tsx
@@ -130,7 +130,9 @@ const Videos = ({ videos, total, search: {searchTerm, shouldUseCreatedDateForSor
       <div className="grid">
         {videos.length ? <ul className="grid__list">
           {videos.map(video => (
-            <VideoItem key={video.id} video={video} presences={getPresencesForVideo(video.id)} />
+            <ErrorBoundary key={video.id}>
+              <VideoItem  video={video} presences={getPresencesForVideo(video.id)} />
+            </ErrorBoundary>
           ))}
         </ul> : <p className="grid__message">No videos found</p>
         }
@@ -148,6 +150,7 @@ import * as reportPresenceClientError from '../../actions/PresenceActions/report
 import { fetchVideos } from '../../slices/videos';
 import { AppDispatch } from "../../util/setupStore";
 import { Search } from "../../slices/search";
+import { ErrorBoundary } from '../../components/ErrorBoundary/ErrorBoundary';
 
 function mapStateToProps(state: { videos: { entries: number, total: number, limit: number }, search: Search}) {
   return {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds an `ErrorBoundary` component so that we can still render the videos page even if one of the components has an error. 

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="2672" height="664" alt="videoerror" src="https://github.com/user-attachments/assets/20c26d14-79f1-4c22-93dc-ea8947f1f290" />


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
