### PR TITLE
Add AV1 encoding to HLS/M3U8 output

### DIFF
--- a/app/util/StepFunctions.scala
+++ b/app/util/StepFunctions.scala
@@ -46,7 +46,10 @@ class StepFunctions(awsConfig: AWSConfig) {
         try {
           Some((Json.parse(cause) \ "errorMessage").as[String])
         } catch {
-          case _: JsonParseException | _: JsResultException =>
+          case _: NullPointerException =>
+            Some("Execution failed but no error message was provided")
+          case _: JsonParseException | _: JsResultException |
+              _: NullPointerException =>
             Some(cause)
         }
     }

--- a/common/src/main/scala/com/gu/media/upload/model/MediaConvertEvent.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/MediaConvertEvent.scala
@@ -83,7 +83,7 @@ object MediaConvertVideoDetails {
 }
 
 case class MediaConvertOutputDetails(
-    outputFilePaths: List[String],
+    outputFilePaths: Option[List[String]],
     durationInMs: Long,
     videoDetails: Option[MediaConvertVideoDetails]
 )

--- a/common/src/test/scala/com/gu/media/upload/model/MediaConvertEventTest.scala
+++ b/common/src/test/scala/com/gu/media/upload/model/MediaConvertEventTest.scala
@@ -218,4 +218,218 @@ class MediaConvertEventTest extends AnyFlatSpec with Matchers {
     val parsedJson = Json.parse(json)
     Json.toJson(parsedJson.as[MediaConvertEvent]) shouldBe parsedJson
   }
+
+  "MediaConvertEvent" should "transparently deserialise and serialise CMAF event which does not have outputFilePaths" in {
+    val json =
+      """{
+        |  "version": "0",
+        |  "id": "20b3a8db-8153-b68c-824e-6c970c8565c4",
+        |  "detail-type": "MediaConvert Job State Change",
+        |  "source": "aws.mediaconvert",
+        |  "account": "563563610310",
+        |  "time": "2026-06-16T15:26:14Z",
+        |  "region": "eu-west-1",
+        |  "resources": [
+        |    "arn:aws:mediaconvert:eu-west-1:563563610310:jobs/1781623407306-4bov8h"
+        |  ],
+        |  "detail": {
+        |    "timestamp": 1781623574418,
+        |    "accountId": "563563610310",
+        |    "queue": "arn:aws:mediaconvert:eu-west-1:563563610310:queues/Default",
+        |    "jobId": "1781623407306-4bov8h",
+        |    "status": "COMPLETE",
+        |    "userMetadata": {
+        |      "stage": "DEV",
+        |      "executionId": "arn:aws:states:eu-west-1:563563610310:execution:VideoPipelineDEV-PGZ5E0CNI0QG:7da36eb3-442f-4b56-a411-0031956343d7-8",
+        |      "hasAudio": "true"
+        |    },
+        |    "outputGroupDetails": [
+        |      {
+        |        "outputDetails": [
+        |          {
+        |            "outputFilePaths": [
+        |              "s3://uploads-origin.code.dev-guim.co.uk/2026/06/16/WS_Change_tags_label--7da36eb3-442f-4b56-a411-0031956343d7-8.0_480w_q8_h264.mp4"
+        |            ],
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 480,
+        |              "heightInPx": 854,
+        |              "averageBitrate": 1676481,
+        |              "qvbrAvgQuality": 8.0,
+        |              "qvbrMinQuality": 8.0,
+        |              "qvbrMaxQuality": 8.0,
+        |              "qvbrMinQualityLocation": 0,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "outputFilePaths": [
+        |              "s3://uploads-origin.code.dev-guim.co.uk/2026/06/16/WS_Change_tags_label--7da36eb3-442f-4b56-a411-0031956343d7-8.0_720h_q8_h264.mp4"
+        |            ],
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 406,
+        |              "heightInPx": 720,
+        |              "averageBitrate": 1297659,
+        |              "qvbrAvgQuality": 8.0,
+        |              "qvbrMinQuality": 8.0,
+        |              "qvbrMaxQuality": 8.0,
+        |              "qvbrMinQualityLocation": 0,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "outputFilePaths": [
+        |              "s3://uploads-origin.code.dev-guim.co.uk/2026/06/16/WS_Change_tags_label--7da36eb3-442f-4b56-a411-0031956343d7-8.0.0000000.jpg"
+        |            ],
+        |            "durationInMs": 1000,
+        |            "videoDetails": {
+        |              "widthInPx": 1080,
+        |              "heightInPx": 1920,
+        |              "averageBitrate": 467499
+        |            }
+        |          },
+        |          {
+        |            "outputFilePaths": [
+        |              "s3://uploads-origin.code.dev-guim.co.uk/2026/06/16/WS_Change_tags_label--7da36eb3-442f-4b56-a411-0031956343d7-8.0.vtt"
+        |            ],
+        |            "durationInMs": 0
+        |          }
+        |        ],
+        |        "type": "FILE_GROUP"
+        |      },
+        |      {
+        |        "outputDetails": [
+        |          {
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 480,
+        |              "heightInPx": 854,
+        |              "averageBitrate": 1689527,
+        |              "qvbrAvgQuality": 8.0,
+        |              "qvbrMinQuality": 8.0,
+        |              "qvbrMaxQuality": 8.0,
+        |              "qvbrMinQualityLocation": 0,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 406,
+        |              "heightInPx": 720,
+        |              "averageBitrate": 1306322,
+        |              "qvbrAvgQuality": 8.0,
+        |              "qvbrMinQuality": 8.0,
+        |              "qvbrMaxQuality": 8.0,
+        |              "qvbrMinQualityLocation": 0,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 480,
+        |              "heightInPx": 854,
+        |              "averageBitrate": 607638,
+        |              "qvbrAvgQuality": 8.0,
+        |              "qvbrMinQuality": 7.86,
+        |              "qvbrMaxQuality": 8.0,
+        |              "qvbrMinQualityLocation": 79320,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 406,
+        |              "heightInPx": 720,
+        |              "averageBitrate": 479797,
+        |              "qvbrAvgQuality": 8.0,
+        |              "qvbrMinQuality": 7.86,
+        |              "qvbrMaxQuality": 8.0,
+        |              "qvbrMinQualityLocation": 41800,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 406,
+        |              "heightInPx": 720,
+        |              "averageBitrate": 572952,
+        |              "qvbrAvgQuality": 6.0,
+        |              "qvbrMinQuality": 6.0,
+        |              "qvbrMaxQuality": 6.0,
+        |              "qvbrMinQualityLocation": 0,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 480,
+        |              "heightInPx": 854,
+        |              "averageBitrate": 715475,
+        |              "qvbrAvgQuality": 6.0,
+        |              "qvbrMinQuality": 6.0,
+        |              "qvbrMaxQuality": 6.0,
+        |              "qvbrMinQualityLocation": 0,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 406,
+        |              "heightInPx": 720,
+        |              "averageBitrate": 262457,
+        |              "qvbrAvgQuality": 4.0,
+        |              "qvbrMinQuality": 4.0,
+        |              "qvbrMaxQuality": 4.0,
+        |              "qvbrMinQualityLocation": 0,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 480,
+        |              "heightInPx": 854,
+        |              "averageBitrate": 323519,
+        |              "qvbrAvgQuality": 4.0,
+        |              "qvbrMinQuality": 4.0,
+        |              "qvbrMaxQuality": 4.0,
+        |              "qvbrMinQualityLocation": 0,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "durationInMs": 0
+        |          },
+        |          {
+        |            "durationInMs": 84358
+        |          }
+        |        ],
+        |        "playlistFilePaths": [
+        |          "s3://uploads-origin.code.dev-guim.co.uk/2026/06/16/WS_Change_tags_label--7da36eb3-442f-4b56-a411-0031956343d7-8.0.mpd",
+        |          "s3://uploads-origin.code.dev-guim.co.uk/2026/06/16/WS_Change_tags_label--7da36eb3-442f-4b56-a411-0031956343d7-8.0.m3u8"
+        |        ],
+        |        "type": "CMAF_GROUP"
+        |      }
+        |    ],
+        |    "paddingInserted": 0,
+        |    "blackVideoDetected": 0,
+        |    "warnings": [
+        |      {
+        |        "code": 250003,
+        |        "count": 1
+        |      }
+        |    ]
+        |  }
+        |}
+        |""".stripMargin
+    val parsedJson = Json.parse(json)
+    Json.toJson(parsedJson.as[MediaConvertEvent]) shouldBe parsedJson
+  }
 }

--- a/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
@@ -156,9 +156,9 @@ class AddAssetToAtom
   ) =
     for {
       (settings, results) <- outputGroupsSettings.zip(outputGroupsResults)
-      assetType <- settings.assetType
-      mimeType <- settings.mimeType
-      playlistFilePath <- first(results.playlistFilePaths)
+      assetType <- settings.assetType.toList
+      mimeType <- settings.mimeType.toList
+      playlistFilePath <- results.playlistFilePaths.getOrElse(Nil)
     } yield ThriftAsset(
       assetType,
       version,

--- a/uploader/src/main/scala/com/gu/media/upload/AddSubtitlesToMP4.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/AddSubtitlesToMP4.scala
@@ -60,7 +60,7 @@ class AddSubtitlesToMP4
   ): Option[String] = {
     // todo: use the mime type from the OutputDefinition instead of checking the file extension
     outputGroupDetails.outputDetails.view
-      .flatMap(_.outputFilePaths.find(_.endsWith(".vtt")))
+      .flatMap(_.outputFilePaths.flatMap(_.find(_.endsWith(".vtt"))))
       .headOption
   }
 
@@ -76,7 +76,8 @@ class AddSubtitlesToMP4
       if upload.metadata.subtitleSource.isDefined;
       outputDetails <- outputGroupDetails.outputDetails;
       // todo: use the mime type from the OutputDefinition instead of checking the file extension
-      path <- outputDetails.outputFilePaths.headOption if path.endsWith(".mp4")
+      path <- outputDetails.outputFilePaths.flatMap(_.headOption)
+      if path.endsWith(".mp4")
     ) {
       val subtitlesFile = createTempPath("input-subtitles-", ".srt")
       val videoFile = createTempPath("input-video-", ".mp4")

--- a/uploader/src/main/scala/com/gu/media/upload/TranscoderComplete.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/TranscoderComplete.scala
@@ -139,7 +139,7 @@ class TranscoderComplete
     (for {
       group <- outputGroups
       output <- group.outputDetails
-      filename <- output.outputFilePaths.headOption
+      filename <- output.outputFilePaths.flatMap(_.headOption)
       videoDetails <- output.videoDetails
       extension <- filename.split('.').lastOption
     } yield {

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/EncodingConfig.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/EncodingConfig.scala
@@ -1,47 +1,40 @@
 package com.gu.media.upload.mediaconvert
 
+import com.gu.media.upload.mediaconvert.SharedCodecSettings.{h264Settings}
+import software.amazon.awssdk.services.mediaconvert.model.{
+  VideoCodec,
+  VideoCodecSettings
+}
+
 case class Dimensions(width: Option[Int], height: Option[Int])
 
 sealed trait EncodingConfig {
   def dimensions: Dimensions
-  def nameModifier: String
+  def nameModifier: String = {
+    val dimensionPart = List(
+      dimensions.width.map(w => s"${w}w"),
+      dimensions.height.map(h => s"${h}h")
+    ).flatten.mkString("_")
+
+    s"_${dimensionPart}_q${qualityLevel}"
+  }
   def qualityLevel: Int
+  def codecSettings: VideoCodecSettings
+}
+
+case class H264EncodingConfig(
+    dimensions: Dimensions,
+    qualityLevel: Int
+) extends EncodingConfig {
+  override def codecSettings: VideoCodecSettings = VideoCodecSettings
+    .builder()
+    .codec(VideoCodec.H_264)
+    .h264Settings(h264Settings(qualityLevel))
+    .build()
 }
 
 object EncodingConfigs {
-  case object Default extends EncodingConfig {
-    val dimensions = Dimensions(None, Some(720))
-    val nameModifier = "_720h"
-    val qualityLevel = 8
-  }
+  val Default = H264EncodingConfig(Dimensions(None, Some(720)), 8)
 
-  case object MobileWidth extends EncodingConfig {
-    val dimensions = Dimensions(Some(480), None)
-    val nameModifier = "_480w"
-    val qualityLevel = 8
-  }
-
-  case object LowQuality extends EncodingConfig {
-    val dimensions = Dimensions(None, Some(720))
-    val nameModifier = "_720h_q6"
-    val qualityLevel = 6
-  }
-
-  case object LowQualityMobileWidth extends EncodingConfig {
-    val dimensions = Dimensions(Some(480), None)
-    val nameModifier = "_480w_q6"
-    val qualityLevel = 6
-  }
-
-  case object VeryLowQuality extends EncodingConfig {
-    val dimensions = Dimensions(None, Some(720))
-    val nameModifier = "_720h_q4"
-    val qualityLevel = 4
-  }
-
-  case object VeryLowQualityMobileWidth extends EncodingConfig {
-    val dimensions = Dimensions(Some(480), None)
-    val nameModifier = "_480w_q4"
-    val qualityLevel = 4
-  }
+  val MobileWidth = H264EncodingConfig(Dimensions(Some(480), None), 8)
 }

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/EncodingConfig.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/EncodingConfig.scala
@@ -1,6 +1,9 @@
 package com.gu.media.upload.mediaconvert
 
-import com.gu.media.upload.mediaconvert.SharedCodecSettings.{h264Settings}
+import com.gu.media.upload.mediaconvert.SharedCodecSettings.{
+  av1Settings,
+  h264Settings
+}
 import software.amazon.awssdk.services.mediaconvert.model.{
   VideoCodec,
   VideoCodecSettings
@@ -16,7 +19,7 @@ sealed trait EncodingConfig {
       dimensions.height.map(h => s"${h}h")
     ).flatten.mkString("_")
 
-    s"_${dimensionPart}_q${qualityLevel}"
+    s"_${dimensionPart}_q${qualityLevel}_${codecSettings.codecAsString.replace("_", "").toLowerCase}"
   }
   def qualityLevel: Int
   def codecSettings: VideoCodecSettings
@@ -30,6 +33,17 @@ case class H264EncodingConfig(
     .builder()
     .codec(VideoCodec.H_264)
     .h264Settings(h264Settings(qualityLevel))
+    .build()
+}
+
+case class AV1EncodingConfig(
+    dimensions: Dimensions,
+    qualityLevel: Int
+) extends EncodingConfig {
+  override def codecSettings: VideoCodecSettings = VideoCodecSettings
+    .builder()
+    .codec(VideoCodec.AV1)
+    .av1Settings(av1Settings(qualityLevel))
     .build()
 }
 

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/SharedCodecSettings.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/SharedCodecSettings.scala
@@ -10,6 +10,26 @@ object SharedCodecSettings {
   /** Migrated from Elastic Transcoder */
   val bitrate: BitrateSetting = BitrateSetting(4_800_000, 2_400_000);
 
+  def av1Settings(qualityLevel: Int = 8): Av1Settings =
+    Av1Settings
+      .builder()
+      .maxBitrate(bitrate.max)
+      .rateControlMode(Av1RateControlMode.QVBR)
+      .qvbrSettings(
+        Av1QvbrSettings
+          .builder()
+          .qvbrQualityLevel(qualityLevel) // 1-10, 10 is best quality
+          .qvbrQualityLevelFineTune(
+            0
+          )
+          .build()
+      )
+      .bitDepth(Av1BitDepth.BIT_10)
+      .adaptiveQuantization(Av1AdaptiveQuantization.HIGH)
+      .spatialAdaptiveQuantization(Av1SpatialAdaptiveQuantization.ENABLED)
+      .framerateControl(Av1FramerateControl.INITIALIZE_FROM_SOURCE)
+      .build()
+
   def h264Settings(qualityLevel: Int = 8): H264Settings =
     H264Settings
       .builder()

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/JPEGOutput.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/JPEGOutput.scala
@@ -1,7 +1,7 @@
 package com.gu.media.upload.mediaconvert.file
 
 import com.gu.media.model.VideoSource
-import com.gu.media.upload.mediaconvert.OutputDefinition
+import com.gu.media.upload.mediaconvert.{OutputDefinition, VideoCodecWrapper}
 import software.amazon.awssdk.services.mediaconvert.model._
 
 object JPEGOutput {
@@ -35,6 +35,7 @@ object JPEGOutput {
             )
             .build()
         )
-        .build()
+        .build(),
+    codec = VideoCodecWrapper(VideoCodec.FRAME_CAPTURE)
   )
 }

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/MP4Output.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/MP4Output.scala
@@ -2,13 +2,13 @@ package com.gu.media.upload.mediaconvert.file
 
 import com.gu.contentatom.thrift.atom.media.AssetType
 import com.gu.media.model.VideoSource
-import com.gu.media.upload.mediaconvert.OutputDefinition
-import com.gu.media.upload.mediaconvert.SharedCodecSettings.{
-  aacAudioDescription,
-  h264Settings
+import com.gu.media.upload.mediaconvert.{
+  EncodingConfig,
+  OutputDefinition,
+  VideoCodecWrapper
 }
+import com.gu.media.upload.mediaconvert.SharedCodecSettings.aacAudioDescription
 import software.amazon.awssdk.services.mediaconvert.model._
-import com.gu.media.upload.mediaconvert.EncodingConfig
 
 object MP4Output {
 
@@ -34,11 +34,7 @@ object MP4Output {
               .width(config.dimensions.width.map(Integer.valueOf).orNull)
               .sharpness(100) // Sharpest possible
               .codecSettings(
-                VideoCodecSettings
-                  .builder()
-                  .codec(VideoCodec.H_264)
-                  .h264Settings(h264Settings(config.qualityLevel))
-                  .build()
+                config.codecSettings
               )
               .build()
           )
@@ -46,7 +42,8 @@ object MP4Output {
         if (hasAudio)
           outputBuilder.audioDescriptions(aacAudioDescription).build()
         else outputBuilder.build()
-      }
+      },
+      codec = VideoCodecWrapper(config.codecSettings.codec())
     )
   }
 }

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/WebVTTOutput.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/file/WebVTTOutput.scala
@@ -2,7 +2,11 @@ package com.gu.media.upload.mediaconvert.file
 
 import com.gu.contentatom.thrift.atom.media.AssetType
 import com.gu.media.model.VideoSource
-import com.gu.media.upload.mediaconvert.{OutputDefinition, SelectorNames}
+import com.gu.media.upload.mediaconvert.{
+  CaptionsCodecWrapper,
+  OutputDefinition,
+  SelectorNames
+}
 import software.amazon.awssdk.services.mediaconvert.model._
 
 object WebVTTOutput {
@@ -35,6 +39,7 @@ object WebVTTOutput {
             .build()
         )
         .extension("vtt") // explicitly setting the extension avoids an AWS bug where the extension isn't included in the media convert complete event
-        .build()
+        .build(),
+    codec = CaptionsCodecWrapper(CaptionDestinationType.WEBVTT)
   )
 }

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/AudioOutput.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/AudioOutput.scala
@@ -1,7 +1,7 @@
 package com.gu.media.upload.mediaconvert.hls
 
 import com.gu.media.model.VideoSource
-import com.gu.media.upload.mediaconvert.OutputDefinition
+import com.gu.media.upload.mediaconvert.{AudioCodecWrapper, OutputDefinition}
 import com.gu.media.upload.mediaconvert.SharedCodecSettings.aacAudioDescription
 import software.amazon.awssdk.services.mediaconvert.model._
 
@@ -11,6 +11,7 @@ object AudioOutput {
       mimeType = Some(VideoSource.mimeTypeM3u8),
       assetType =
         None, // Not currently used as an asset, as the m3u8 playlist is used instead
+      codec = AudioCodecWrapper(aacAudioDescription.codecSettings().codec()),
       output = () => {
         val outputBuilder = Output
           .builder()

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/AudioOutput.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/AudioOutput.scala
@@ -1,0 +1,31 @@
+package com.gu.media.upload.mediaconvert.hls
+
+import com.gu.media.model.VideoSource
+import com.gu.media.upload.mediaconvert.OutputDefinition
+import com.gu.media.upload.mediaconvert.SharedCodecSettings.aacAudioDescription
+import software.amazon.awssdk.services.mediaconvert.model._
+
+object AudioOutput {
+  def apply(): OutputDefinition =
+    OutputDefinition(
+      mimeType = Some(VideoSource.mimeTypeM3u8),
+      assetType =
+        None, // Not currently used as an asset, as the m3u8 playlist is used instead
+      output = () => {
+        val outputBuilder = Output
+          .builder()
+          .containerSettings(
+            ContainerSettings
+              .builder()
+              .container(ContainerType.CMFC)
+              .cmfcSettings(CmfcSettings.builder().build())
+              .build()
+          )
+          .nameModifier("_audio")
+          .audioDescriptions(aacAudioDescription)
+
+        outputBuilder.build()
+      }
+    )
+
+}

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/CaptionsOutput.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/CaptionsOutput.scala
@@ -15,11 +15,11 @@ object CaptionsOutput {
         .containerSettings(
           ContainerSettings
             .builder()
-            .container(ContainerType.M3_U8)
-            .m3u8Settings(M3u8Settings.builder().build())
+            .container(ContainerType.CMFC)
+            .cmfcSettings(CmfcSettings.builder().build())
             .build()
         )
-        .nameModifier("captions")
+        .nameModifier("_captions")
         .captionDescriptions(
           CaptionDescription
             .builder()

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/CaptionsOutput.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/CaptionsOutput.scala
@@ -1,7 +1,11 @@
 package com.gu.media.upload.mediaconvert.hls
 
 import com.gu.media.model.VideoSource
-import com.gu.media.upload.mediaconvert.{OutputDefinition, SelectorNames}
+import com.gu.media.upload.mediaconvert.{
+  CaptionsCodecWrapper,
+  OutputDefinition,
+  SelectorNames
+}
 import software.amazon.awssdk.services.mediaconvert.model._
 
 object CaptionsOutput {
@@ -9,6 +13,7 @@ object CaptionsOutput {
     mimeType = Some(VideoSource.mimeTypeM3u8),
     assetType =
       None, // Not currently used as an asset, as the m3u8 playlist which combines this and video is used instead
+    codec = CaptionsCodecWrapper(CaptionDestinationType.WEBVTT),
     output = () =>
       Output
         .builder()

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/HLSOutputGroup.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/HLSOutputGroup.scala
@@ -4,7 +4,8 @@ import com.gu.contentatom.thrift.atom.media.AssetType
 import com.gu.media.model.VideoSource
 import com.gu.media.upload.mediaconvert.{EncodingConfigs, OutputGroupDefinition}
 import software.amazon.awssdk.services.mediaconvert.model.{
-  HlsGroupSettings,
+  CmafGroupSettings,
+  CmafWriteDASHManifest,
   OutputGroup,
   OutputGroupSettings,
   OutputGroupType
@@ -13,14 +14,14 @@ import software.amazon.awssdk.services.mediaconvert.model.{
 object HLSOutputGroup {
   def apply(hasAudio: Boolean): OutputGroupDefinition = {
     val outputs = List(
-      VideoOutput(EncodingConfigs.MobileWidth, hasAudio),
-      VideoOutput(EncodingConfigs.Default, hasAudio),
-      VideoOutput(EncodingConfigs.LowQuality, hasAudio),
-      VideoOutput(EncodingConfigs.LowQualityMobileWidth, hasAudio),
-      VideoOutput(EncodingConfigs.VeryLowQuality, hasAudio),
-      VideoOutput(EncodingConfigs.VeryLowQualityMobileWidth, hasAudio),
+      VideoOutput(EncodingConfigs.MobileWidth),
+      VideoOutput(EncodingConfigs.Default),
+      VideoOutput(EncodingConfigs.LowQuality),
+      VideoOutput(EncodingConfigs.LowQualityMobileWidth),
+      VideoOutput(EncodingConfigs.VeryLowQuality),
+      VideoOutput(EncodingConfigs.VeryLowQualityMobileWidth),
       CaptionsOutput()
-    )
+    ) ++ (if (hasAudio) List(AudioOutput()) else Nil)
     OutputGroupDefinition(
       mimeType = Some(VideoSource.mimeTypeM3u8),
       assetType = Some(
@@ -30,17 +31,18 @@ object HLSOutputGroup {
       outputGroup = (destination: String) =>
         OutputGroup
           .builder()
-          .name("Apple HLS")
+          .name("CMAF HLS")
           .outputs(outputs.map(_.output()): _*)
           .outputGroupSettings(
             OutputGroupSettings
               .builder()
-              .`type`(OutputGroupType.HLS_GROUP_SETTINGS)
-              .hlsGroupSettings(
-                HlsGroupSettings
+              .`type`(OutputGroupType.CMAF_GROUP_SETTINGS)
+              .cmafGroupSettings(
+                CmafGroupSettings
                   .builder()
+                  .writeDashManifest(CmafWriteDASHManifest.DISABLED)
                   .segmentLength(10)
-                  .minSegmentLength(0)
+                  .fragmentLength(2)
                   .destination(destination)
                   .build()
               )

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/HLSOutputGroup.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/HLSOutputGroup.scala
@@ -2,7 +2,12 @@ package com.gu.media.upload.mediaconvert.hls
 
 import com.gu.contentatom.thrift.atom.media.AssetType
 import com.gu.media.model.VideoSource
-import com.gu.media.upload.mediaconvert.{EncodingConfigs, OutputGroupDefinition}
+import com.gu.media.upload.mediaconvert.{
+  Dimensions,
+  EncodingConfig,
+  H264EncodingConfig,
+  OutputGroupDefinition
+}
 import software.amazon.awssdk.services.mediaconvert.model.{
   CmafGroupSettings,
   CmafWriteDASHManifest,
@@ -12,16 +17,29 @@ import software.amazon.awssdk.services.mediaconvert.model.{
 }
 
 object HLSOutputGroup {
+
+  private val commonDimensions = List(
+    Dimensions(Some(480), None),
+    Dimensions(None, Some(720))
+  )
+
+  private val outputDefinitions: List[
+    ((Dimensions, Int) => EncodingConfig, List[Dimensions], List[Int])
+  ] = List(
+    (H264EncodingConfig, commonDimensions, List(8, 6, 4))
+  )
+
+  private val videoOutputs = for {
+    (encodingConfig, dimensions, qualities) <- outputDefinitions
+    dimension <- dimensions
+    quality <- qualities
+  } yield VideoOutput(encodingConfig(dimension, quality))
+
   def apply(hasAudio: Boolean): OutputGroupDefinition = {
-    val outputs = List(
-      VideoOutput(EncodingConfigs.MobileWidth),
-      VideoOutput(EncodingConfigs.Default),
-      VideoOutput(EncodingConfigs.LowQuality),
-      VideoOutput(EncodingConfigs.LowQualityMobileWidth),
-      VideoOutput(EncodingConfigs.VeryLowQuality),
-      VideoOutput(EncodingConfigs.VeryLowQualityMobileWidth),
-      CaptionsOutput()
-    ) ++ (if (hasAudio) List(AudioOutput()) else Nil)
+    val outputs = videoOutputs ++
+      List(CaptionsOutput()) ++
+      List(AudioOutput()).filter(_ => hasAudio)
+
     OutputGroupDefinition(
       mimeType = Some(VideoSource.mimeTypeM3u8),
       assetType = Some(

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/HLSOutputGroup.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/HLSOutputGroup.scala
@@ -3,18 +3,25 @@ package com.gu.media.upload.mediaconvert.hls
 import com.gu.contentatom.thrift.atom.media.AssetType
 import com.gu.media.model.VideoSource
 import com.gu.media.upload.mediaconvert.{
+  AV1EncodingConfig,
   Dimensions,
   EncodingConfig,
   H264EncodingConfig,
-  OutputGroupDefinition
+  OutputDefinition,
+  OutputGroupDefinition,
+  VideoCodecWrapper
 }
 import software.amazon.awssdk.services.mediaconvert.model.{
+  CmafAdditionalManifest,
   CmafGroupSettings,
   CmafWriteDASHManifest,
   OutputGroup,
   OutputGroupSettings,
-  OutputGroupType
+  OutputGroupType,
+  VideoCodec
 }
+
+import scala.jdk.CollectionConverters._
 
 object HLSOutputGroup {
 
@@ -26,7 +33,8 @@ object HLSOutputGroup {
   private val outputDefinitions: List[
     ((Dimensions, Int) => EncodingConfig, List[Dimensions], List[Int])
   ] = List(
-    (H264EncodingConfig, commonDimensions, List(8, 6, 4))
+    (H264EncodingConfig, commonDimensions, List(8, 4)),
+    (AV1EncodingConfig, commonDimensions, List(8, 4))
   )
 
   private val videoOutputs = for {
@@ -34,6 +42,23 @@ object HLSOutputGroup {
     dimension <- dimensions
     quality <- qualities
   } yield VideoOutput(encodingConfig(dimension, quality))
+
+  def manifestWithoutCodec(
+      outputs: List[OutputDefinition],
+      codec: VideoCodec,
+      nameModifier: String
+  ): CmafAdditionalManifest = {
+    CmafAdditionalManifest
+      .builder()
+      .manifestNameModifier(nameModifier)
+      .selectedOutputs(
+        outputs
+          .filter(o => o.codec != VideoCodecWrapper(codec))
+          .map(_.output().nameModifier())
+          .asJava
+      )
+      .build()
+  }
 
   def apply(hasAudio: Boolean): OutputGroupDefinition = {
     val outputs = videoOutputs ++
@@ -62,6 +87,12 @@ object HLSOutputGroup {
                   .segmentLength(10)
                   .fragmentLength(2)
                   .destination(destination)
+                  .additionalManifests(
+                    List(
+                      manifestWithoutCodec(outputs, VideoCodec.H_264, "_av1"),
+                      manifestWithoutCodec(outputs, VideoCodec.AV1, "_h264")
+                    ).asJava
+                  )
                   .build()
               )
               .build()

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/VideoOutput.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/VideoOutput.scala
@@ -3,12 +3,15 @@ package com.gu.media.upload.mediaconvert.hls
 import com.gu.media.model.VideoSource
 import com.gu.media.upload.mediaconvert.SharedCodecSettings.h264Settings
 import com.gu.media.upload.mediaconvert.{EncodingConfig, OutputDefinition}
+import com.gu.media.upload.mediaconvert.VideoCodecWrapper
+
 import software.amazon.awssdk.services.mediaconvert.model._
 
 object VideoOutput {
   def apply(config: EncodingConfig): OutputDefinition =
     OutputDefinition(
       mimeType = Some(VideoSource.mimeTypeM3u8),
+      codec = VideoCodecWrapper(config.codecSettings.codec),
       assetType =
         None, // Not currently used as an asset, as the m3u8 playlist which combines this and subtitles is used instead
       output = () => {

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/VideoOutput.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/VideoOutput.scala
@@ -1,31 +1,27 @@
 package com.gu.media.upload.mediaconvert.hls
 
 import com.gu.media.model.VideoSource
-import com.gu.media.upload.mediaconvert.OutputDefinition
-import com.gu.media.upload.mediaconvert.SharedCodecSettings.{
-  aacAudioDescription,
-  h264Settings
-}
+import com.gu.media.upload.mediaconvert.SharedCodecSettings.h264Settings
+import com.gu.media.upload.mediaconvert.{EncodingConfig, OutputDefinition}
 import software.amazon.awssdk.services.mediaconvert.model._
-import com.gu.media.upload.mediaconvert.EncodingConfig
 
 object VideoOutput {
-  def apply(config: EncodingConfig, hasAudio: Boolean): OutputDefinition =
+  def apply(config: EncodingConfig): OutputDefinition =
     OutputDefinition(
       mimeType = Some(VideoSource.mimeTypeM3u8),
       assetType =
         None, // Not currently used as an asset, as the m3u8 playlist which combines this and subtitles is used instead
       output = () => {
-        val outputBuilder = Output
+        Output
           .builder()
           .containerSettings(
             ContainerSettings
               .builder()
-              .container(ContainerType.M3_U8)
-              .m3u8Settings(M3u8Settings.builder().build())
+              .container(ContainerType.CMFC)
+              .cmfcSettings(CmfcSettings.builder().build())
               .build()
           )
-          .nameModifier(s"hls${config.nameModifier}")
+          .nameModifier(config.nameModifier)
           .videoDescription(
             VideoDescription
               .builder()
@@ -54,11 +50,7 @@ object VideoOutput {
               )
               .build()
           )
-
-        if (hasAudio)
-          outputBuilder.audioDescriptions(aacAudioDescription).build()
-        else outputBuilder.build()
+          .build()
       }
     )
-
 }

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/model.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/model.scala
@@ -1,10 +1,23 @@
 package com.gu.media.upload.mediaconvert
 
 import com.gu.contentatom.thrift.atom.media.AssetType
-import software.amazon.awssdk.services.mediaconvert.model.{Output, OutputGroup}
+import software.amazon.awssdk.services.mediaconvert.model.{
+  AudioCodec,
+  CaptionDestinationType,
+  Output,
+  OutputGroup,
+  VideoCodec
+}
+
+sealed trait Codec
+
+case class AudioCodecWrapper(codec: AudioCodec) extends Codec
+case class VideoCodecWrapper(codec: VideoCodec) extends Codec
+case class CaptionsCodecWrapper(codec: CaptionDestinationType) extends Codec
 
 case class OutputDefinition(
     output: () => Output,
+    codec: Codec,
     mimeType: Option[String],
     assetType: Option[AssetType]
 )


### PR DESCRIPTION
## What does this change?

This PR adds AV1 alongside H.264 in the CMAF HLS output group, and generates separate manifests for each codec so clients that don't support AV1 can fall back to the H.264-only playlist. AV1 encoding parameters are based on Mateusz's testing.

AV1 produces visually similar outputs with significantly less bandwidth.

Before we release this, we need to release https://github.com/guardian/media-atom-maker/pull/1598 and ensure that:

1. DCR lists the AV1 manifest first, and the H.264 manifest second
2. MAPI returns only the H.264 manifest 

Later we can explore how MAPI can expose the AV1 and H.264 manifests to the native app so that devices that support AV1 can use it.

### Changes

#### Codec tracking on `OutputDefinition` (`model.scala`, all output objects)

- Adds a `codec: Codec` field to `OutputDefinition`, represented by a sealed trait with three wrappers: `VideoCodecWrapper`, `AudioCodecWrapper`, and `CaptionsCodecWrapper`.
- All existing output objects (`VideoOutput`, `AudioOutput`, `CaptionsOutput`, `MP4Output`, `JPEGOutput`, `WebVTTOutput`) are updated to populate this field.
- This enables filtering outputs by codec at the group level, which is needed to generate per-codec manifests.

#### AV1 encoding config and settings (`EncodingConfig.scala`, `SharedCodecSettings.scala`)

- Adds `AV1EncodingConfig(dimensions, qualityLevel)` alongside `H264EncodingConfig`, implementing `codecSettings` with `VideoCodec.AV1` and QVBR rate control.
- AV1 settings: 10-bit depth, `HIGH` adaptive quantization, spatial adaptive quantization enabled, max bitrate inherited from the existing shared bitrate config.
- The `nameModifier` derived from `EncodingConfig` now includes the codec name (e.g. `_480w_q8_av1`, `_720h_q4_h264`), making codec identifiable in logs and MediaConvert output paths.

#### Dual-codec HLS output group (`HLSOutputGroup.scala`)

- `outputDefinitions` now contains both `H264EncodingConfig` and `AV1EncodingConfig` across the same two dimensions (`480w`, `720h`) and two quality levels (`q8`, `q4`), producing 8 video outputs in total (4 H.264 + 4 AV1).
- Adds two additional CMAF manifests via `additionalManifests`:
  - `_av1`: AV1-only playlist (excludes H.264 outputs) — for clients that support AV1.
  - `_h264`: H.264-only playlist (excludes AV1 outputs) — for clients that don't support AV1.
- The main manifest continues to include all outputs which might be helpful for debugging but probably will not be used in practice.
- `manifestWithoutCodec` is a helper that builds a `CmafAdditionalManifest` by filtering outputs whose codec doesn't match the excluded codec.

#### `AddAssetToAtom.scala`

`playlistFilePaths` can now include multiple playlists, corresponding to the additional manifests explained above.

## How has this change been tested?

tbd
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
