### PR TITLE
Show iconik working group on video search page

### DIFF
--- a/app/data/AtomListStore.scala
+++ b/app/data/AtomListStore.scala
@@ -6,6 +6,7 @@ import com.gu.media.model.Platform.{Url, Youtube}
 import com.gu.media.model.VideoPlayerFormat.{Loop, videoPlayerFormat}
 import com.gu.media.model.{
   ContentChangeDetails,
+  IconikData,
   Image,
   MediaAtom,
   Platform,
@@ -180,6 +181,10 @@ class CapiBackedAtomListStore(capi: CapiAccess)
           .asOpt[VideoPlayerFormat]
           .orElse(if (platform == Url) Some(Loop) else None)
 
+      val iconikData =
+        (atom \ "iconikData")
+          .asOpt[IconikData]
+
       Some(
         MediaAtomSummary(
           id,
@@ -187,7 +192,8 @@ class CapiBackedAtomListStore(capi: CapiAccess)
           posterImage,
           contentChangeDetails,
           platform,
-          videoPlayerFormat
+          videoPlayerFormat,
+          iconikData
         )
       )
     }
@@ -267,7 +273,8 @@ class DynamoBackedAtomListStore(store: PreviewDynamoDataStoreV2)
       atom.posterImage,
       atom.contentChangeDetails,
       atom.platform.getOrElse(Youtube),
-      atom.videoPlayerFormat
+      atom.videoPlayerFormat,
+      atom.iconikData
     )
   }
 }

--- a/app/model/MediaAtomSummary.scala
+++ b/app/model/MediaAtomSummary.scala
@@ -1,11 +1,6 @@
 package model
 
-import com.gu.media.model.{
-  ContentChangeDetails,
-  Image,
-  Platform,
-  VideoPlayerFormat
-}
+import com.gu.media.model.{ContentChangeDetails, IconikData, Image, Platform, VideoPlayerFormat}
 import com.gu.ai.x.play.json.Encoders._
 import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.Format
@@ -18,7 +13,8 @@ case class MediaAtomSummary(
     posterImage: Option[Image],
     contentChangeDetails: ContentChangeDetails,
     platform: Platform,
-    videoPlayerFormat: Option[VideoPlayerFormat]
+    videoPlayerFormat: Option[VideoPlayerFormat],
+    iconikData: Option[IconikData]
 )
 
 object MediaAtomList {

--- a/app/model/MediaAtomSummary.scala
+++ b/app/model/MediaAtomSummary.scala
@@ -1,6 +1,12 @@
 package model
 
-import com.gu.media.model.{ContentChangeDetails, IconikData, Image, Platform, VideoPlayerFormat}
+import com.gu.media.model.{
+  ContentChangeDetails,
+  IconikData,
+  Image,
+  Platform,
+  VideoPlayerFormat
+}
 import com.gu.ai.x.play.json.Encoders._
 import com.gu.ai.x.play.json.Jsonx
 import play.api.libs.json.Format

--- a/public/video-ui/src/components/VideoItem/index.jsx
+++ b/public/video-ui/src/components/VideoItem/index.jsx
@@ -48,6 +48,7 @@ export default class VideoItem extends React.Component {
 
   render() {
     const video = this.props.video;
+    const workingGroupName = VideoUtils.getWorkingGroupName(video);
     const platform = VideoUtils.getPlatformFromSummary(video);
     const scheduledLaunch = VideoUtils.getScheduledLaunch(video);
     const scheduledLaunchMoment = moment(scheduledLaunch);
@@ -89,6 +90,11 @@ export default class VideoItem extends React.Component {
             <div className="grid__image sixteen-by-nine">
               {this.renderItemImage()}
             </div>
+            {workingGroupName && (
+              <div className="iconik__group__overlay">
+                <div className="iconik__label label__working-group">{workingGroupName}</div>
+              </div>
+            )}
             <div className="grid__status__overlay">
               <ReactTooltip />
               {this.renderPublishStatus()}

--- a/public/video-ui/src/components/VideoItem/index.jsx
+++ b/public/video-ui/src/components/VideoItem/index.jsx
@@ -10,9 +10,10 @@ import Youtube from "../../../images/youtube.svg?react";
 import Loop from "../../../images/loop.svg?react";
 import Cinemagraph from "../../../images/cinemagraph.svg?react";
 import NonYoutube from "../../../images/nonyoutube.svg?react";
+import { connect } from 'react-redux';
 
 
-export default class VideoItem extends React.Component {
+class VideoItem extends React.Component {
   renderPublishStatus() {
     if (VideoUtils.hasExpired(this.props.video)) {
       return <span className="publish__label label__expired">Expired</span>;
@@ -48,7 +49,7 @@ export default class VideoItem extends React.Component {
 
   render() {
     const video = this.props.video;
-    const workingGroupName = VideoUtils.getWorkingGroupName(video);
+    const workingGroupName = VideoUtils.getWorkingGroupName(video, this.props.workingGroups);
     const platform = VideoUtils.getPlatformFromSummary(video);
     const scheduledLaunch = VideoUtils.getScheduledLaunch(video);
     const scheduledLaunchMoment = moment(scheduledLaunch);
@@ -149,3 +150,9 @@ export default class VideoItem extends React.Component {
     );
   }
 }
+
+const mapStateToProps = state => ({
+  workingGroups: state.iconik?.workingGroups ?? []
+});
+
+export default connect(mapStateToProps)(VideoItem);

--- a/public/video-ui/src/pages/Search/index.tsx
+++ b/public/video-ui/src/pages/Search/index.tsx
@@ -127,6 +127,10 @@ const Videos = ({ videos, total, search: {searchTerm, shouldUseCreatedDateForSor
     dispatch(fetchVideos({search: searchTerm, limit, shouldUseCreatedDateForSort, videoPlayerFormatFilter}));
   }, [shouldUseCreatedDateForSort, videoPlayerFormatFilter]);
 
+  useEffect(() => {
+    dispatch(fetchIconikWorkingGroups());
+  }, [dispatch]);
+
   return (
     <div>
       <div className="grid">
@@ -150,6 +154,7 @@ import { connect, useDispatch } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as reportPresenceClientError from '../../actions/PresenceActions/reportError';
 import { fetchVideos } from '../../slices/videos';
+import { fetchIconikWorkingGroups } from '../../slices/iconik';
 import { AppDispatch } from "../../util/setupStore";
 import { Search } from "../../slices/search";
 

--- a/public/video-ui/src/services/VideosApi.ts
+++ b/public/video-ui/src/services/VideosApi.ts
@@ -125,7 +125,7 @@ export type Video = {
 
 export type MediaAtomSummary = Pick<
   Video,
-  'id' | 'title' | 'contentChangeDetails' | 'posterImage'
+  'id' | 'title' | 'contentChangeDetails' | 'posterImage' | 'platform' | 'iconikData'
 >;
 
 export type VideoWithoutId = Omit<Video, 'id'>;

--- a/public/video-ui/src/util/video.js
+++ b/public/video-ui/src/util/video.js
@@ -130,4 +130,13 @@ export default class VideoUtils {
   static mustHaveTags(atom) {
     return atom.videoPlayerFormat === 'Default';
   }
+
+  static getWorkingGroupName({ iconikData }) {
+    const workingGroupId = iconikData?.workingGroupId;
+    if (!workingGroupId) return null;
+
+    const state = getStore().getState();
+    const workingGroups = state.iconik?.workingGroups ?? [];
+    return workingGroups.find(wg => wg.id === workingGroupId)?.title ?? null;
+  }
 }

--- a/public/video-ui/src/util/video.js
+++ b/public/video-ui/src/util/video.js
@@ -131,12 +131,9 @@ export default class VideoUtils {
     return atom.videoPlayerFormat === 'Default';
   }
 
-  static getWorkingGroupName({ iconikData }) {
+  static getWorkingGroupName({ iconikData }, workingGroups) {
     const workingGroupId = iconikData?.workingGroupId;
     if (!workingGroupId) return null;
-
-    const state = getStore().getState();
-    const workingGroups = state.iconik?.workingGroups ?? [];
     return workingGroups.find(wg => wg.id === workingGroupId)?.title ?? null;
   }
 }

--- a/public/video-ui/styles/components/_header.scss
+++ b/public/video-ui/styles/components/_header.scss
@@ -1,5 +1,5 @@
-.publish__label {
-  min-width: 60px;
+.publish__label, .iconik__label {
+  min-width: 80px;
   height: 30px;
   color: $color800Grey;
   border-radius: 25px;
@@ -9,6 +9,14 @@
   font-weight: bold;
   font-size:12px;
   margin-right: 1px;
+  border: 2px solid black;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.label__working-group {
+  background-color: $color100Grey;
 }
 
 .label__live {

--- a/public/video-ui/styles/layout/_grid.scss
+++ b/public/video-ui/styles/layout/_grid.scss
@@ -107,3 +107,9 @@
   left: 5px;
   bottom: 70px;
 }
+
+.iconik__group__overlay {
+  position: absolute;
+  left: 5px;
+  top: 6px;
+}

--- a/test/data/CapiBackedAtomListStoreSpec.scala
+++ b/test/data/CapiBackedAtomListStoreSpec.scala
@@ -3,7 +3,13 @@ package data
 import com.gu.media.CapiAccess
 import com.gu.media.model.Platform.{Url, Youtube}
 import com.gu.media.model.VideoPlayerFormat.Loop
-import com.gu.media.model.{ChangeRecord, ContentChangeDetails, Image, User}
+import com.gu.media.model.{
+  ChangeRecord,
+  ContentChangeDetails,
+  IconikData,
+  Image,
+  User
+}
 import model.MediaAtomSummary
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.any
@@ -153,7 +159,8 @@ class CapiBackedAtomListStoreSpec
         None
       ),
       platform = Url,
-      videoPlayerFormat = Some(Loop)
+      videoPlayerFormat = Some(Loop),
+      iconikData = None
     ),
     MediaAtomSummary(
       id = "0de596fb-bca3-48f9-846b-3f843508f772",
@@ -179,7 +186,15 @@ class CapiBackedAtomListStoreSpec
         None
       ),
       platform = Url,
-      videoPlayerFormat = Some(Loop)
+      videoPlayerFormat = Some(Loop),
+      iconikData = Some(
+        IconikData(
+          workingGroupId = Some("wg-123"),
+          commissionId = Some("comm-456"),
+          projectId = Some("proj-789"),
+          masterPlaceholderId = Some("pl-123")
+        )
+      )
     )
   )
 
@@ -287,7 +302,13 @@ class CapiBackedAtomListStoreSpec
       |            "commissioningDesks": [],
       |            "keywords": [],
       |            "commentsEnabled": false,
-      |            "platform": "url"
+      |            "platform": "url",
+      |            "iconikData": {
+      |              "workingGroupId": "wg-123",
+      |              "commissionId": "comm-456",
+      |              "projectId": "proj-789",
+      |              "masterPlaceholderId": "pl-123"
+      |            }
       |          }
       |        },
       |        "contentChangeDetails": {


### PR DESCRIPTION
## What does this change?
A quick cheap and cheerful PR to add the Iconic Working Group to the video items on the search page, to better distinguish which desks are producing what videos. This isn't always set (but should be), so this should encourage uptake.

At some point we could do with rejigging at what point the Iconik data is added (initial creation modal, perhaps?) – it's currently in a weird form next to the upload mechanism.

### Design
<img width="1496" height="704" alt="image" src="https://github.com/user-attachments/assets/9f74777b-9ec3-4f88-9045-b30068da940c" />

The new label is a light grey and sits at the top rather than the bottom of the video thumbnail.

Some minor changes to the published / draft labels while adding this new working group label: a border to improve contrast and legibility, and a greater min-width to increase consistency.

We could place this label in line with published and draft, but I think embargo can also live on this bottom line, along with the video icon, so top is better to avoid a clash. It's getting a little busy, and could do with a rejig at a later date.

### Search considerations
We might want to add this as a filter if this proves popular. We'd want to do this server side, otherwise you end up filtering on the first 50 results which may have few / no results for your group. 

To do this would require us to add the working group _name_ field to the CAPI model. We could use the working group ID, which is already there, but it's not parseable by humans. We'd also need to add a new search parameter in Concierge.

### Wouldn't the commissioning desk be better?
Possibly.

This is the list of Iconik working groups:
* Berger Projects
* Documentaries
* Guardian Studios
* It's Complicated
* MMR Team
* News Features
* Originals Australia
* Podcasts
* Reactive Explainers
* Reactive News
* Social
* Special Projects

These are the commissioning desks I can find attached to the most recent media atoms in PROD:
* UK Video (commissioning)
* UK Audio (commissioning)
* US News (commissioning)
* Australia Video and Audio (commissioning)

The Iconik working groups are more narrowly defined, and closer reflect the actual desks responsible for each video. 

At the same time, the Iconik set is also much smaller than the overall pool of commissioning desks available, which would make it easier to filter on in future (unless we limited the commissioning desk field to align with the above sample).

So I think Iconik makes most sense, but you may disagree – perhaps the commissioning desk field should be rejigged instead. From a user perspective, is it great that we're asking for people to add two separate fields broadly doing the same thing? Perhaps they should be further aligned.

We also have the Section field as well – and the YouTube channel, in some cases!
