### PR TITLE
Hide tags if YouTube video

### DIFF
--- a/public/video-ui/src/components/VideoData/VideoData.jsx
+++ b/public/video-ui/src/components/VideoData/VideoData.jsx
@@ -149,9 +149,9 @@ export default class VideoData extends React.Component {
             </ManagedField>
         }
         {
-          <ManagedField
+          video.platform !== 'Youtube' && <ManagedField
             fieldLocation="atomTagIds"
-            name="Tags (self-hosted video)"
+            name="Tags"
             formRowClass="form__row__byline"
             isDesired={mustHaveTags}
             isRequired={false}


### PR DESCRIPTION
## What does this change?
We shouldn't show self-hosted fields on YouTube videos.

This can be changed later, if YouTube videos need the tags field, but for now this will stop users filling in the wrong field by accident.

I still think there needs to be a clearer distinction between 'Composer keywords' and 'Tags' (it's quite confusing to users currently).