### PR TITLE
Change label for the field tags

### DIFF
--- a/public/video-ui/src/components/VideoData/VideoData.jsx
+++ b/public/video-ui/src/components/VideoData/VideoData.jsx
@@ -151,7 +151,7 @@ export default class VideoData extends React.Component {
         {
           <ManagedField
             fieldLocation="atomTagIds"
-            name="Tags"
+            name="Tags (self-hosted video)"
             formRowClass="form__row__byline"
             isDesired={mustHaveTags}
             isRequired={false}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This pull request renames the label for the "tags" field to "Tags (self-hosted video)" to differentiate it from any other forms of tagging, as per requests from users.

It changes the label on the frontend only.

## Testing

Deploy to CODE and open Media Atom Maker
- create a new Non-Youtube video.
- open the furniture tab and edit. We should see the new label on the "Tags" field.
- add some tags.
- save and publish. We should see this atom has those tags in its CAPI response.

| Screenshots |
| ----------- |
| Before |
| <img width="914" height="142" alt="Screenshot 2026-06-15 at 14 43 07" src="https://github.com/user-attachments/assets/e3cb953e-f985-4982-b6cb-4a921a6f0abd" />|
| After |
| <img width="915" height="143" alt="Screenshot 2026-06-15 at 14 52 55" src="https://github.com/user-attachments/assets/dcd97bfc-fe68-456b-9741-383478c2d451" />|