### PR TITLE
add config switching non-ffmpeg lambdas to use arm64

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -232,10 +232,12 @@ lazy val uploader = (project in file("uploader"))
       ),
       "SendToTranscoderV2" -> LambdaConfig(
         description =
-          "Sends a complete video to the AWS MediaConvert transcoder"
+          "Sends a complete video to the AWS MediaConvert transcoder",
+        architecture = Architecture.x64,
       ),
       "AddSubtitlesToMP4" -> LambdaConfig(
-        description = "Adds subtitles to an MP4 video using ffmpeg"
+        description = "Adds subtitles to an MP4 video using ffmpeg",
+        architecture = Architecture.x64,
       ),
       "AddAssetToAtom" -> LambdaConfig(
         description = "Adds the resulting asset to the atom"

--- a/project/StateMachine.scala
+++ b/project/StateMachine.scala
@@ -2,10 +2,23 @@ import sbt._
 import sbt.Keys._
 
 object StateMachine {
+  sealed trait Architecture {
+    val name: String
+  }
+  object Architecture {
+    object x64 extends Architecture {
+      override val name: String = "x86_64"
+    }
+
+    object arm64 extends Architecture {
+      override val name: String = "arm64"
+    }
+  }
   case class LambdaConfig(
     description: String,
     timeout: Int = 300,
     memory: Int = 2048,
+    architecture: Architecture = Architecture.arm64,
   )
 
   val lambdas = settingKey[Map[String, LambdaConfig]]("The lambdas to include in the state machine")
@@ -16,12 +29,13 @@ object StateMachine {
     val stateMachine = IO.read((Compile / resourceDirectory).value / "state-machine.json")
 
     val withLambdas = (Compile / lambdas).value.foldLeft(template) {
-      case (tmpl, (name, LambdaConfig(description, timeout, memory))) =>
+      case (tmpl, (name, LambdaConfig(description, timeout, memory, architecture))) =>
         val instance = lambdaTemplate
           .replace("{{name}}", name)
           .replace("{{description}}", description)
           .replace("{{timeout}}", timeout.toString)
           .replace("{{memory}}", memory.toString)
+          .replace("{{architecture}}", architecture.name)
 
         replace(s"{{$name}}", instance, tmpl)
     }

--- a/uploader/src/main/resources/lambda-template.yaml
+++ b/uploader/src/main/resources/lambda-template.yaml
@@ -27,7 +27,7 @@
     MemorySize: {{memory}}
 # Architecture specified to match version of ffmpeg used to inject subtitles into mp4
     Architectures:
-      - "x86_64"
+      - {{architecture}}
     Role: !GetAtt LambdaExecutionRole.Arn
     Runtime: "java21"
     Timeout: {{timeout}}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a bit of config to the lambda template allowing us to choose whether each lambda runs on an x64 (for those using ffmpeg) or arm64 (otherwise) architecture, to eke out a little more performance from those lambdas which don't use an x64 binary.

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
