### PR TITLE
try upgrading atom-maker lib to new v12 with updated reindexing logic

### DIFF
--- a/app/controllers/Healthcheck.scala
+++ b/app/controllers/Healthcheck.scala
@@ -1,8 +1,8 @@
 package controllers
 
-import com.amazonaws.util.EC2MetadataUtils
 import com.gu.media.aws.{AwsAccess, KinesisAccess}
-import play.api.mvc.{Action, BaseController, ControllerComponents}
+import play.api.mvc.{BaseController, ControllerComponents}
+import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils
 
 class Healthcheck(
     val kinesis: AwsAccess with KinesisAccess,

--- a/app/data/DataStores.scala
+++ b/app/data/DataStores.scala
@@ -2,6 +2,7 @@ package data
 
 import com.gu.atom.data._
 import com.gu.atom.publish._
+import com.gu.atom.reindex._
 import com.gu.contentatom.thrift.Atom
 import com.gu.media.aws.SNSAccess
 import com.gu.media.iconik.{
@@ -65,16 +66,30 @@ class DataStores(aws: AWSConfig with SNSAccess, capi: CapiAccess) {
       )
   }
 
-  val reindexPreview: PreviewAtomReindexer =
+  val previewReindexStore = new DynamoReindexDataStoreV2(
+    aws.dynamoDbSdkV2,
+    aws.previewReindexTableName
+  )
+
+  val publishedReindexStore = new DynamoReindexDataStoreV2(
+    aws.dynamoDbSdkV2,
+    aws.publishedReindexTableName
+  )
+
+  val previewReindexer: PreviewAtomReindexer =
     new PreviewKinesisAtomReindexerV2(
-      aws.previewKinesisReindexStreamName,
-      aws.crossAccountKinesisClient
+      streamName = aws.previewKinesisReindexStreamName,
+      kinesis = aws.crossAccountKinesisClient,
+      atomDataStore = preview,
+      reindexDataStore = previewReindexStore
     )
 
-  val reindexPublished: PublishedKinesisAtomReindexerV2 =
+  val publishedReindexer: PublishedKinesisAtomReindexerV2 =
     new PublishedKinesisAtomReindexerV2(
-      aws.publishedKinesisReindexStreamName,
-      aws.crossAccountKinesisClient
+      streamName = aws.publishedKinesisReindexStreamName,
+      kinesis = aws.crossAccountKinesisClient,
+      atomDataStore = published,
+      reindexDataStore = publishedReindexStore
     )
 
   val plutoCommissionStore: PlutoCommissionDataStore =

--- a/app/di.scala
+++ b/app/di.scala
@@ -216,13 +216,11 @@ class MediaAtomMaker(context: Context)
   private def buildReindexer() = {
     // pass the parameters manually since the reindexer is part of the atom-maker lib
     new ReindexController(
-      stores.preview,
-      stores.published,
-      stores.reindexPreview,
-      stores.reindexPublished,
-      configuration,
-      controllerComponents,
-      actorSystem
+      previewReindexer = stores.previewReindexer,
+      publishedReindexer = stores.publishedReindexer,
+      config = configuration,
+      controllerComponents = controllerComponents,
+      system = actorSystem
     )
 
   }

--- a/app/util/AWS.scala
+++ b/app/util/AWS.scala
@@ -9,6 +9,7 @@ import com.typesafe.config.Config
 import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils
 
 import scala.jdk.CollectionConverters._
+import scala.util.Try
 
 class AWSConfig(
     override val config: Config,
@@ -51,21 +52,25 @@ class AWSConfig(
   final override def region = AwsAccess.regionFrom(this)
 
   final override def readTag(tagName: String) = {
-    val tagsResult = ec2Client.describeTags(
-      DescribeTagsRequest
-        .builder()
-        .filters(
-          Filter.builder().name("resource-type").values("instance").build(),
-          Filter
-            .builder()
-            .name("resource-id")
-            .values(EC2MetadataUtils.getInstanceId)
-            .build(),
-          Filter.builder().name("key").values(tagName).build()
-        )
-        .build()
-    )
+    val tagsResult = Try {
+      ec2Client.describeTags(
+        DescribeTagsRequest
+          .builder()
+          .filters(
+            Filter.builder().name("resource-type").values("instance").build(),
+            Filter
+              .builder()
+              .name("resource-id")
+              .values(EC2MetadataUtils.getInstanceId)
+              .build(),
+            Filter.builder().name("key").values(tagName).build()
+          )
+          .build()
+      )
+    }
 
-    tagsResult.tags().asScala.find(_.key == tagName).map(_.value)
+    tagsResult.toOption.flatMap(
+      _.tags().asScala.find(_.key == tagName).map(_.value)
+    )
   }
 }

--- a/app/util/AWS.scala
+++ b/app/util/AWS.scala
@@ -2,11 +2,11 @@ package util
 
 import software.amazon.awssdk.services.ec2.Ec2Client
 import software.amazon.awssdk.services.ec2.model.{DescribeTagsRequest, Filter}
-import com.amazonaws.util.EC2MetadataUtils
 import com.gu.media.Settings
 import com.gu.media.aws._
-import com.gu.media.logging.{Logging}
+import com.gu.media.logging.Logging
 import com.typesafe.config.Config
+import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils
 
 import scala.jdk.CollectionConverters._
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import scala.sys.process.*
 val scroogeVersion = "4.12.0"
 val awsV2Version = "2.44.4"
 val pandaVersion = "19.0.0"
-val atomMakerVersion = "11.0.0"
+val atomMakerVersion = "12.0.0-PREVIEW.anpageable-cancellable-atom-reindex.2026-05-29T1652.35adac95"
 val typesafeConfigVersion =
   "1.4.0" // to match what we get from Play transitively
 val scanamoVersion = "1.0.0-M28"

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import scala.sys.process.*
 val scroogeVersion = "4.12.0"
 val awsV2Version = "2.44.4"
 val pandaVersion = "19.0.0"
-val atomMakerVersion = "12.0.0-PREVIEW.anpageable-cancellable-atom-reindex.2026-05-29T1652.35adac95"
+val atomMakerVersion = "12.0.0"
 val typesafeConfigVersion =
   "1.4.0" // to match what we get from Play transitively
 val scanamoVersion = "1.0.0-M28"

--- a/cloudformation/media-atom-maker-dev.yml
+++ b/cloudformation/media-atom-maker-dev.yml
@@ -119,6 +119,34 @@ Resources:
         ReadCapacityUnits: "10"
         WriteCapacityUnits: "5"
 
+  PreviewReindexDynamoTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: jobStatus
+          AttributeType: S
+      KeySchema:
+        - AttributeName: jobStatus
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      Tags:
+        - Key: devx-backup-enabled
+          Value: false
+
+  PublishedReindexDynamoTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: jobStatus
+          AttributeType: S
+      KeySchema:
+        - AttributeName: jobStatus
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      Tags:
+        - Key: devx-backup-enabled
+          Value: false
+
   PlutoProjectDynamoTable:
     Type: "AWS::DynamoDB::Table"
     Properties:

--- a/common/src/main/scala/com/gu/media/aws/DynamoAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/DynamoAccess.scala
@@ -18,6 +18,13 @@ trait DynamoAccess { this: Settings with AwsAccess =>
     "aws.dynamo.publishedTableName"
   )
 
+  lazy val previewReindexTableName: String = getMandatoryString(
+    "aws.dynamo.previewReindexTableName"
+  )
+  lazy val publishedReindexTableName: String = getMandatoryString(
+    "aws.dynamo.publishedReindexTableName"
+  )
+
   private def getTableName(itemType: String, stage: String): String =
     s"$app-$stage-$itemType-table"
 

--- a/common/src/main/scala/com/gu/media/aws/SNSAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/SNSAccess.scala
@@ -1,6 +1,5 @@
 package com.gu.media.aws
 
-import com.amazonaws.regions.Regions
 import software.amazon.awssdk.services.sns.SnsClient
 import com.gu.media.Settings
 

--- a/common/src/main/scala/com/gu/media/model/PlutoIntegrationData.scala
+++ b/common/src/main/scala/com/gu/media/model/PlutoIntegrationData.scala
@@ -1,6 +1,5 @@
 package com.gu.media.model
 
-import com.amazonaws.services.s3.model.PutObjectRequest
 import com.gu.media.aws.{AwsAccess, UploadAccess}
 import com.gu.media.upload.CompleteUploadKey
 import com.gu.ai.x.play.json.Jsonx
@@ -43,29 +42,6 @@ object AtomAssignedProjectMessage {
       plutoData.projectId.get,
       atom.title,
       email
-    )
-  }
-}
-
-case class PacFileMessage(
-    `type`: String,
-    atomId: String,
-    s3Bucket: String,
-    s3Path: String
-) extends PlutoIntegrationMessage {
-  override def partitionKey: String = s3Path
-}
-
-object PacFileMessage {
-  implicit val format: Format[PacFileMessage] =
-    Jsonx.formatCaseClass[PacFileMessage]
-
-  def build(atom: MediaAtom, putRequest: PutObjectRequest): PacFileMessage = {
-    PacFileMessage(
-      "pac-file-upload",
-      atom.id,
-      putRequest.getBucketName,
-      putRequest.getKey
     )
   }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -57,6 +57,8 @@ POST           /reindex-preview                                 com.gu.atom.play
 POST           /reindex-publish                                 com.gu.atom.play.ReindexController.newPublishedReindexJob()
 GET            /reindex-preview                                 com.gu.atom.play.ReindexController.previewReindexJobStatus()
 GET            /reindex-publish                                 com.gu.atom.play.ReindexController.publishedReindexJobStatus()
+DELETE         /reindex-preview                                 com.gu.atom.play.ReindexController.cancelPreviewReindexJob()
+DELETE         /reindex-publish                                 com.gu.atom.play.ReindexController.cancelPublishedReindexJob()
 
 #video specific react frontend
 GET            /                                                controllers.VideoUIApp.index(id = "")

--- a/expirer/src/test/scala/com/gu/media/ExpirerLambdaTest.scala
+++ b/expirer/src/test/scala/com/gu/media/ExpirerLambdaTest.scala
@@ -1,7 +1,6 @@
 package com.gu.media
 
 import software.amazon.awssdk.services.ses.SesClient
-import com.amazonaws.util.IOUtils
 import com.gu.contentatom.thrift.atom.media.PrivacyStatus
 import com.gu.media.expirer.ExpirerLambda
 import com.gu.media.model.{AdSettings, VideoUpdateError}
@@ -9,6 +8,8 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.must.Matchers
 import play.api.libs.json.{JsValue, Json}
 import org.mockito.MockitoSugar.{mock, when}
+
+import java.nio.charset.StandardCharsets
 
 class ExpirerLambdaTest extends AnyFunSuite with Matchers {
   test("Make YouTube assets private") {
@@ -94,6 +95,6 @@ class ExpirerLambdaTest extends AnyFunSuite with Matchers {
 
   private def capiResult(filename: String) = {
     val resource = getClass.getResourceAsStream('/' + filename)
-    IOUtils.toString(resource)
+    new String(resource.readAllBytes(), StandardCharsets.UTF_8)
   }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates atom-workshop to v12. Implement the updated atom reindexing classes (https://github.com/guardian/atom-maker/pull/146) which reindex atoms in batches, so we no longer need to fit the entire atom database into memory all at once.

## How has this change been tested?

Tested on CODE 

## How can we measure success?

With a successful reindex of atoms.
