### PR TITLE
Increase ratio tolerance from 3 to 6.

### DIFF
--- a/common/src/main/scala/com/gu/media/util/AspectRatio.scala
+++ b/common/src/main/scala/com/gu/media/util/AspectRatio.scala
@@ -27,7 +27,7 @@ object AspectRatio {
   @tailrec
   private def gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
 
-  def calculate(width: Int, height: Int, tolerance: Int = 3): Option[Ratio] = {
+  def calculate(width: Int, height: Int, tolerance: Int = 6): Option[Ratio] = {
     val matchingRatio = for {
       w <- width - tolerance until width + tolerance
       h <- height - tolerance until height + tolerance

--- a/common/src/test/scala/com/gu/media/util/AspectRatioTest.scala
+++ b/common/src/test/scala/com/gu/media/util/AspectRatioTest.scala
@@ -13,19 +13,29 @@ class AspectRatioTest extends AnyFlatSpec with Matchers {
   }
 
   "calculate" should "apply a tolerance to match inexact dimensions" in {
-    AspectRatio.calculate(1280, 720, tolerance = 3).map(_.name) should contain(
+    AspectRatio.calculate(1280, 720, tolerance = 6).map(_.name) should contain(
       "16:9"
     )
-    AspectRatio.calculate(1280, 721, tolerance = 3).map(_.name) should contain(
+    AspectRatio.calculate(1280, 721, tolerance = 6).map(_.name) should contain(
       "16:9"
     )
-    AspectRatio.calculate(1280, 722, tolerance = 3).map(_.name) should contain(
+    AspectRatio.calculate(1280, 722, tolerance = 6).map(_.name) should contain(
       "16:9"
     )
-    AspectRatio.calculate(1280, 723, tolerance = 3).map(_.name) should contain(
+    AspectRatio.calculate(1280, 723, tolerance = 6).map(_.name) should contain(
       "16:9"
     )
-    AspectRatio.calculate(1280, 724, tolerance = 3).map(_.name) shouldBe empty
+    AspectRatio.calculate(1280, 724, tolerance = 6).map(_.name) should contain(
+      "16:9"
+    )
+    AspectRatio.calculate(1280, 725, tolerance = 6).map(_.name) should contain(
+      "16:9"
+    )
+    AspectRatio.calculate(1280, 726, tolerance = 6).map(_.name) should contain(
+      "16:9"
+    )
+    AspectRatio.calculate(1280, 727, tolerance = 6).map(_.name) shouldBe empty
+
   }
 
 }


### PR DESCRIPTION
## What does this change?
This is because 480w 9:16 videos are commonly encoded at 480×854, which does not reduce cleanly to a known ratio and requires a wider tolerance to match.

The test suite has been updated to show the output for a tolerance of 6 as this is now the default.

## How has this change been tested?
- Deployed branch to CODE
- Uploaded a 9:16 video that had previously failed to correctly assign the 9:16 aspect ratio to 480w encoded video
- Verified all video assets now had 9:16 aspect ratio

## How can we measure success?
Videos and images are assigned the correct aspect ratio

## Have we considered potential risks?
The greater the tolerance, the more chance there is of a false positive ratio. 

## Images

### Before 
<img width="1426" height="467" alt="Screenshot 2026-05-19 at 09 40 31" src="https://github.com/user-attachments/assets/8746738e-54e5-4685-95f3-948e7be77a08" />


### After

<img width="1430" height="605" alt="Screenshot 2026-05-19 at 09 40 21" src="https://github.com/user-attachments/assets/6eb91809-95b5-4154-9500-f7b7c242f017" />


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
