### PR TITLE
Extract the stepfunciton id from the execution arn

### DIFF
--- a/common/src/main/scala/com/gu/media/util/JobCompletedMetrics.scala
+++ b/common/src/main/scala/com/gu/media/util/JobCompletedMetrics.scala
@@ -137,18 +137,27 @@ class JobCompletedMetrics(stepFunctionsClient: SfnClient) {
     getAllHistory(None, Nil)
   }
 
-  def getMetricsForJobRun(event: StepFunctionEvent) = {
-    val runTime = getRunTime(event.detail)
-    val historyEvents = getAllHistoryEvents(event.detail.executionArn)
+  def getStepFunctionId(executionArn: String) = {
+    executionArn
+      .split(":")
+      .toList
+      .last
+  }
+  def getMetricsForJobRun(detail: StepFunctionDetail) = {
+    val executionArn = detail.executionArn
+    val runTime = getRunTime(detail)
+    val historyEvents = getAllHistoryEvents(executionArn)
     val metricsFromHistory = getMetricsFromHistory(historyEvents, runTime)
-    val uploadOpt = Json.parse(event.detail.input).validate[Upload].asOpt
+    val uploadOpt = Json.parse(detail.input).validate[Upload].asOpt
     val metricsFromUploadData =
       uploadOpt.fold(Map[String, TagValue]())(getMetricsFromUpload)
-    val (atomId, version) = extractAtomIdAndVersion(event.id)
+
+    val stepFunctionId = getStepFunctionId(executionArn)
+    val (atomId, version) = extractAtomIdAndVersion(stepFunctionId)
 
     Map(
       "jobTime" -> TagLong(runTime),
-      "stepFunctionId" -> TagString(event.id),
+      "stepFunctionId" -> TagString(stepFunctionId),
       "atomId" -> TagString(atomId),
       "version" -> TagString(version)
     ) ++ metricsFromHistory ++ metricsFromUploadData

--- a/uploader/src/main/scala/com/gu/media/upload/JobMetricsPublisher.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/JobMetricsPublisher.scala
@@ -24,7 +24,7 @@ class JobMetricsPublisher
     val secretArn = sys.env("HMAC_SECRET_ARN")
     val telemetry = new Telemetry(Stage(stage), secretArn, client)
     val sfMetrics = new JobCompletedMetrics(stepFunctionsClient)
-    val metrics = sfMetrics.getMetricsForJobRun(input)
+    val metrics = sfMetrics.getMetricsForJobRun(input.detail)
     log.info("Sending telemetry event")
     telemetry.sendTelemetryEvent("VIDEO_UPLOAD_COMPLETE", metrics)
     log.info("Completed jobs metrics publisher lambda")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This changes the way we extract the stepFunctionId. It turns out the data we get from the event bridge invocation is a completeEvent, which has it's own id, and it's not the id of the running execution:

### Id of the complete event that is coming through

<img width="508" height="410" alt="image" src="https://github.com/user-attachments/assets/2a36a92b-b739-4f01-abf4-00b4f801aa54" />

### Id of the stepfunction

<img width="497" height="502" alt="image" src="https://github.com/user-attachments/assets/2ca0c3bc-d76f-40d8-aeb1-9b8bf620b9e5" />



## How has this change been tested?

Tested in CODE and the lambda executes successfully. 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
