### PR TITLE
Adjust colour in Stand tag picker

### DIFF
--- a/public/video-ui/src/components/FormFields/StandTagPicker.tsx
+++ b/public/video-ui/src/components/FormFields/StandTagPicker.tsx
@@ -120,9 +120,9 @@ const editableUiTheme = {
     borderColor: '#BDBDBD',
     item: {
       color: '#BDBDBD',
-      backgroundHoverColor: '#393939',
+      backgroundHoverColor: '#252525',
       colorHover: '#BDBDBD',
-      backgroundFocusedColor: '#393939',
+      backgroundFocusedColor: '#252525',
       colorFocused: '#BDBDBD'
     }
   }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This pull request adjusts the colour of option items in Stand tag picker component so that they can be visible. The new colour is chosen based on other existing components.

## How has this change been tested?

Open a video page in MAM, manually append "?supportTagging", and search for tags in the tag picker under "Tags" field.

## How can we measure success?

Make it possible to work on the tag picker using keyboard only.

## Have we considered potential risks?

Very low, as it changes the colour in CSS only.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
| Before | After |
| --- | --- |
| <img width="666" height="259" alt="Screenshot 2026-05-14 at 11 35 05" src="https://github.com/user-attachments/assets/0138e45a-9da1-4566-8c0a-8afeb49bbe62" /> | <img width="666" height="256" alt="Screenshot 2026-05-14 at 11 36 14" src="https://github.com/user-attachments/assets/b627876a-88c1-4d1e-bd4e-cc9f1080879e" /> |

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [X] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
