### PR TITLE
try running all lambdas, including ffmpeg calling lambdas, under arm64

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -200,9 +200,9 @@ lazy val uploader = (project in file("uploader"))
         log.info("Downloading statically compiled FFmpeg binary")
         IO.createDirectory(ffmpegFolder)
         import scala.sys.process.*
-        val archive = target.value / "ffmpeg" / "ffmpeg-release-amd64-static.tar.xz"
-        s"wget -nv https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz -O $archive".!!
-        (s"tar xOf $archive ffmpeg-7.0.2-amd64-static/ffmpeg" #> binary).!!
+        val archive = target.value / "ffmpeg" / "ffmpeg-release-arm64-static.tar.xz"
+        s"wget -nv https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.tar.xz -O $archive".!!
+        (s"tar xOf $archive ffmpeg-7.0.2-arm64-static/ffmpeg" #> binary).!!
       }
 
       binary -> "bin/ffmpeg"

--- a/uploader/src/main/resources/lambda-template.yaml
+++ b/uploader/src/main/resources/lambda-template.yaml
@@ -27,7 +27,7 @@
     MemorySize: {{memory}}
 # Architecture specified to match version of ffmpeg used to inject subtitles into mp4
     Architectures:
-      - "x86_64"
+      - "arm64"
     Role: !GetAtt LambdaExecutionRole.Arn
     Runtime: "java21"
     Timeout: {{timeout}}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Alternative to #1584, make _all_ lambdas run on arm64. The prebuilt ffmpeg binaries are also available for the arm64 architecture, so download and use them instead of x86_64, and we can have all the lambdas running happily on arm64.

## How was this tested?

Deployed to CODE, uploaded a self-hosted loop with subtitles, and the upload completed successfully. We've not checked for any change to youtube upload speed, we can monitor ongoing metrics in PROD with realistic throughputs.