### PR TITLE
Require users to have permission to publish default non-youtube videos

### DIFF
--- a/common/src/main/scala/com/gu/media/Permissions.scala
+++ b/common/src/main/scala/com/gu/media/Permissions.scala
@@ -11,7 +11,8 @@ import com.gu.permissions.PermissionDefinition
 case class Permissions(
     deleteAtom: Boolean = false,
     setVideosOnAllChannelsPublic: Boolean = false,
-    pinboard: Boolean = false
+    pinboard: Boolean = false,
+    addSelfHostedAsset: Boolean = false
 )
 object Permissions {
   implicit val format: Format[Permissions] = Jsonx.formatCaseClass[Permissions]
@@ -21,6 +22,8 @@ object Permissions {
   val deleteAtom = PermissionDefinition("delete_atom", app)
   val setVideosOnAllChannelsPublic =
     PermissionDefinition("set_videos_on_all_channels_public", app)
+  val addSelfHostedAsset =
+    PermissionDefinition("add_self_hosted_asset", app)
   val pinboard = PermissionDefinition("pinboard", "pinboard")
 }
 
@@ -39,7 +42,8 @@ class MediaAtomMakerPermissionsProvider(
     deleteAtom = hasPermission(deleteAtom, user),
     setVideosOnAllChannelsPublic =
       hasPermission(setVideosOnAllChannelsPublic, user),
-    pinboard = hasPermission(pinboard, user)
+    pinboard = hasPermission(pinboard, user),
+    addSelfHostedAsset = hasPermission(addSelfHostedAsset, user)
   )
 
   def getStatusPermissions(user: PandaUser): Permissions =

--- a/public/video-ui/src/components/Create.tsx
+++ b/public/video-ui/src/components/Create.tsx
@@ -12,13 +12,19 @@ import Youtube from "../../images/youtube.svg?react";
 import Cinemagraph from "../../images/cinemagraph.svg?react";
 import NonYoutube from "../../images/nonyoutube.svg?react";
 import {fieldLengths} from "../constants/videoEditValidation";
+import { getStore } from '../util/storeAccessor';
 
 export default class Create extends React.Component {
   props: React.PropsWithChildren<{
-    createVideo: (video: VideoWithoutId) => (dispatch: AppDispatch) => Promise<void>
-    inModal: boolean
+    createVideo: (video: VideoWithoutId) => (dispatch: AppDispatch) => Promise<void>;
+    inModal: boolean;
     closeCreateModal?: () => void;
   }>;
+
+  // this permission is not validated on the server-side because we are only hiding the option
+  // to discourage use of this feature
+  permissions = getStore().getState().config.permissions;
+  selfHostedAllowed = this.permissions.addSelfHostedAsset;
 
   state: { title: string; videoCreateOption: VideoCreateOption } = {
     title: "",
@@ -156,7 +162,8 @@ export default class Create extends React.Component {
                   {videoCreateOptions.offPlatform.map((videoCreateOptionDetails) => (
                     this.renderVideoCreateOption(videoCreateOptionDetails)
                   ))}
-                  {videoCreateOptions.selfHosted.map((videoCreateOptionDetails) => (
+                  {videoCreateOptions.selfHosted.filter((videoCreateOptionDetails) => videoCreateOptionDetails.id !== 'Default' || this.selfHostedAllowed)
+                    .map((videoCreateOptionDetails) => (
                     this.renderVideoCreateOption(videoCreateOptionDetails)
                   ))}
               </div>

--- a/public/video-ui/src/components/Create.tsx
+++ b/public/video-ui/src/components/Create.tsx
@@ -58,7 +58,7 @@ export default class Create extends React.Component {
     Default: <NonYoutube/>
   };
 
-  renderVideoCreateOption(videoCreateOptionDetails: VideoCreateOptionDetails) {
+  renderVideoCreateOption(videoCreateOptionDetails: VideoCreateOptionDetails, disabled: boolean = false) {
     const isSelected = this.state.videoCreateOption === videoCreateOptionDetails.id;
     const inputRef = createRef<HTMLInputElement>();
 
@@ -67,12 +67,16 @@ export default class Create extends React.Component {
         key={videoCreateOptionDetails.id}
         className={
           "create-form__option " +
-          (isSelected ? 'create-form__option--selected ' : '')
+          (isSelected ? 'create-form__option--selected ' : '') +
+          (disabled ? 'create-form__option--disabled ' : '')
         }
         onClick={() => {
-          this.setState({ videoCreateOption: videoCreateOptionDetails.id });
-          inputRef?.current?.focus();
-        }}>
+          if (!disabled) {
+            this.setState({ videoCreateOption: videoCreateOptionDetails.id });
+            inputRef?.current?.focus();
+          }
+        }}
+        >
         <div className="create-form__option-controls">
           <div className="create-form__option-radio-summary">
             <div className="create-form__option-radio-label-and-icon">
@@ -88,9 +92,10 @@ export default class Create extends React.Component {
             </div>
             <div className="create-form__option-radio-description">
               {videoCreateOptionDetails.description}
+              { disabled ? '. Contact Central Production if you need to use this video format.' : ''}
             </div>
           </div>
-          <input
+          {!disabled && <input
             type="radio"
             className="create-form__option-radio"
             id={videoCreateOptionDetails.id}
@@ -99,7 +104,7 @@ export default class Create extends React.Component {
             checked={isSelected}
             onChange={() => this.setState({ videoCreateOption: videoCreateOptionDetails.id })}
             ref={inputRef}
-          />
+          />}
         </div>
         {
           <div className={
@@ -162,9 +167,8 @@ export default class Create extends React.Component {
                   {videoCreateOptions.offPlatform.map((videoCreateOptionDetails) => (
                     this.renderVideoCreateOption(videoCreateOptionDetails)
                   ))}
-                  {videoCreateOptions.selfHosted.filter((videoCreateOptionDetails) => videoCreateOptionDetails.id !== 'Default' || this.selfHostedAllowed)
-                    .map((videoCreateOptionDetails) => (
-                    this.renderVideoCreateOption(videoCreateOptionDetails)
+                  {videoCreateOptions.selfHosted.map((videoCreateOptionDetails) => (
+                    this.renderVideoCreateOption(videoCreateOptionDetails, videoCreateOptionDetails.id === 'Default' && !this.selfHostedAllowed)
                   ))}
               </div>
             </div>

--- a/public/video-ui/src/util/config.ts
+++ b/public/video-ui/src/util/config.ts
@@ -10,7 +10,8 @@ const PresenceSchema = z.object({
 const PermissionsSchema = z.object({
   deleteAtom: z.boolean().default(false),
   setVideosOnAllChannelsPublic: z.boolean().default(false),
-  pinboard: z.boolean().default(false)
+  pinboard: z.boolean().default(false),
+  addSelfHostedAsset: z.boolean().default(false)
 });
 
 export const ClientConfigSchema = z.object({
@@ -76,7 +77,8 @@ export function getAppConfig(): ConfigState {
       permissions: {
         deleteAtom: false,
         setVideosOnAllChannelsPublic: false,
-        pinboard: false
+        pinboard: false,
+        addSelfHostedAsset: false
       },
       minDurationForAds: 0,
       isTrainingMode: false,

--- a/public/video-ui/src/util/setupStore.ts
+++ b/public/video-ui/src/util/setupStore.ts
@@ -53,5 +53,6 @@ export function setupStore() {
   });
 }
 
-export type RootState = ReturnType<ReturnType<typeof setupStore>['getState']>;
-export type AppDispatch = ReturnType<typeof setupStore>['dispatch'];
+export type Store = ReturnType<typeof setupStore>;
+export type RootState = ReturnType<Store['getState']>;
+export type AppDispatch = Store['dispatch'];

--- a/public/video-ui/src/util/storeAccessor.js
+++ b/public/video-ui/src/util/storeAccessor.js
@@ -1,9 +1,0 @@
-let savedStore;
-
-export function setStore(store) {
-  savedStore = store;
-}
-
-export function getStore() {
-  return savedStore;
-}

--- a/public/video-ui/src/util/storeAccessor.ts
+++ b/public/video-ui/src/util/storeAccessor.ts
@@ -1,0 +1,11 @@
+import { Store } from "./setupStore";
+
+let savedStore: Store;
+
+export function setStore(store: Store) {
+  savedStore = store;
+}
+
+export function getStore(): Store {
+  return savedStore;
+}

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -469,6 +469,11 @@
     color: $cYellow;
     height: auto;
   }
+
+   &.create-form__option--disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## What does this change?

The non-youtube default player should only be used in limited circumstances when Youtube is not suitable. While we work out why the non-youtube player is being used more than we expect, we will limit the number of people who can use this feature by putting it behind a permission.

Instead of just hiding the option, the option is still displayed but with a note saying to contact Central Production if you need to use this feature. CP will be able to assess the need and if appropriate give the user the necessary permission.

Since this change is merely to discourage use of a generally safe feature, this PR does not actually enforce this limitation server side.

## How has this change been tested?

Tested locally

## How can we measure success?

Fewer non-Youtube videos are created.

## Have we considered potential risks?

People who need to create these videos will be unable to. This is mitigated by referring them to central production.

## Images
<img width="1866" height="746" alt="Screenshot 2026-06-10 at 10 14 20" src="https://github.com/user-attachments/assets/8fa1d359-febc-4236-a0df-431a24389af7" />


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
