### PR TITLE
try increasing youtube uploader memory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -216,7 +216,8 @@ lazy val uploader = (project in file("uploader"))
           "Checks to see if a chunk of video has been uploaded to S3"
       ),
       "UploadChunkToYouTube" -> LambdaConfig(
-        description = "Uploads a chunk of video to YouTube"
+        description = "Uploads a chunk of video to YouTube",
+        memory = 8192,
       ),
       "MultipartCopyChunkInS3" -> LambdaConfig(
         description =

--- a/build.sbt
+++ b/build.sbt
@@ -214,7 +214,8 @@ lazy val uploader = (project in file("uploader"))
           "Checks to see if a chunk of video has been uploaded to S3"
       ),
       "UploadChunkToYouTube" -> LambdaConfig(
-        description = "Uploads a chunk of video to YouTube"
+        description = "Uploads a chunk of video to YouTube",
+        memory = 8192,
       ),
       "MultipartCopyChunkInS3" -> LambdaConfig(
         description =

--- a/project/StateMachine.scala
+++ b/project/StateMachine.scala
@@ -2,7 +2,11 @@ import sbt._
 import sbt.Keys._
 
 object StateMachine {
-  case class LambdaConfig(description: String, timeout: Int = 300)
+  case class LambdaConfig(
+    description: String,
+    timeout: Int = 300,
+    memory: Int = 2048,
+  )
 
   val lambdas = settingKey[Map[String, LambdaConfig]]("The lambdas to include in the state machine")
 
@@ -12,11 +16,12 @@ object StateMachine {
     val stateMachine = IO.read((Compile / resourceDirectory).value / "state-machine.json")
 
     val withLambdas = (Compile / lambdas).value.foldLeft(template) {
-      case (tmpl, (name, LambdaConfig(description, timeout))) =>
+      case (tmpl, (name, LambdaConfig(description, timeout, memory))) =>
         val instance = lambdaTemplate
           .replace("{{name}}", name)
           .replace("{{description}}", description)
           .replace("{{timeout}}", timeout.toString)
+          .replace("{{memory}}", memory.toString)
 
         replace(s"{{$name}}", instance, tmpl)
     }

--- a/uploader/src/main/resources/lambda-template.yaml
+++ b/uploader/src/main/resources/lambda-template.yaml
@@ -24,7 +24,7 @@
           - { Stage: !Ref Stage }
         ATOM_TABLE_NAME: !Ref 'MediaAtomTable'
         MEDIA_CONVERT_ROLE: !GetAtt MediaConvertRole.Arn
-    MemorySize: 2048
+    MemorySize: {{memory}}
 # Architecture specified to match version of ffmpeg used to inject subtitles into mp4
     Architectures:
       - "x86_64"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Try the straightforward thing to try speeding up the lambdas - increase the memory of the yt upload lambda. Going 2GB to 8GB sped up the upload of a 3.5GB vid from 8:30 to 5:55. A large increase for a comparatively small speedup, but every little helps.

## How has this change been tested?

Ran on CODE, an unscientific test showed it reduce the overall upload time for a 3.5GB vid from 8m30s to 5m55s. This may or may not hold (a subsequent test which increased the memory further then took 7m30s to run, which is not what we'd have expected), but feels a fairly safe way to increase upload speed a bit.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
