### PR TITLE
upgrade aws to 2.44.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import scala.collection.immutable.Seq
 import scala.sys.process.*
 
 val scroogeVersion = "4.12.0"
-val awsV2Version = "2.42.25"
+val awsV2Version = "2.44.4"
 val pandaVersion = "19.0.0"
 val atomMakerVersion = "11.0.0"
 val typesafeConfigVersion =


### PR DESCRIPTION
Upgrades the AWS java SDK to latest, which includes the latest version of netty with security fixes