### PR TITLE
Upgrade AWS SDK to 2.46.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import scala.collection.immutable.Seq
 import scala.sys.process.*
 
 val scroogeVersion = "4.12.0"
-val awsV2Version = "2.44.4"
+val awsV2Version = "2.46.8"
 val pandaVersion = "19.0.0"
 val atomMakerVersion = "12.0.0"
 val typesafeConfigVersion =

--- a/common/src/main/scala/com/gu/media/aws/AwsV2Util.scala
+++ b/common/src/main/scala/com/gu/media/aws/AwsV2Util.scala
@@ -5,7 +5,7 @@ import software.amazon.awssdk.awscore.client.builder.{
   AwsClientBuilder,
   AwsSyncClientBuilder
 }
-import software.amazon.awssdk.http.apache.ApacheHttpClient
+import software.amazon.awssdk.http.apache5.Apache5HttpClient
 import software.amazon.awssdk.regions.Region
 
 object AwsV2Util {
@@ -14,7 +14,7 @@ object AwsV2Util {
       creds: AwsCredentialsProvider,
       region: Region
   ): T = builder
-    .httpClientBuilder(ApacheHttpClient.builder())
+    .httpClientBuilder(Apache5HttpClient.builder())
     .credentialsProvider(creds)
     .region(region)
     .build()


### PR DESCRIPTION


<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Includes transitive dependency bump to netty-handler 4.1.135-FINAL
