### PR TITLE
Enable video atom tagging

### DIFF
--- a/public/video-ui/src/components/VideoData/VideoData.jsx
+++ b/public/video-ui/src/components/VideoData/VideoData.jsx
@@ -18,7 +18,6 @@ import FieldNotification from "../../constants/FieldNotification";
 import { trailTextConfig, standfirstConfig } from "../FormFields/richtext/config";
 import { ExpireNowComponent } from "../FormFields/ExpireNow";
 import {addOrDropBundlingTags} from "../../services/KeywordsApi";
-import { isTaggingSupported } from '../../util/config';
 
 export default class VideoData extends React.Component {
   static propTypes = {
@@ -150,7 +149,6 @@ export default class VideoData extends React.Component {
             </ManagedField>
         }
         {
-          isTaggingSupported() &&
           <ManagedField
             fieldLocation="atomTagIds"
             name="Tags"

--- a/public/video-ui/src/constants/queryParams.js
+++ b/public/video-ui/src/constants/queryParams.js
@@ -1,3 +1,2 @@
 export const QUERY_PARAM_shouldUseCreatedDateForSort = "shouldUseCreatedDateForSort";
 export const QUERY_PARAM_videoPlayerFormatFilter = "videoPlayerFormat";
-export const QUERY_PARAM_supportTagging = "supportTagging";

--- a/public/video-ui/src/util/config.ts
+++ b/public/video-ui/src/util/config.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { QUERY_PARAM_supportTagging } from '../constants/queryParams';
 
 const PresenceSchema = z.object({
   domain: z.string(),
@@ -102,9 +101,4 @@ export function getUserTelemetryClient(stage: string): string {
     default:
       return 'https://user-telemetry.local.dev-gutools.co.uk';
   }
-}
-
-export function isTaggingSupported(): boolean {
-  const url = new URL(window.location.href);
-  return url.searchParams.has(QUERY_PARAM_supportTagging);
 }

--- a/public/video-ui/src/util/videoPublishCheck.ts
+++ b/public/video-ui/src/util/videoPublishCheck.ts
@@ -1,12 +1,9 @@
 import { Video } from "../services/VideosApi";
-import { isTaggingSupported } from "./config";
 
 export const checkVideoReadyToPublish = (video: Video): string[] => {
-  if (isTaggingSupported()) {
-    if (video.videoPlayerFormat === 'Default') {
-      if (video.atomTagIds && video.atomTagIds.length === 0) {
-        return ['Add at least one tag before publishing non-youtube video'];
-      }
+  if (video.videoPlayerFormat === 'Default') {
+    if (video.atomTagIds && video.atomTagIds.length === 0) {
+      return ['Add at least one tag before publishing non-youtube video'];
     }
   }
   return [];


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We added support for tagging video atoms behind a feature switch in #1548 and #1561.

This pull request enables this function for all users and removes the feature switch.

## How has this change been tested?

Deploy to CODE and run MAM:
- we can add and manage tags in furniture.
- tags are required for publishing Non-Youtube videos.
- loop can be published without tags.
- the tags can come through to the CAPI response.