### PR TITLE
upgrade aws-lambda-java-events to latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ val scalaXmlVersion = "2.2.0"
 val scalaCheckVersion = "1.18.0" // to match ScalaTest version
 
 val awsLambdaCoreVersion = "1.1.0"
-val awsLambdaEventsVersion = "1.3.0"
+val awsLambdaEventsVersion = "3.16.1"
 
 val logbackClassicVersion = "1.5.18"
 val logstashLogbackEncoderVersion = "4.8"


### PR DESCRIPTION
to get updated transitive dependencies

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Upgrades aws-lambda-java-events to latest. The older version had transitive dependencies on old versions of various modules of the v1 AWS Java SDK. The new version does not (or depends on v2), removing at least one vulnerable dependency. The aws-lambda-java-events module is only used for specifying the input types for the lambda functions, so as long as the compile succeeds we should be confident that all is working as expected.

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
