### PR TITLE
More primitive aspect ratio calculation

### DIFF
--- a/common/src/main/scala/com/gu/media/util/AspectRatio.scala
+++ b/common/src/main/scala/com/gu/media/util/AspectRatio.scala
@@ -1,9 +1,5 @@
 package com.gu.media.util
 
-import scala.annotation.tailrec
-
-/** image/video aspect ratio calculation copied from guardian/grid
-  */
 object AspectRatio {
   case class Ratio(name: String, width: Int, height: Int)
 
@@ -24,20 +20,41 @@ object AspectRatio {
     Ratio("16:9", 16, 9)
   )
 
-  @tailrec
-  private def gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
+  // A tolerance of zero means that for a given width (or height), the height (or width) is the closest
+  // whole number to the exact aspect ratio. e.g. 480x854 is not exactly 9:16, but it is closer than
+  // 480x853 or 480x855, so it cannot be improved.
+  //
+  // A tolerance of one means that for a given width (or height), the height (or width) is at most 1px
+  // away from the closest integer to the exact aspect ratio. e.g. 480x855 is not exactly 9:16, and
+  // 480x854 is closer to 9:16, but 480x855 will be accepted as 9:16 if the tolerance is one.
+  //
+  // Unfortunately this is slightly complicated by allowing a tolerance on both the width and height.
+  // As a result 480x855 is also accepted as 9:16 with a tolerance of *zero* because 480x855 is the
+  // closest approximation to 9:16 when the height is fixed at 855.
 
-  def calculate(width: Int, height: Int, tolerance: Int = 3): Option[Ratio] = {
-    val matchingRatio = for {
-      w <- width - tolerance until width + tolerance
-      h <- height - tolerance until height + tolerance
-      g = gcd(w, h)
-      simplifiedWidth = w / g
-      simplifiedHeight = h / g
-      ratio <- knownRatios.find(ratio =>
-        ratio.width == simplifiedWidth && ratio.height == simplifiedHeight
-      )
-    } yield ratio
-    matchingRatio.headOption
+  def calculate(width: Int, height: Int, tolerance: Int = 1): Option[Ratio] = {
+    // Assume that the height is fixed, and desired ratio was achieved by adjusting the width.
+    // What range of aspect ratios would be possible within the tolerance?
+    val fixedHeightLowerBound = (width - tolerance - 1).toDouble / height
+    val fixedHeightUpperBound = (width + tolerance + 1).toDouble / height
+
+    // Assume that the width is fixed, and desired ratio was achieved by adjusting the height.
+    // What range of aspect ratios would be possible within the tolerance?
+    val fixedWidthLowerBound = width.toDouble / (height + tolerance + 1)
+    val fixedWidthUpperBound = width.toDouble / (height - tolerance - 1)
+
+    knownRatios
+      .flatMap({ knownRatio =>
+        val knownDouble = knownRatio.width.toDouble / knownRatio.height
+        if (
+          fixedWidthLowerBound < knownDouble && knownDouble < fixedWidthUpperBound ||
+          fixedHeightLowerBound < knownDouble && knownDouble < fixedHeightUpperBound
+        ) {
+          Some((knownRatio, Math.abs(knownDouble - (width.toDouble / height))))
+        } else { None }
+      })
+      .sortBy(_._2) // sort by error from the exact aspect ratio, so that the closest match is first
+      .headOption
+      .map(_._1) // return the aspect ratio only
   }
 }

--- a/common/src/test/scala/com/gu/media/util/AspectRatioTest.scala
+++ b/common/src/test/scala/com/gu/media/util/AspectRatioTest.scala
@@ -7,25 +7,36 @@ class AspectRatioTest extends AnyFlatSpec with Matchers {
 
   "calculate" should "produce an aspect ratio from dimensions" in {
     AspectRatio.calculate(1280, 720).map(_.name) should contain("16:9")
+    AspectRatio.calculate(1280, 720).map(_.name) should contain("16:9")
     AspectRatio.calculate(720, 1280).map(_.name) should contain("9:16")
     AspectRatio.calculate(1024, 1280).map(_.name) should contain("4:5")
     AspectRatio.calculate(1280, 1024).map(_.name) should contain("5:4")
   }
 
   "calculate" should "apply a tolerance to match inexact dimensions" in {
-    AspectRatio.calculate(1280, 720, tolerance = 3).map(_.name) should contain(
+    AspectRatio.calculate(480, 854, tolerance = 0).map(_.name) should contain(
+      "9:16"
+    )
+    AspectRatio.calculate(480, 855, tolerance = 1).map(_.name) should contain(
+      "9:16"
+    )
+
+    AspectRatio.calculate(1280, 720, tolerance = 0).map(_.name) should contain(
       "16:9"
     )
-    AspectRatio.calculate(1280, 721, tolerance = 3).map(_.name) should contain(
+    AspectRatio.calculate(1280, 721, tolerance = 0) shouldBe empty
+    AspectRatio.calculate(1280, 721, tolerance = 1).map(_.name) should contain(
       "16:9"
     )
-    AspectRatio.calculate(1280, 722, tolerance = 3).map(_.name) should contain(
+    AspectRatio.calculate(1280, 722, tolerance = 1) shouldBe empty
+    AspectRatio.calculate(1280, 722, tolerance = 2).map(_.name) should contain(
       "16:9"
     )
+    AspectRatio.calculate(1280, 723, tolerance = 2) shouldBe empty
     AspectRatio.calculate(1280, 723, tolerance = 3).map(_.name) should contain(
       "16:9"
     )
-    AspectRatio.calculate(1280, 724, tolerance = 3).map(_.name) shouldBe empty
+    AspectRatio.calculate(1280, 724, tolerance = 3) shouldBe empty
   }
 
 }

--- a/common/src/test/scala/com/gu/media/util/AspectRatioTest.scala
+++ b/common/src/test/scala/com/gu/media/util/AspectRatioTest.scala
@@ -7,7 +7,6 @@ class AspectRatioTest extends AnyFlatSpec with Matchers {
 
   "calculate" should "produce an aspect ratio from dimensions" in {
     AspectRatio.calculate(1280, 720).map(_.name) should contain("16:9")
-    AspectRatio.calculate(1280, 720).map(_.name) should contain("16:9")
     AspectRatio.calculate(720, 1280).map(_.name) should contain("9:16")
     AspectRatio.calculate(1024, 1280).map(_.name) should contain("4:5")
     AspectRatio.calculate(1280, 1024).map(_.name) should contain("5:4")


### PR DESCRIPTION
## What does this change?

The existing aspect ratio solution is quite complicated. It attempts to express the aspect ratio in the standard form x:y, allowing a supplied pixel tolerance to match to pre-defined ratios.

For our purposes, it is more helpful to assume that the video creator was trying to create a video that matched one of our ratios, but with the constraint that the width (or height) had to be fixed to a specific size. This more closely matches how our tool is used.

A side effect is that in most cases a tolerance of zero should be fine.

I believe this will make https://github.com/guardian/media-atom-maker/pull/1558 unnecessary