### PR TITLE
Extend tag picker to video tracking tags and other allowed tags

### DIFF
--- a/public/video-ui/src/components/FormFields/StandTagPicker.tsx
+++ b/public/video-ui/src/components/FormFields/StandTagPicker.tsx
@@ -176,7 +176,15 @@ const StandTagPicker = ({ tagTypes, allowTags, filters, fieldName, fieldValue, e
   const [isLoading, setIsLoading] = useState(false);
   const [tagSearchError, setTagSearchError] = useState<boolean>(false);
   const tagManagerUrl = useSelector((state: {config: AppConfig}) => state.config.tagManagerUrl);
-
+  const tagPickerContainerStyle = { display: 'flex', alignItems: 'stretch', gap: '8px', marginBottom: '8px' };
+  const tagPickerDropdownStyle = {
+    border: "1px solid #BDBDBD",
+    backgroundColor: "#393939",
+    color: "inherit",
+    font: "inherit",
+    paddingLeft: "8px",
+    paddingRight: "8px"
+  };
   const searchTags = useCallback((inputText: string, selectedTags: VideoTag[], filter?: StandTagPickerFilter) => {
     if (tagManagerUrl) {
       setIsLoading(true);
@@ -295,7 +303,7 @@ const StandTagPicker = ({ tagTypes, allowTags, filters, fieldName, fieldValue, e
               Tags are currently unavailable
             </div>
           )}
-          <div style={{ display: 'flex', alignItems: 'flex-start', gap: '8px' }}>
+          <div style={tagPickerContainerStyle}>
             <div style={{ flex: 1 }}>
               <TagAutocomplete
                 onTextInputChange={onTextInputChange}
@@ -310,7 +318,7 @@ const StandTagPicker = ({ tagTypes, allowTags, filters, fieldName, fieldValue, e
               />
             </div>
             {filters && filters.length > 0 && (
-              <select onChange={onFilterChange}>
+              <select style={tagPickerDropdownStyle} onChange={onFilterChange}>
                 {filters.map((filter, index) => (
                   <option key={filter.displayLabel} value={index}>{filter.displayLabel}</option>
                 ))}

--- a/public/video-ui/src/components/FormFields/StandTagPicker.tsx
+++ b/public/video-ui/src/components/FormFields/StandTagPicker.tsx
@@ -8,11 +8,18 @@ import FieldNotification from '../../constants/FieldNotification';
 import debounce from "lodash/debounce";
 import type { AppConfig } from '../../slices/config';
 
-type VideoTag = {
+export type StandTagPickerFilter = {
+  displayLabel: string;
+  tagTypes: string[];
+  tagSubType?: string;
+}
+
+export type VideoTag = {
   id: number;
   path: string;
   name: string;
   type: string;
+  subtype?: string;
   sectionName: string;
 };
 
@@ -22,7 +29,8 @@ const videoTagFromTagManager = (data: Tag): VideoTag => {
     path: data.path,
     name: data.internalName,
     type: data.type,
-    sectionName: data.section.name
+    sectionName: data.section.name,
+    subtype: data.subType
   };
 };
 
@@ -130,6 +138,8 @@ const editableUiTheme = {
 
 interface StandTagPickerProps {
   tagTypes: string[];
+  allowTags?: (tag: VideoTag) => boolean;
+  filters?: StandTagPickerFilter[];
 
   // the following properties are passed down from the parent ManagedField
   fieldName: string;
@@ -157,25 +167,32 @@ const isFieldValueChanged = (fieldValue: string[], selectedTags: VideoTag[]) => 
   return false;
 };
 
-const StandTagPicker = ({ tagTypes, fieldName, fieldValue, editable, onUpdateField, placeholder, hasError, hasWarning, notification }: StandTagPickerProps) => {
+const StandTagPicker = ({ tagTypes, allowTags, filters, fieldName, fieldValue, editable, onUpdateField, placeholder, hasError, hasWarning, notification }: StandTagPickerProps) => {
 
   const [selectedTags, setSelectedTags] = useState<VideoTag[]>([]);
   const [options, setOptions] = useState<VideoTag[]>([]);
   const [value, setValue] = useState('');
+  const [selectedFilter, setSelectedFilter] = useState<StandTagPickerFilter | undefined>(filters?.[0]);
   const [isLoading, setIsLoading] = useState(false);
   const [tagSearchError, setTagSearchError] = useState<boolean>(false);
   const tagManagerUrl = useSelector((state: {config: AppConfig}) => state.config.tagManagerUrl);
 
-  const searchTags = useCallback((inputText: string, selectedTags: VideoTag[]) => {
+  const searchTags = useCallback((inputText: string, selectedTags: VideoTag[], filter?: StandTagPickerFilter) => {
     if (tagManagerUrl) {
       setIsLoading(true);
-      getTagsByType(tagManagerUrl, inputText, tagTypes)
+      const activeTagTypes = filter?.tagTypes ?? tagTypes;
+      const activeSubType = filter?.tagSubType;
+      const filterTag = (tag: VideoTag) => (
+        (allowTags ? allowTags(tag) : true) &&
+        !selectedTags.some((selectedTag) => selectedTag.path === tag.path)
+      );
+      getTagsByType(tagManagerUrl, inputText, activeTagTypes, activeSubType)
         .then(response => {
           const tags = response.data
             .map((tagItem) => tagItem.data)
             .filter((tag) => !tag.deprecated)
             .map(videoTagFromTagManager)
-            .filter((tag) => !selectedTags.some((selectedTag) => selectedTag.path === tag.path));
+            .filter(filterTag);
           setTagSearchError(false);
           setOptions(tags);
         })
@@ -186,7 +203,7 @@ const StandTagPicker = ({ tagTypes, fieldName, fieldValue, editable, onUpdateFie
           setIsLoading(false);
         });
     }
-  }, [tagManagerUrl, tagTypes, setIsLoading, setTagSearchError, setOptions]);
+  }, [tagManagerUrl, tagTypes, allowTags, setIsLoading, setTagSearchError, setOptions]);
 
   const debouncedSearchTags = useMemo(() => debounce(searchTags, 500), [searchTags]);
 
@@ -196,7 +213,17 @@ const StandTagPicker = ({ tagTypes, fieldName, fieldValue, editable, onUpdateFie
       setOptions([]);
       return;
     }
-    debouncedSearchTags(inputText, selectedTags);
+    debouncedSearchTags(inputText, selectedTags, selectedFilter);
+  };
+
+  const onFilterChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newFilter = filters?.[Number(e.target.value)];
+    setSelectedFilter(newFilter);
+    if (value !== '') {
+      debouncedSearchTags(value, selectedTags, newFilter);
+    } else {
+      setOptions([]);
+    }
   };
 
   const onUpdate = (newTags: VideoTag[]) => {
@@ -268,17 +295,28 @@ const StandTagPicker = ({ tagTypes, fieldName, fieldValue, editable, onUpdateFie
               Tags are currently unavailable
             </div>
           )}
-          <TagAutocomplete
-            onTextInputChange={onTextInputChange}
-            options={options}
-            label="Tags"
-            addTag={onTagAdded}
-            loading={isLoading}
-            placeholder={''}
-            disabled={false}
-            value={value}
-            theme={editableUiTheme}
-          />
+          <div style={{ display: 'flex', alignItems: 'flex-start', gap: '8px' }}>
+            <div style={{ flex: 1 }}>
+              <TagAutocomplete
+                onTextInputChange={onTextInputChange}
+                options={options}
+                label="Tags"
+                addTag={onTagAdded}
+                loading={isLoading}
+                placeholder={''}
+                disabled={false}
+                value={value}
+                theme={editableUiTheme}
+              />
+            </div>
+            {filters && filters.length > 0 && (
+              <select onChange={onFilterChange}>
+                {filters.map((filter, index) => (
+                  <option key={filter.displayLabel} value={index}>{filter.displayLabel}</option>
+                ))}
+              </select>
+            )}
+          </div>
           {selectedTags.length > 0 && (
             <div className="stand-tag-table-container">
               <TagTable

--- a/public/video-ui/src/components/FormFields/StandTagPicker.tsx
+++ b/public/video-ui/src/components/FormFields/StandTagPicker.tsx
@@ -187,7 +187,6 @@ const StandTagPicker = ({ tagTypes, allowTags, filters, fieldName, fieldValue, e
   };
   const searchTags = useCallback((inputText: string, selectedTags: VideoTag[], filter?: StandTagPickerFilter) => {
     if (tagManagerUrl) {
-      setIsLoading(true);
       const activeTagTypes = filter?.tagTypes ?? tagTypes;
       const activeSubType = filter?.tagSubType;
       const filterTag = (tag: VideoTag) => (
@@ -221,7 +220,13 @@ const StandTagPicker = ({ tagTypes, allowTags, filters, fieldName, fieldValue, e
       setOptions([]);
       return;
     }
-    debouncedSearchTags(inputText, selectedTags, selectedFilter);
+    if (tagManagerUrl) {
+      if (options.length === 0) {
+        // if there are no options currently shown, we want to show the loading state immediately when user starts typing
+        setIsLoading(true);
+      }
+      debouncedSearchTags(inputText, selectedTags, selectedFilter);
+    }
   };
 
   const onFilterChange = (e: React.ChangeEvent<HTMLSelectElement>) => {

--- a/public/video-ui/src/components/FormFields/StandTagPicker.tsx
+++ b/public/video-ui/src/components/FormFields/StandTagPicker.tsx
@@ -136,10 +136,22 @@ const editableUiTheme = {
   }
 };
 
+const tagPickerContainerStyle = { display: 'flex', alignItems: 'stretch', gap: '8px', marginBottom: '8px' };
+
+const tagPickerDropdownStyle = {
+  border: "1px solid #BDBDBD",
+  backgroundColor: "#393939",
+  color: "inherit",
+  font: "inherit",
+  paddingLeft: "8px",
+  paddingRight: "8px"
+};
+
+
 interface StandTagPickerProps {
   tagTypes: string[];
   allowTags?: (tag: VideoTag) => boolean;
-  filters?: StandTagPickerFilter[];
+  filterOptions?: StandTagPickerFilter[];
 
   // the following properties are passed down from the parent ManagedField
   fieldName: string;
@@ -167,7 +179,7 @@ const isFieldValueChanged = (fieldValue: string[], selectedTags: VideoTag[]) => 
   return false;
 };
 
-const StandTagPicker = ({ tagTypes, allowTags, filters, fieldName, fieldValue, editable, onUpdateField, placeholder, hasError, hasWarning, notification }: StandTagPickerProps) => {
+const StandTagPicker = ({ tagTypes, allowTags, filterOptions: filters, fieldName, fieldValue, editable, onUpdateField, placeholder, hasError, hasWarning, notification }: StandTagPickerProps) => {
 
   const [selectedTags, setSelectedTags] = useState<VideoTag[]>([]);
   const [options, setOptions] = useState<VideoTag[]>([]);
@@ -176,15 +188,6 @@ const StandTagPicker = ({ tagTypes, allowTags, filters, fieldName, fieldValue, e
   const [isLoading, setIsLoading] = useState(false);
   const [tagSearchError, setTagSearchError] = useState<boolean>(false);
   const tagManagerUrl = useSelector((state: {config: AppConfig}) => state.config.tagManagerUrl);
-  const tagPickerContainerStyle = { display: 'flex', alignItems: 'stretch', gap: '8px', marginBottom: '8px' };
-  const tagPickerDropdownStyle = {
-    border: "1px solid #BDBDBD",
-    backgroundColor: "#393939",
-    color: "inherit",
-    font: "inherit",
-    paddingLeft: "8px",
-    paddingRight: "8px"
-  };
   const searchTags = useCallback((inputText: string, selectedTags: VideoTag[], filter?: StandTagPickerFilter) => {
     if (tagManagerUrl) {
       const activeTagTypes = filter?.tagTypes ?? tagTypes;
@@ -230,12 +233,15 @@ const StandTagPicker = ({ tagTypes, allowTags, filters, fieldName, fieldValue, e
   };
 
   const onFilterChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newFilter = filters?.[Number(e.target.value)];
-    setSelectedFilter(newFilter);
-    if (value !== '') {
-      debouncedSearchTags(value, selectedTags, newFilter);
-    } else {
+    const index = parseInt(e.target.value);
+    if (filters && index >= 0 && index < filters.length) {
+      const newFilter = filters[index];
+      setSelectedFilter(newFilter);
       setOptions([]);
+      if (value !== '') {
+        setIsLoading(true);
+        debouncedSearchTags(value, selectedTags, newFilter);
+      }
     }
   };
 
@@ -270,7 +276,7 @@ const StandTagPicker = ({ tagTypes, allowTags, filters, fieldName, fieldValue, e
           });
       }
     }
-  }, [fieldValue, selectedTags,tagManagerUrl]);
+  }, [fieldValue, selectedTags, tagManagerUrl]);
 
   const renderReadOnly = () => {
     if (selectedTags.length === 0) {

--- a/public/video-ui/src/components/FormFields/tags/allowTags.ts
+++ b/public/video-ui/src/components/FormFields/tags/allowTags.ts
@@ -1,0 +1,37 @@
+import TagTypes from "../../../constants/TagTypes";
+import type { StandTagPickerFilter, VideoTag } from "../StandTagPicker";
+
+export const isTagAllowed = (tag: VideoTag): boolean => {
+  if (tag.type === 'Keyword') {
+    return true;
+  }
+  if (tag.type === 'Tracking' && tag.subtype === 'video') {
+    return true;
+  }
+  const allowedTags = ['podcasts', 'tone/news', 'tone/features'];
+  return allowedTags.includes(tag.path);
+};
+
+export const supportedTagFilters: StandTagPickerFilter[] = [
+  {
+    displayLabel: 'All',
+    tagTypes: [TagTypes.keyword, TagTypes.tracking, TagTypes.tone, TagTypes.contentType]
+  },
+  {
+    displayLabel: 'Keywords',
+    tagTypes: [TagTypes.keyword]
+  },
+  {
+    displayLabel: 'Tracking - video',
+    tagTypes: [TagTypes.tracking],
+    tagSubType: 'video'
+  },
+  {
+    displayLabel: 'Tone',
+    tagTypes: [TagTypes.tone]
+  },
+  {
+    displayLabel: 'Content type',
+    tagTypes: [TagTypes.contentType]
+  }
+];

--- a/public/video-ui/src/components/VideoData/VideoData.jsx
+++ b/public/video-ui/src/components/VideoData/VideoData.jsx
@@ -162,7 +162,7 @@ export default class VideoData extends React.Component {
             <StandTagPicker
               tagTypes={[TagTypes.keyword, TagTypes.tracking, TagTypes.tone]}
               allowTags={isTagAllowed}
-              filters={supportedTagFilters} />
+              filterOptions={supportedTagFilters} />
           </ManagedField>
         }
         {

--- a/public/video-ui/src/components/VideoData/VideoData.jsx
+++ b/public/video-ui/src/components/VideoData/VideoData.jsx
@@ -8,6 +8,7 @@ import SelectBox from '../FormFields/SelectBox';
 import DatePicker from '../FormFields/DatePicker';
 import TagPicker from '../FormFields/TagPicker';
 import StandTagPicker from '../FormFields/StandTagPicker';
+import { isTagAllowed, supportedTagFilters } from '../FormFields/tags/allowTags';
 import TagTypes from '../../constants/TagTypes';
 import { fieldLengths } from '../../constants/videoEditValidation';
 import { videoCategories } from '../../constants/videoCategories';
@@ -158,7 +159,10 @@ export default class VideoData extends React.Component {
             isRequired={false}
             inputPlaceholder="Search tags (type '*' to show all)"
           >
-            <StandTagPicker tagTypes={[TagTypes.keyword]} />
+            <StandTagPicker
+              tagTypes={[TagTypes.keyword, TagTypes.tracking, TagTypes.tone]}
+              allowTags={isTagAllowed}
+              filters={supportedTagFilters} />
           </ManagedField>
         }
         {

--- a/public/video-ui/src/components/VideoData/VideoData.jsx
+++ b/public/video-ui/src/components/VideoData/VideoData.jsx
@@ -159,8 +159,9 @@ export default class VideoData extends React.Component {
             isRequired={false}
             inputPlaceholder="Search tags (type '*' to show all)"
           >
+            {/* tagTypes is not really used as we supply filterOptions */}
             <StandTagPicker
-              tagTypes={[TagTypes.keyword, TagTypes.tracking, TagTypes.tone]}
+              tagTypes={[]}
               allowTags={isTagAllowed}
               filterOptions={supportedTagFilters} />
           </ManagedField>

--- a/public/video-ui/src/constants/TagTypes.ts
+++ b/public/video-ui/src/constants/TagTypes.ts
@@ -26,4 +26,8 @@ export default class TagTypes {
   static get commercial() {
     return 'paidContent';
   }
+
+  static get contentType() {
+    return 'contenttype';
+  }
 }

--- a/public/video-ui/src/services/tagmanager.ts
+++ b/public/video-ui/src/services/tagmanager.ts
@@ -14,6 +14,7 @@ export type Tag = {
   externalName: string,
   deprecated: boolean,
   section: Section,
+  subType?: string
 };
 
 export type TagManagerItem = {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This pull request follows up our work on supporting tags on atoms in #1548, extending the tag picker to allow more types of tags to apply to video atoms.

It allows the following tags to be applied to video atoms:
- all keyword tags
- all tracking/video tags
- two tone tags: `tone/news` and `tone/features`
- one content type tag: `podcasts`

Specifically it makes the following changes:
- query tag manager API with "keyword", "tracking", "tone" and "contenttype" types by default 
- add a filter function to refine the search result
- add a dropdown list in the tag picker to allow searching in one type only 

## How has this change been tested?

To test the change, we should manually append the query parameter ?supportTagging to the end of the URL.

1. Create a new Non-Youtube video. 
2. Click "Edit" on the Furniture tab. We should see the tag picker field under "Tags" and it has a dropdown box to select a particular tag type for searching. It should have the options "keyword", "tracking-video", "tone" and "contenttype".
3. Select tags from the tag picker. We could limit the type of tags to search by the tag picker. We should see the selected tags with their type in the table below the tag picker.
4. Click "Save". We should see the selected tag paths in the data model returned from the backend API (URL: https://video.local.dev-gutools.co.uk/api/atoms/<atom id>).
5. Open the video in a separate tab. We should see the selected tags correctly.

## How can we measure success?

It makes progress with improving data analysis on video content.

## Have we considered potential risks?

The tags field is currently behind a query parameter.

The UI change of this PR should not be visible to users. The risk should be low.

## Images

| Screenshots |
| --- |
| Tag picker with no selected tags |
| <img width="725" height="128" alt="Screenshot 2026-05-20 at 14 36 57" src="https://github.com/user-attachments/assets/b5a7ced0-c693-4306-b819-72448ff2ec00" /> |
| Filter by tag type |
| <img width="723" height="220" alt="Screenshot 2026-05-20 at 14 37 07" src="https://github.com/user-attachments/assets/c1464d7a-b7b6-4e0a-b61b-158d9532df6c" /> |
| With selected tags |
| <img width="723" height="344" alt="Screenshot 2026-05-20 at 12 28 07" src="https://github.com/user-attachments/assets/d50c99f5-1ef2-40e6-879d-3cc8b1887aa1" /> |
| In non-edit mode |
| <img width="718" height="250" alt="Screenshot 2026-05-20 at 14 37 26" src="https://github.com/user-attachments/assets/8bab7491-8aa5-47d7-8119-91ac2b6d94ce" /> |

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [X] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214904384250550