### PR TITLE
Add failing test for Lambda warmup calculation

### DIFF
--- a/common/src/test/scala/com/gu/media/util/JobCompletedMetricsTest.scala
+++ b/common/src/test/scala/com/gu/media/util/JobCompletedMetricsTest.scala
@@ -1,0 +1,36 @@
+package com.gu.media.util
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers
+import software.amazon.awssdk.services.sfn.model.{
+  HistoryEvent,
+  HistoryEventType
+}
+
+import java.time.Instant
+
+class JobCompletedMetricsTest extends AnyFunSuite with Matchers {
+
+  val metrics = new JobCompletedMetrics(null)
+
+  def event(
+      id: Long,
+      eventType: HistoryEventType,
+      epochMilli: Long
+  ): HistoryEvent =
+    HistoryEvent
+      .builder()
+      .id(id)
+      .`type`(eventType)
+      .timestamp(Instant.ofEpochMilli(epochMilli))
+      .build()
+
+  test("computeDurations calculates lambda warm-up duration") {
+    val scheduled = event(1L, HistoryEventType.LAMBDA_FUNCTION_SCHEDULED, 1000L)
+    val started = event(2L, HistoryEventType.LAMBDA_FUNCTION_STARTED, 1500L)
+
+    val result = metrics.computeDurations(List(scheduled, started))
+
+    result must contain(metrics.LAMBA_WARM_UP -> 500L)
+  }
+}


### PR DESCRIPTION
If this test case captures the intended behaviour then it reveals a bug in the lambda warm up calculation, as it's currently failing.