### PR TITLE
Use VTT subtitle output file instead of the uploaded one

### DIFF
--- a/uploader/src/main/scala/com/gu/media/upload/AddSubtitlesToMP4.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/AddSubtitlesToMP4.scala
@@ -58,10 +58,8 @@ class AddSubtitlesToMP4
   private def getVttOutput(
       outputGroupDetails: MediaConvertOutputGroupDetails
   ): Option[String] = {
-    val vttOutputDetails = outputGroupDetails.outputDetails.find(
-      _.outputFilePaths.exists(_.endsWith(".vtt"))
-    )
-    vttOutputDetails.flatMap(_.outputFilePaths.find(_.endsWith(".vtt")))
+    // todo: use the mime type from the OutputDefinition instead of checking the file extension
+    outputGroupDetails.outputDetails.view.flatMap(_.outputFilePaths.find(_.endsWith(".vtt"))).headOption
   }
 
   override def handle(upload: Upload): Upload = {
@@ -72,10 +70,8 @@ class AddSubtitlesToMP4
       }.toList;
       event <- selfHostedUploadMetadata.completeEvent.toList;
       outputGroupDetails <- event.detail.outputGroupDetails;
-      outputVttPath <- getVttOutput(outputGroupDetails);
+      outputVttPath <- getVttOutput(outputGroupDetails) if upload.metadata.subtitleSource.isDefined;
       outputDetails <- outputGroupDetails.outputDetails;
-      // we don't need the subtitle source, but just meant to check if it exists
-      subtitleSource <- upload.metadata.subtitleSource;
       // todo: use the mime type from the OutputDefinition instead of checking the file extension
       path <- outputDetails.outputFilePaths.headOption if path.endsWith(".mp4")
     ) {

--- a/uploader/src/main/scala/com/gu/media/upload/AddSubtitlesToMP4.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/AddSubtitlesToMP4.scala
@@ -59,7 +59,9 @@ class AddSubtitlesToMP4
       outputGroupDetails: MediaConvertOutputGroupDetails
   ): Option[String] = {
     // todo: use the mime type from the OutputDefinition instead of checking the file extension
-    outputGroupDetails.outputDetails.view.flatMap(_.outputFilePaths.find(_.endsWith(".vtt"))).headOption
+    outputGroupDetails.outputDetails.view
+      .flatMap(_.outputFilePaths.find(_.endsWith(".vtt")))
+      .headOption
   }
 
   override def handle(upload: Upload): Upload = {
@@ -70,7 +72,8 @@ class AddSubtitlesToMP4
       }.toList;
       event <- selfHostedUploadMetadata.completeEvent.toList;
       outputGroupDetails <- event.detail.outputGroupDetails;
-      outputVttPath <- getVttOutput(outputGroupDetails) if upload.metadata.subtitleSource.isDefined;
+      outputVttPath <- getVttOutput(outputGroupDetails)
+      if upload.metadata.subtitleSource.isDefined;
       outputDetails <- outputGroupDetails.outputDetails;
       // todo: use the mime type from the OutputDefinition instead of checking the file extension
       path <- outputDetails.outputFilePaths.headOption if path.endsWith(".mp4")

--- a/uploader/src/main/scala/com/gu/media/upload/AddSubtitlesToMP4.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/AddSubtitlesToMP4.scala
@@ -3,7 +3,11 @@ package com.gu.media.upload
 import com.gu.media.aws.{MediaConvertAccess, S3Access}
 import com.gu.media.lambda.{LambdaBase, LambdaWithParams}
 import com.gu.media.logging.Logging
-import com.gu.media.upload.model.{SelfHostedUploadMetadata, Upload}
+import com.gu.media.upload.model.{
+  SelfHostedUploadMetadata,
+  Upload,
+  MediaConvertOutputGroupDetails
+}
 import software.amazon.awssdk.services.s3.model.{
   GetObjectRequest,
   PutObjectRequest
@@ -13,6 +17,7 @@ import java.net.URI
 import java.nio.file.{Files, Path}
 import scala.PartialFunction.condOpt
 import scala.util.Random
+import scala.jdk.CollectionConverters._
 
 class AddSubtitlesToMP4
     extends LambdaWithParams[Upload, Upload]
@@ -50,6 +55,15 @@ class AddSubtitlesToMP4
     s3Client.putObject(putObjectRequest, path)
   }
 
+  private def getVttOutput(
+      outputGroupDetails: MediaConvertOutputGroupDetails
+  ): Option[String] = {
+    val vttOutputDetails = outputGroupDetails.outputDetails.find(
+      _.outputFilePaths.exists(_.endsWith(".vtt"))
+    )
+    vttOutputDetails.flatMap(_.outputFilePaths.find(_.endsWith(".vtt")))
+  }
+
   override def handle(upload: Upload): Upload = {
     for (
       selfHostedUploadMetadata <- condOpt(upload.metadata.runtime) {
@@ -58,7 +72,9 @@ class AddSubtitlesToMP4
       }.toList;
       event <- selfHostedUploadMetadata.completeEvent.toList;
       outputGroupDetails <- event.detail.outputGroupDetails;
+      outputVttPath <- getVttOutput(outputGroupDetails);
       outputDetails <- outputGroupDetails.outputDetails;
+      // we don't need the subtitle source, but just meant to check if it exists
       subtitleSource <- upload.metadata.subtitleSource;
       // todo: use the mime type from the OutputDefinition instead of checking the file extension
       path <- outputDetails.outputFilePaths.headOption if path.endsWith(".mp4")
@@ -72,8 +88,13 @@ class AddSubtitlesToMP4
       val key = uri.getPath.drop(
         1
       ) // drop the leading slash from the path to fit with S3 conventions
+      val vttUri = new URI(outputVttPath)
+      val vttBucketName = vttUri.getHost
+      val vttKey = vttUri.getPath.drop(
+        1
+      ) // drop the leading slash from the path to fit with S3 conventions
       s3Download(bucketName, key, videoFile)
-      s3Download(upload.metadata.bucket, subtitleSource.src, subtitlesFile)
+      s3Download(vttBucketName, vttKey, subtitlesFile)
       FfMpeg.addSubtitlesToMP4(videoFile, subtitlesFile, updatedVideo)
       s3Upload(bucketName, key, updatedVideo)
     }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This pull request addresses an issue with uploaded subtitle files having a longer duration than their corresponding videos.

After a subtitle file is uploaded for a video, the "AddSubtitleToMP4" process in the video pipeline adds the subtitle stream from the uploaded subtitle file to the output MP4 files of MediaConvert. If the subtitle stream has a longer duration than the video stream, some video players may use this longer duration for the whole video, showing the last frame until the subtitle stream finishes.

Therefore, this pull request aims to have the subtitle stream truncated in the output MP4 files.

### Solution

We set the MediaConvert job to produce a subtitle file in VTT in the `FileOutputGroup` together with MP4 files (in two resolutions) and a thumbnail image. The output subtitle file is truncated so that it doesn't have subtitle text that goes beyond the length of the video track.

Instead of using the original subtitle file uploaded by users, this PR adds that output subtitle track to the output MP4 files, both of which come from the same output group of the MediaConvert job.

However, the MediaConvert job produces a VTT file even when there are no subtitles uploaded. So we add the subtitle track only if an uploaded subtitle file is present.
 
### Alternative approach

An alternative approach is to modify a subtitle track using `ffmpeg` before adding it to those MP4 files. I tried this approach, running `ffmpeg` with [`-t`](https://ffmpeg.org/ffmpeg.html#Subtitle-options:~:text=%2Dt%20duration%20(input/output)) option over a subtitle file. It successfully removed subtitle blocks that are shown after the duration, but it does not modify the subtitle block that appears before the duration ends and remains past the end of the duration. For example, if the subtitle file has this block:

```
3
00:00:10,000 --> 00:00:18,500
Subtitle from 10.00 to 19.00
```

Using `ffmpeg` to truncate it to 15 seconds will still leave this block unmodified in the output file, producing a subtitle file that is still 18.5 seconds long. 

The MediaConvert job used in our solution can handle this case without this issue.

In addition, we need to find out the length of a video track before truncating the subtitle track, which adds more complexity to this approach.

The `ffmpeg` supports an option `-shortest`, which tells it to "finish encoding when the shortest output stream ends". But as expected, it truncates the video track (that is undesirable) if the subtitle track doesn't have subtitle near the end of the video.

## How has this change been tested?

Deploy the main branch to CODE
- upload a video in MAM with a subtitle file that has longer duration.
- download the output MP4 file produced by MediaConvert job.
- open the MP4 file using VLC locally.
- we should see that the video has the same duration as the subtitle file, not the video we've uploaded.
- we should see the subtitle track in VLC.

Deploy this branch to CODE
- upload the same video in MAM with the same subtitle file (that has longer duration).
- download the output MP4 file produced by MediaConvert job.
- open the MP4 file using VLC locally.
- we should see that the video has the same duration as the original video we've uploaded.
- we should see the subtitle track in VLC.

## How can we measure success?

Users are not required to manually trim subtitle files before uploading them to MAM.

## Have we considered potential risks?

Rely more on the output of MediaConvert job. But it is in the same output group as those MP4 files and as we already rely on the transcoding of MediaConvert, it should not be much of a concern.