### PR TITLE
Add single source of truth for asset versioning

### DIFF
--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -21,7 +21,10 @@ import com.gu.pandahmac.HMACAuthActions
 import data.{DataStores, UnpackedDataStores}
 import com.gu.ai.x.play.json.Jsonx
 import com.gu.media.telemetry.{TagLong, TagString, Telemetry}
-import model.commands.CommandExceptions.commandExceptionAsResult
+import model.commands.CommandExceptions.{
+  AssetVersionClaimFailed,
+  commandExceptionAsResult
+}
 import model.commands.{SubtitleFileDeleteCommand, SubtitleFileUploadCommand}
 import org.scanamo.{ConditionNotMet, Table}
 import org.scanamo.generic.auto._
@@ -127,7 +130,12 @@ class UploadController(
         version = MediaAtomHelpers.getNextAssetVersion(thriftAtom.tdata),
         userEmail = userEmail,
         originalFilename = Some(req.filename)
-      )
+      ) match {
+        case Right(claimedVersion) => claimedVersion
+        case Left(error) =>
+          log.error(error.message)
+          AssetVersionClaimFailed(error.message)
+      }
 
       val upload = start(atom, userEmail, req, assetVersion)
 
@@ -253,17 +261,18 @@ class UploadController(
       log.warn(
         s"Execution already exists for atom ${atom.id} version ${assetVersion}. Trying next available version. NB. This should not happen unless the backfill script has failed, or an upload was started during the backfill process."
       )
-      start(
-        atom,
-        email,
-        req,
-        assetVersionManager.claimThisOrNextAvailableVersion(
-          atom.id,
-          assetVersion,
-          userEmail = email,
-          originalFilename = Some(req.filename)
-        )
-      )
+      assetVersionManager.claimThisOrNextAvailableVersion(
+        atom.id,
+        assetVersion,
+        userEmail = email,
+        originalFilename = Some(req.filename)
+      ) match {
+        case Right(nextVersion) =>
+          start(atom, email, req, nextVersion)
+        case Left(error) =>
+          log.error(error.message)
+          AssetVersionClaimFailed(error.message)
+      }
     }
   }
 

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -1,10 +1,7 @@
 package controllers
 
 import com.gu.ai.x.play.json.Encoders._
-import software.amazon.awssdk.services.sfn.model.{
-  ExecutionAlreadyExistsException,
-  ExecutionListItem
-}
+import software.amazon.awssdk.services.sfn.model.ExecutionListItem
 import com.gu.media.MediaAtomMakerPermissionsProvider
 import com.gu.media.logging.Logging
 import com.gu.media.model.{
@@ -23,8 +20,9 @@ import com.gu.ai.x.play.json.Jsonx
 import com.gu.media.telemetry.{TagLong, TagString, Telemetry}
 import model.commands.CommandExceptions.commandExceptionAsResult
 import model.commands.{SubtitleFileDeleteCommand, SubtitleFileUploadCommand}
-import org.scanamo.Table
+import org.scanamo.{ConditionNotMet, Table}
 import org.scanamo.generic.auto._
+import org.scanamo.syntax._
 import play.api.libs.Files
 import play.api.libs.json.{Format, Json}
 import play.api.mvc.{
@@ -227,14 +225,25 @@ class UploadController(
       email: String,
       req: UploadRequest,
       assetVersion: Long
-  ): Upload = try {
+  ): Upload = {
     val upload = UploadBuilder.build(atom, email, assetVersion, req, awsConfig)
-    stepFunctions.start(upload)
+    val table = Table[Upload](awsConfig.cacheTableName)
+    val result = awsConfig.scanamo.exec(
+      table.when(attributeNotExists("id")).put(upload)
+    )
 
-    upload
-  } catch {
-    case _: ExecutionAlreadyExistsException =>
-      start(atom, email, req, assetVersion + 1)
+    result match {
+      case Right(_) =>
+        stepFunctions.start(upload)
+        upload
+      case Left(ConditionNotMet(_)) =>
+        start(atom, email, req, assetVersion + 1)
+      case Left(_) =>
+        log.warn(
+          s"Encountered unexpected error when saving upload ${upload.id} to DynamoDB. Retrying with next asset version."
+        )
+        start(atom, email, req, assetVersion + 1)
+    }
   }
 
   /** re-run an existing upload through the state machine to reprocess the video

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -118,9 +118,9 @@ class UploadController(
       )
       val thriftAtom = getPreviewAtom(req.atomId)
       val atom = MediaAtom.fromThrift(thriftAtom)
-      val assetVersion = assetVersionManager.claimNextVersion(
+      val assetVersion = assetVersionManager.claimThisOrNextAvailableVersion(
         atom.id,
-        MediaAtomHelpers.getCurrentAssetVersion(thriftAtom.tdata).getOrElse(1L)
+        MediaAtomHelpers.getNextAssetVersion(thriftAtom.tdata)
       )
 
       val upload = start(atom, raw.user.email, req, assetVersion)
@@ -242,7 +242,10 @@ class UploadController(
         atom,
         email,
         req,
-        assetVersionManager.claimNextVersion(atom.id, assetVersion)
+        assetVersionManager.claimThisOrNextAvailableVersion(
+          atom.id,
+          assetVersion
+        )
       )
   }
 

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -261,18 +261,21 @@ class UploadController(
       log.warn(
         s"Execution already exists for atom ${atom.id} version ${assetVersion}. Trying next available version. NB. This should not happen unless the backfill script has failed, or an upload was started during the backfill process."
       )
-      assetVersionManager.claimThisOrNextAvailableVersion(
-        atom.id,
-        assetVersion,
-        userEmail = email,
-        originalFilename = Some(req.filename)
-      ) match {
-        case Right(nextVersion) =>
-          start(atom, email, req, nextVersion)
-        case Left(error) =>
-          log.error(error.message)
-          AssetVersionClaimFailed(error.message)
-      }
+      val nextVersion = assetVersionManager
+        .claimThisOrNextAvailableVersion(
+          atom.id,
+          assetVersion,
+          userEmail = email,
+          originalFilename = Some(req.filename)
+        )
+        .fold(
+          error => {
+            log.error(error.message)
+            AssetVersionClaimFailed(error.message)
+          },
+          identity
+        )
+      start(atom, email, req, nextVersion)
     }
   }
 

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -59,7 +59,8 @@ class UploadController(
 
   private val credsGenerator = new CredentialsGenerator(awsConfig)
   private val uploadDecorator = new UploadDecorator(awsConfig, stepFunctions)
-  private val assetVersionManager = new AssetVersionManager(awsConfig)
+  private val assetVersionManager =
+    new AssetVersionManager(awsConfig, AssetClaimSource.UploadPipeline)
 
   /** prepares a list of ClientAssets that represent the multiple versioned
     * assets for the atom to be displayed in the client. The list is made up of

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -1,7 +1,10 @@
 package controllers
 
 import com.gu.ai.x.play.json.Encoders._
-import software.amazon.awssdk.services.sfn.model.ExecutionListItem
+import software.amazon.awssdk.services.sfn.model.{
+  ExecutionAlreadyExistsException,
+  ExecutionListItem
+}
 import com.gu.media.MediaAtomMakerPermissionsProvider
 import com.gu.media.logging.Logging
 import com.gu.media.model.{
@@ -56,6 +59,7 @@ class UploadController(
 
   private val credsGenerator = new CredentialsGenerator(awsConfig)
   private val uploadDecorator = new UploadDecorator(awsConfig, stepFunctions)
+  private val assetVersionManager = new AssetVersionManager(awsConfig)
 
   /** prepares a list of ClientAssets that represent the multiple versioned
     * assets for the atom to be displayed in the client. The list is made up of
@@ -114,8 +118,10 @@ class UploadController(
       )
       val thriftAtom = getPreviewAtom(req.atomId)
       val atom = MediaAtom.fromThrift(thriftAtom)
-      val assetVersion =
-        MediaAtomHelpers.getNextAssetVersion(thriftAtom.tdata)
+      val assetVersion = assetVersionManager.claimNextVersion(
+        atom.id,
+        MediaAtomHelpers.getCurrentAssetVersion(thriftAtom.tdata).getOrElse(1L)
+      )
 
       val upload = start(atom, raw.user.email, req, assetVersion)
 
@@ -225,25 +231,19 @@ class UploadController(
       email: String,
       req: UploadRequest,
       assetVersion: Long
-  ): Upload = {
+  ): Upload = try {
     val upload = UploadBuilder.build(atom, email, assetVersion, req, awsConfig)
-    val table = Table[Upload](awsConfig.cacheTableName)
-    val result = awsConfig.scanamo.exec(
-      table.when(attributeNotExists("id")).put(upload)
-    )
+    stepFunctions.start(upload)
 
-    result match {
-      case Right(_) =>
-        stepFunctions.start(upload)
-        upload
-      case Left(ConditionNotMet(_)) =>
-        start(atom, email, req, assetVersion + 1)
-      case Left(_) =>
-        log.warn(
-          s"Encountered unexpected error when saving upload ${upload.id} to DynamoDB. Retrying with next asset version."
-        )
-        start(atom, email, req, assetVersion + 1)
-    }
+    upload
+  } catch {
+    case _: ExecutionAlreadyExistsException =>
+      start(
+        atom,
+        email,
+        req,
+        assetVersionManager.claimNextVersion(atom.id, assetVersion)
+      )
   }
 
   /** re-run an existing upload through the state machine to reprocess the video

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -119,12 +119,17 @@ class UploadController(
       )
       val thriftAtom = getPreviewAtom(req.atomId)
       val atom = MediaAtom.fromThrift(thriftAtom)
+
+      val userEmail = raw.user.email
+
       val assetVersion = assetVersionManager.claimThisOrNextAvailableVersion(
-        atom.id,
-        MediaAtomHelpers.getNextAssetVersion(thriftAtom.tdata)
+        atomId = atom.id,
+        version = MediaAtomHelpers.getNextAssetVersion(thriftAtom.tdata),
+        userEmail = userEmail,
+        originalFilename = Some(req.filename)
       )
 
-      val upload = start(atom, raw.user.email, req, assetVersion)
+      val upload = start(atom, userEmail, req, assetVersion)
 
       log.info(
         s"Upload created under atom ${req.atomId}. upload=${upload.id}. parts=${upload.parts.size}, selfHosted=${upload.metadata.selfHost}"
@@ -238,16 +243,28 @@ class UploadController(
 
     upload
   } catch {
-    case _: ExecutionAlreadyExistsException =>
+    /** @todo
+      *   once the new asset version claim mechanism has been live long enough
+      *   for any existing executions to have been flushed through, we should be
+      *   able to remove this path, and then `start()` will no longer need to be
+      *   recursive.
+      */
+    case _: ExecutionAlreadyExistsException => {
+      log.warn(
+        s"Execution already exists for atom ${atom.id} version ${assetVersion}. Trying next available version. NB. This should not happen unless the backfill script has failed, or an upload was started during the backfill process."
+      )
       start(
         atom,
         email,
         req,
         assetVersionManager.claimThisOrNextAvailableVersion(
           atom.id,
-          assetVersion
+          assetVersion,
+          userEmail = email,
+          originalFilename = Some(req.filename)
         )
       )
+    }
   }
 
   /** re-run an existing upload through the state machine to reprocess the video

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -259,7 +259,7 @@ class UploadController(
       */
     case _: ExecutionAlreadyExistsException => {
       log.warn(
-        s"Execution already exists for atom ${atom.id} version ${assetVersion}. Trying next available version. NB. This should not happen unless the backfill script has failed, or an upload was started during the backfill process."
+        s"Execution already exists for atom ${atom.id} version ${assetVersion}. Trying next available version from claims table."
       )
       val nextVersion = assetVersionManager
         .claimThisOrNextAvailableVersion(

--- a/app/model/commands/AddAssetCommand.scala
+++ b/app/model/commands/AddAssetCommand.scala
@@ -86,7 +86,12 @@ case class AddAssetCommand(
         version = MediaAtomHelpers.getNextAssetVersion(mediaAtom),
         userEmail = user.email,
         originalFilename = None
-      )
+      ) match {
+        case Right(claimedVersion) => claimedVersion
+        case Left(error) =>
+          log.error(error.message)
+          AssetVersionClaimFailed(error.message)
+      }
 
     val newAsset = ThriftUtil
       .parseAsset(uri = videoUri, version = version, mimeType = None)

--- a/app/model/commands/AddAssetCommand.scala
+++ b/app/model/commands/AddAssetCommand.scala
@@ -81,17 +81,20 @@ case class AddAssetCommand(
       videoId: String
   ) = {
     val version =
-      assetVersionManager.claimThisOrNextAvailableVersion(
-        atomId = atom.id,
-        version = MediaAtomHelpers.getNextAssetVersion(mediaAtom),
-        userEmail = user.email,
-        originalFilename = None
-      ) match {
-        case Right(claimedVersion) => claimedVersion
-        case Left(error) =>
-          log.error(error.message)
-          AssetVersionClaimFailed(error.message)
-      }
+      assetVersionManager
+        .claimThisOrNextAvailableVersion(
+          atomId = atom.id,
+          version = MediaAtomHelpers.getNextAssetVersion(mediaAtom),
+          userEmail = user.email,
+          originalFilename = None
+        )
+        .fold(
+          error => {
+            log.error(error.message)
+            AssetVersionClaimFailed(error.message)
+          },
+          identity
+        )
 
     val newAsset = ThriftUtil
       .parseAsset(uri = videoUri, version = version, mimeType = None)

--- a/app/model/commands/AddAssetCommand.scala
+++ b/app/model/commands/AddAssetCommand.scala
@@ -22,12 +22,8 @@ import com.gu.media.model.MediaAtom.fromThrift
 import com.gu.media.telemetry.{TagBool, TagLong, TagString, Telemetry}
 import com.gu.media.youtube.YoutubeUrl
 import model.commands.CommandExceptions._
-import org.scanamo.{ConditionNotMet, Table}
-import org.scanamo.generic.auto._
-import org.scanamo.syntax._
-import util.{AWSConfig, AssetVersionManager, YouTube}
+import util.{AWSConfig, AssetClaimSource, AssetVersionManager, YouTube}
 
-import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 case class AddAssetCommand(
@@ -44,7 +40,8 @@ case class AddAssetCommand(
 
   type T = MediaAtom
 
-  private val assetVersionManager = new AssetVersionManager(awsConfig)
+  private val assetVersionManager =
+    new AssetVersionManager(awsConfig, AssetClaimSource.PreexistingAssetURL)
 
   def process(): MediaAtom = {
     log.info(s"Request to add new asset $videoUri to $atomId")

--- a/app/model/commands/AddAssetCommand.scala
+++ b/app/model/commands/AddAssetCommand.scala
@@ -82,8 +82,10 @@ case class AddAssetCommand(
   ) = {
     val version =
       assetVersionManager.claimThisOrNextAvailableVersion(
-        atom.id,
-        MediaAtomHelpers.getNextAssetVersion(mediaAtom)
+        atomId = atom.id,
+        version = MediaAtomHelpers.getNextAssetVersion(mediaAtom),
+        userEmail = user.email,
+        originalFilename = None
       )
 
     val newAsset = ThriftUtil

--- a/app/model/commands/AddAssetCommand.scala
+++ b/app/model/commands/AddAssetCommand.scala
@@ -10,15 +10,24 @@ import com.gu.contentatom.thrift.atom.media.{
 }
 import com.gu.media.logging.Logging
 import com.gu.media.model.MediaAtom
-import com.gu.media.util.{MAMLogger, MediaAtomImplicits, ThriftUtil}
+import com.gu.media.util.{
+  MAMLogger,
+  MediaAtomHelpers,
+  MediaAtomImplicits,
+  ThriftUtil
+}
 import com.gu.pandomainauth.model.{User => PandaUser}
 import data.DataStores
 import com.gu.media.model.MediaAtom.fromThrift
 import com.gu.media.telemetry.{TagBool, TagLong, TagString, Telemetry}
 import com.gu.media.youtube.YoutubeUrl
 import model.commands.CommandExceptions._
+import org.scanamo.{ConditionNotMet, Table}
+import org.scanamo.generic.auto._
+import org.scanamo.syntax._
 import util.{AWSConfig, YouTube}
 
+import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 case class AddAssetCommand(
@@ -72,7 +81,8 @@ case class AddAssetCommand(
       currentAssets: Seq[Asset],
       videoId: String
   ) = {
-    val version = getNextAssetVersionNumber(currentAssets)
+    val version =
+      MediaAtomHelpers.getNextAssetVersion(mediaAtom)
 
     val newAsset = ThriftUtil
       .parseAsset(uri = videoUri, version = version, mimeType = None)
@@ -159,14 +169,6 @@ case class AddAssetCommand(
             e
           )
           existingChannel
-      }
-    }
-  }
-
-  private def getNextAssetVersionNumber(currentAssets: Seq[Asset]): Long = {
-    currentAssets.foldLeft(1L) { (acc, asset) =>
-      {
-        if (asset.version >= acc) asset.version + 1 else acc
       }
     }
   }

--- a/app/model/commands/AddAssetCommand.scala
+++ b/app/model/commands/AddAssetCommand.scala
@@ -25,7 +25,7 @@ import model.commands.CommandExceptions._
 import org.scanamo.{ConditionNotMet, Table}
 import org.scanamo.generic.auto._
 import org.scanamo.syntax._
-import util.{AWSConfig, YouTube}
+import util.{AWSConfig, AssetVersionManager, YouTube}
 
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
@@ -43,6 +43,8 @@ case class AddAssetCommand(
     with Logging {
 
   type T = MediaAtom
+
+  private val assetVersionManager = new AssetVersionManager(awsConfig)
 
   def process(): MediaAtom = {
     log.info(s"Request to add new asset $videoUri to $atomId")
@@ -82,7 +84,10 @@ case class AddAssetCommand(
       videoId: String
   ) = {
     val version =
-      MediaAtomHelpers.getNextAssetVersion(mediaAtom)
+      assetVersionManager.claimThisOrNextAvailableVersion(
+        atom.id,
+        MediaAtomHelpers.getNextAssetVersion(mediaAtom)
+      )
 
     val newAsset = ThriftUtil
       .parseAsset(uri = videoUri, version = version, mimeType = None)

--- a/app/model/commands/CommandException.scala
+++ b/app/model/commands/CommandException.scala
@@ -25,6 +25,8 @@ object CommandExceptions extends Results {
     throw new CommandException("Asset is not a youtube video", 400)
   def AssetVersionConflict =
     throw new CommandException("Asset version conflict", 400)
+  def AssetVersionClaimFailed(err: String) =
+    throw new CommandException(s"Failed to claim asset version: $err", 500)
   def AssetAlreadyAdded =
     throw new CommandException("Asset has already been added to this atom", 400)
   def AssetParseFailed =

--- a/app/util/AssetVersionManager.scala
+++ b/app/util/AssetVersionManager.scala
@@ -1,22 +1,46 @@
 package util
 
-import org.scanamo.{ConditionNotMet, Table}
+import org.scanamo.{ConditionNotMet, DynamoFormat, Table}
 import org.scanamo.syntax.attributeNotExists
 import org.scanamo.generic.auto._
 import com.gu.media.logging.Logging
 
 import scala.annotation.tailrec
 
-class AssetVersionManager(awsConfig: AWSConfig) extends Logging {
+sealed trait AssetClaimSource {
+  def name: String
+}
+object AssetClaimSource {
+  case object UploadPipeline extends AssetClaimSource {
+    override def name: String = "UploadPipeline"
+  }
+  case object PreexistingAssetURL extends AssetClaimSource {
+    override def name: String = "PreexistingAssetURL"
+  }
 
-  case class VersionClaim(id: String)
+  private val all: Map[String, AssetClaimSource] =
+    Map("UploadPipeline" -> UploadPipeline, "PreexistingAssetURL" -> PreexistingAssetURL)
+
+  implicit val dynamoFormat: DynamoFormat[AssetClaimSource] =
+    DynamoFormat.coercedXmap[AssetClaimSource, String, IllegalArgumentException](
+      name => all.getOrElse(name, throw new IllegalArgumentException(s"Unknown AssetClaimSource: $name")),
+      _.name
+    )
+}
+
+class AssetVersionManager(
+    awsConfig: AWSConfig,
+    assetClaimSource: AssetClaimSource
+) extends Logging {
+
+  case class VersionClaim(id: String, claimSource: AssetClaimSource)
 
   object VersionClaim {
     def fromAtomIdAndVersionNumber(
         atomId: String,
         version: Long
     ): VersionClaim = {
-      VersionClaim(s"$atomId-$version")
+      VersionClaim(s"$atomId-$version", assetClaimSource)
     }
   }
 

--- a/app/util/AssetVersionManager.scala
+++ b/app/util/AssetVersionManager.scala
@@ -9,7 +9,7 @@ import scala.annotation.tailrec
 
 class AssetVersionManager(awsConfig: AWSConfig) extends Logging {
 
-  case class VersionClaim(assetId: String)
+  case class VersionClaim(id: String)
 
   object VersionClaim {
     def fromAtomIdAndVersionNumber(

--- a/app/util/AssetVersionManager.scala
+++ b/app/util/AssetVersionManager.scala
@@ -19,13 +19,23 @@ object AssetClaimSource {
   }
 
   private val all: Map[String, AssetClaimSource] =
-    Map("UploadPipeline" -> UploadPipeline, "PreexistingAssetURL" -> PreexistingAssetURL)
+    Map(
+      "UploadPipeline" -> UploadPipeline,
+      "PreexistingAssetURL" -> PreexistingAssetURL
+    )
 
   implicit val dynamoFormat: DynamoFormat[AssetClaimSource] =
-    DynamoFormat.coercedXmap[AssetClaimSource, String, IllegalArgumentException](
-      name => all.getOrElse(name, throw new IllegalArgumentException(s"Unknown AssetClaimSource: $name")),
-      _.name
-    )
+    DynamoFormat
+      .coercedXmap[AssetClaimSource, String, IllegalArgumentException](
+        name =>
+          all.getOrElse(
+            name,
+            throw new IllegalArgumentException(
+              s"Unknown AssetClaimSource: $name"
+            )
+          ),
+        _.name
+      )
 }
 
 class AssetVersionManager(

--- a/app/util/AssetVersionManager.scala
+++ b/app/util/AssetVersionManager.scala
@@ -43,25 +43,29 @@ class AssetVersionManager(
     assetClaimSource: AssetClaimSource
 ) extends Logging {
 
-  case class VersionClaim(id: String, claimSource: AssetClaimSource)
-
-  object VersionClaim {
-    def fromAtomIdAndVersionNumber(
-        atomId: String,
-        version: Long
-    ): VersionClaim = {
-      VersionClaim(s"$atomId-$version", assetClaimSource)
-    }
-  }
+  case class VersionClaim(
+      id: String,
+      claimSource: AssetClaimSource,
+      claimedAtTimestamp: Long, // Unix timestamp in milliseconds
+      claimedByUser: String,
+      originalFilename: Option[String]
+  )
 
   @tailrec
   final def claimThisOrNextAvailableVersion(
       atomId: String,
-      version: Long
+      version: Long,
+      userEmail: String,
+      originalFilename: Option[String]
   ): Long = {
     val assetsTable = Table[VersionClaim](awsConfig.assetsTableName)
-    val claim =
-      VersionClaim.fromAtomIdAndVersionNumber(atomId, version)
+    val claim = VersionClaim(
+      id = s"$atomId-$version",
+      claimSource = assetClaimSource,
+      claimedAtTimestamp = System.currentTimeMillis(),
+      claimedByUser = userEmail,
+      originalFilename = originalFilename
+    )
     val assetsResult = awsConfig.scanamo.exec(
       assetsTable.when(attributeNotExists("id")).put(claim)
     )
@@ -69,12 +73,22 @@ class AssetVersionManager(
     assetsResult match {
       case Right(_) => version
       case Left(ConditionNotMet(_)) =>
-        claimThisOrNextAvailableVersion(atomId, version + 1)
+        claimThisOrNextAvailableVersion(
+          atomId = atomId,
+          version = version + 1,
+          userEmail = userEmail,
+          originalFilename = originalFilename
+        )
       case Left(_) =>
         log.warn(
           s"Unexpected error claiming version $version for atom $atomId. Retrying with next version."
         )
-        claimThisOrNextAvailableVersion(atomId, version + 1)
+        claimThisOrNextAvailableVersion(
+          atomId = atomId,
+          version = version + 1,
+          userEmail = userEmail,
+          originalFilename = originalFilename
+        )
     }
   }
 

--- a/app/util/AssetVersionManager.scala
+++ b/app/util/AssetVersionManager.scala
@@ -1,11 +1,20 @@
 package util
 
-import org.scanamo.{ConditionNotMet, DynamoFormat, Table}
+import org.scanamo.{ConditionNotMet, DynamoFormat, ScanamoError, Table}
 import org.scanamo.syntax.attributeNotExists
 import org.scanamo.generic.auto._
 import com.gu.media.logging.Logging
 
 import scala.annotation.tailrec
+
+case class AssetVersionClaimError(
+    atomId: String,
+    version: Long,
+    cause: ScanamoError
+) {
+  def message: String =
+    s"atom $atomId, version $version: $cause"
+}
 
 sealed trait AssetClaimSource {
   def name: String
@@ -57,7 +66,7 @@ class AssetVersionManager(
       version: Long,
       userEmail: String,
       originalFilename: Option[String]
-  ): Long = {
+  ): Either[AssetVersionClaimError, Long] = {
     val assetsTable = Table[VersionClaim](awsConfig.assetsTableName)
     val claim = VersionClaim(
       id = s"$atomId-$version",
@@ -71,7 +80,7 @@ class AssetVersionManager(
     )
 
     assetsResult match {
-      case Right(_) => version
+      case Right(_) => Right(version)
       case Left(ConditionNotMet(_)) =>
         claimThisOrNextAvailableVersion(
           atomId = atomId,
@@ -79,16 +88,11 @@ class AssetVersionManager(
           userEmail = userEmail,
           originalFilename = originalFilename
         )
-      case Left(_) =>
+      case Left(error) =>
         log.warn(
-          s"Unexpected error claiming version $version for atom $atomId. Retrying with next version."
+          s"Unexpected error claiming version $version for atom $atomId: $error"
         )
-        claimThisOrNextAvailableVersion(
-          atomId = atomId,
-          version = version + 1,
-          userEmail = userEmail,
-          originalFilename = originalFilename
-        )
+        Left(AssetVersionClaimError(atomId, version, error))
     }
   }
 

--- a/app/util/AssetVersionManager.scala
+++ b/app/util/AssetVersionManager.scala
@@ -1,0 +1,43 @@
+package util
+
+import org.scanamo.{ConditionNotMet, Table}
+import org.scanamo.syntax.attributeNotExists
+import org.scanamo.generic.auto._
+import com.gu.media.logging.Logging
+
+import scala.annotation.tailrec
+
+class AssetVersionManager(awsConfig: AWSConfig) extends Logging {
+
+  case class VersionClaim(assetId: String)
+
+  object VersionClaim {
+    def fromAtomIdAndVersionNumber(
+        atomId: String,
+        version: Long
+    ): VersionClaim = {
+      VersionClaim(s"$atomId-$version")
+    }
+  }
+
+  @tailrec
+  final def claimNextVersion(atomId: String, version: Long): Long = {
+    val assetsTable = Table[VersionClaim](awsConfig.assetsTableName)
+    val claim = VersionClaim.fromAtomIdAndVersionNumber(atomId, version)
+    val assetsResult = awsConfig.scanamo.exec(
+      assetsTable.when(attributeNotExists("id")).put(claim)
+    )
+
+    assetsResult match {
+      case Right(_) => version
+      case Left(ConditionNotMet(_)) =>
+        claimNextVersion(atomId, version + 1)
+      case Left(_) =>
+        log.warn(
+          s"Unexpected error claiming version $version for atom $atomId. Retrying with next version."
+        )
+        claimNextVersion(atomId, version + 1)
+    }
+  }
+
+}

--- a/app/util/AssetVersionManager.scala
+++ b/app/util/AssetVersionManager.scala
@@ -9,11 +9,10 @@ import scala.annotation.tailrec
 
 case class AssetVersionClaimError(
     atomId: String,
-    version: Long,
-    cause: ScanamoError
+    version: Long
 ) {
   def message: String =
-    s"atom $atomId, version $version: $cause"
+    s"atom $atomId, version $version could not be claimed due to a DynamoDB error"
 }
 
 sealed trait AssetClaimSource {
@@ -89,10 +88,10 @@ class AssetVersionManager(
           originalFilename = originalFilename
         )
       case Left(error) =>
-        log.warn(
+        log.error(
           s"Unexpected error claiming version $version for atom $atomId: $error"
         )
-        Left(AssetVersionClaimError(atomId, version, error))
+        Left(AssetVersionClaimError(atomId, version))
     }
   }
 

--- a/app/util/AssetVersionManager.scala
+++ b/app/util/AssetVersionManager.scala
@@ -21,9 +21,13 @@ class AssetVersionManager(awsConfig: AWSConfig) extends Logging {
   }
 
   @tailrec
-  final def claimNextVersion(atomId: String, version: Long): Long = {
+  final def claimThisOrNextAvailableVersion(
+      atomId: String,
+      version: Long
+  ): Long = {
     val assetsTable = Table[VersionClaim](awsConfig.assetsTableName)
-    val claim = VersionClaim.fromAtomIdAndVersionNumber(atomId, version)
+    val claim =
+      VersionClaim.fromAtomIdAndVersionNumber(atomId, version)
     val assetsResult = awsConfig.scanamo.exec(
       assetsTable.when(attributeNotExists("id")).put(claim)
     )
@@ -31,12 +35,12 @@ class AssetVersionManager(awsConfig: AWSConfig) extends Logging {
     assetsResult match {
       case Right(_) => version
       case Left(ConditionNotMet(_)) =>
-        claimNextVersion(atomId, version + 1)
+        claimThisOrNextAvailableVersion(atomId, version + 1)
       case Left(_) =>
         log.warn(
           s"Unexpected error claiming version $version for atom $atomId. Retrying with next version."
         )
-        claimNextVersion(atomId, version + 1)
+        claimThisOrNextAvailableVersion(atomId, version + 1)
     }
   }
 

--- a/app/util/UploadDecorator.scala
+++ b/app/util/UploadDecorator.scala
@@ -34,7 +34,9 @@ class UploadDecorator(
   }
 
   def getUpload(id: String): Option[Upload] =
-    aws.scanamo.exec(table.get("id" === id)).flatMap(_.toOption) orElse {
+    aws.scanamo
+      .exec(table.get("id" === id))
+      .flatMap(res => res.toOption) orElse {
       stepFunctions.getById(id)
     }
 }

--- a/common/src/main/scala/com/gu/media/aws/UploadAccess.scala
+++ b/common/src/main/scala/com/gu/media/aws/UploadAccess.scala
@@ -17,6 +17,8 @@ trait UploadAccess { this: Settings with AwsAccess =>
 
   val cacheTableName: String = s"media-atom-pipeline-cache-$stage"
 
+  val assetsTableName: String = s"media-atom-maker-$stage-atom-assets"
+
   lazy val uploadSTSClient = createUploadSTSClient()
 
   lazy val stepFunctionsClient = SfnClient

--- a/scripts/backfill-asset-versions.sh
+++ b/scripts/backfill-asset-versions.sh
@@ -56,6 +56,7 @@ fi
 
 CACHE_TABLE="media-atom-pipeline-cache-${STAGE}"
 ASSETS_TABLE="media-atom-maker-${STAGE}-atom-assets"
+NOW_MS=$(( $(date +%s) * 1000 ))
 
 echo "Cache table:  ${CACHE_TABLE}"
 echo "Assets table: ${ASSETS_TABLE}"
@@ -141,10 +142,27 @@ process_page() {
       continue
     fi
 
+    local original_filename
+    original_filename=$(echo "$page_json" | jq -r ".Items[$i].metadata.M.originalFilename.S // empty")
+
+    local start_timestamp
+    start_timestamp=$(echo "$page_json" | jq -r ".Items[$i].metadata.M.startTimestamp.N // empty")
+    local claim_timestamp=${start_timestamp:-$NOW_MS}
+
     # Build item JSON safely with jq to prevent injection
     local item_json
-    item_json=$(jq -n --arg id "$claim_id" \
-      '{PutRequest:{Item:{id:{S:$id},claimSource:{S:"UploadPipeline"}}}}')
+    item_json=$(jq -n \
+      --arg id "$claim_id" \
+      --argjson ts "$claim_timestamp" \
+      --arg fn "$original_filename" \
+      '{
+        PutRequest: {
+          Item: (
+            {id:{S:$id}, claimSource:{S:"UploadPipeline"}, claimedAtTimestamp:{N:($ts|tostring)}, claimedByUser:{S:"backfill"}}
+            | if $fn != "" then . + {originalFilename:{S:$fn}} else . end
+          )
+        }
+      }')
     batch_items+=("$item_json")
 
     if [[ ${#batch_items[@]} -ge $BATCH_SIZE ]]; then
@@ -188,7 +206,8 @@ while true; do
     --table-name "$CACHE_TABLE"
     --region "$REGION"
     --profile "$PROFILE"
-    --projection-expression "id"
+    --projection-expression "id, #m.originalFilename, #m.startTimestamp"
+    --expression-attribute-names '{"#m":"metadata"}'
     --page-size "$PAGE_SIZE"
     --max-items "$PAGE_SIZE"
   )

--- a/scripts/backfill-asset-versions.sh
+++ b/scripts/backfill-asset-versions.sh
@@ -149,16 +149,20 @@ process_page() {
     start_timestamp=$(echo "$page_json" | jq -r ".Items[$i].metadata.M.startTimestamp.N // empty")
     local claim_timestamp=${start_timestamp:-$NOW_MS}
 
+    local claimed_by_user
+    claimed_by_user=$(echo "$page_json" | jq -r ".Items[$i].metadata.M.user.S // empty")
+
     # Build item JSON safely with jq to prevent injection
     local item_json
     item_json=$(jq -n \
       --arg id "$claim_id" \
       --argjson ts "$claim_timestamp" \
       --arg fn "$original_filename" \
+      --arg claimed_by_user "$claimed_by_user" \
       '{
         PutRequest: {
           Item: (
-            {id:{S:$id}, claimSource:{S:"UploadPipeline"}, claimedAtTimestamp:{N:($ts|tostring)}, claimedByUser:{S:"backfill"}}
+            {id:{S:$id}, claimSource:{S:"UploadPipeline"}, claimedAtTimestamp:{N:($ts|tostring)}, claimedByUser:{S:$claimed_by_user}}
             | if $fn != "" then . + {originalFilename:{S:$fn}} else . end
           )
         }
@@ -206,8 +210,8 @@ while true; do
     --table-name "$CACHE_TABLE"
     --region "$REGION"
     --profile "$PROFILE"
-    --projection-expression "id, #m.originalFilename, #m.startTimestamp"
-    --expression-attribute-names '{"#m":"metadata"}'
+    --projection-expression "id, #m.originalFilename, #m.startTimestamp, #m.#u"
+    --expression-attribute-names '{"#m":"metadata","#u":"user"}'
     --page-size "$PAGE_SIZE"
     --max-items "$PAGE_SIZE"
   )

--- a/scripts/backfill-asset-versions.sh
+++ b/scripts/backfill-asset-versions.sh
@@ -162,7 +162,7 @@ process_page() {
       '{
         PutRequest: {
           Item: (
-            {id:{S:$id}, claimSource:{S:"UploadPipeline"}, claimedAtTimestamp:{N:($ts|tostring)}, claimedByUser:{S:$claimed_by_user}}
+            {id:{S:$id}, claimSource:{S:"UploadPipeline"}, claimedAtTimestamp:{N:($ts|tostring)}, claimedByUser:{S:$claimed_by_user}, fromBackfill:{BOOL:true}}
             | if $fn != "" then . + {originalFilename:{S:$fn}} else . end
           )
         }

--- a/scripts/backfill-asset-versions.sh
+++ b/scripts/backfill-asset-versions.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Backfills the asset versions table with entries from the upload pipeline cache.
+#
+# For each upload in the cache, creates a VersionClaim in the assets table with:
+#   id: "<atomId>-<version>"
+#   claimSource: UploadPipeline
+#
+# Uses batch-write-item for efficiency. Note: batch-write-item does not support
+# condition expressions, so existing items will be overwritten with the same data.
+# This is safe because the backfill only writes idempotent UploadPipeline claims.
+#
+# Usage:
+#   ./scripts/backfill-asset-versions.sh --stage PROD --profile media-service [--dry-run] [--region eu-west-1]
+
+STAGE=""
+PROFILE=""
+REGION="eu-west-1"
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stage)
+      STAGE="$2"
+      shift 2
+      ;;
+    --profile)
+      PROFILE="$2"
+      shift 2
+      ;;
+    --region)
+      REGION="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$STAGE" ]]; then
+  echo "Error: --stage is required (e.g. PROD, CODE)"
+  exit 1
+fi
+
+if [[ -z "$PROFILE" ]]; then
+  echo "Error: --profile is required (e.g. media-service)"
+  exit 1
+fi
+
+CACHE_TABLE="media-atom-pipeline-cache-${STAGE}"
+ASSETS_TABLE="media-atom-maker-${STAGE}-atom-assets"
+
+echo "Cache table:  ${CACHE_TABLE}"
+echo "Assets table: ${ASSETS_TABLE}"
+echo "Region:       ${REGION}"
+echo "Profile:      ${PROFILE}"
+echo "Dry run:      ${DRY_RUN}"
+echo ""
+
+INSERTED=0
+SKIPPED=0
+ERRORS=0
+TOTAL=0
+BATCH_SIZE=25
+# Number of items per scan page. Keeps each response small and makes the
+# pagination loop below process the table incrementally rather than loading it
+# all into memory at once.
+PAGE_SIZE=500
+
+# Writes a batch of items to DynamoDB using batch-write-item.
+# Retries unprocessed items with exponential backoff.
+write_batch() {
+  local request_json="$1"
+  local attempt=0
+  local max_attempts=5
+
+  while true; do
+    local result
+    if ! result=$(aws dynamodb batch-write-item \
+      --region "$REGION" \
+      --profile "$PROFILE" \
+      --request-items "$request_json" \
+      2>&1); then
+      echo "  ERROR: batch-write-item failed: ${result}"
+      local failed_count
+      failed_count=$(echo "$request_json" | jq ".\"${ASSETS_TABLE}\" | length")
+      ERRORS=$((ERRORS + failed_count))
+      return
+    fi
+
+    local unprocessed
+    unprocessed=$(echo "$result" | jq ".UnprocessedItems.\"${ASSETS_TABLE}\" // [] | length")
+
+    if [[ $unprocessed -eq 0 ]]; then
+      return
+    fi
+
+    attempt=$((attempt + 1))
+    if [[ $attempt -ge $max_attempts ]]; then
+      echo "  WARN: ${unprocessed} items still unprocessed after ${max_attempts} retries"
+      ERRORS=$((ERRORS + unprocessed))
+      return
+    fi
+
+    echo "  Retrying ${unprocessed} unprocessed items (attempt ${attempt})..."
+    request_json=$(echo "$result" | jq '.UnprocessedItems')
+    sleep $((2 ** attempt))
+  done
+}
+
+process_page() {
+  local page_json="$1"
+
+  local count
+  count=$(echo "$page_json" | jq '.Items | length')
+
+  local batch_items=()
+
+  for ((i = 0; i < count; i++)); do
+    TOTAL=$((TOTAL + 1))
+
+    local claim_id
+    claim_id=$(echo "$page_json" | jq -r ".Items[$i].id.S")
+
+    if [[ -z "$claim_id" || "$claim_id" == "null" ]]; then
+      echo "  WARN: Skipping item $i — missing id"
+      SKIPPED=$((SKIPPED + 1))
+      continue
+    fi
+
+    if $DRY_RUN; then
+      echo "  [DRY RUN] Would insert: ${claim_id}"
+      INSERTED=$((INSERTED + 1))
+      continue
+    fi
+
+    # Build item JSON safely with jq to prevent injection
+    local item_json
+    item_json=$(jq -n --arg id "$claim_id" \
+      '{PutRequest:{Item:{id:{S:$id},claimSource:{S:"UploadPipeline"}}}}')
+    batch_items+=("$item_json")
+
+    if [[ ${#batch_items[@]} -ge $BATCH_SIZE ]]; then
+      local request_json
+      request_json=$(printf '%s\n' "${batch_items[@]}" | jq -s --arg table "$ASSETS_TABLE" '{($table): .}')
+      local errors_before=$ERRORS
+      write_batch "$request_json"
+      local batch_count=${#batch_items[@]}
+      local new_errors=$((ERRORS - errors_before))
+      INSERTED=$((INSERTED + batch_count - new_errors))
+      echo "  Wrote batch of ${batch_count} items"
+      batch_items=()
+    fi
+  done
+
+  # Write remaining items
+  if [[ ${#batch_items[@]} -gt 0 ]] && ! $DRY_RUN; then
+    local request_json
+    request_json=$(printf '%s\n' "${batch_items[@]}" | jq -s --arg table "$ASSETS_TABLE" '{($table): .}')
+    local errors_before=$ERRORS
+    write_batch "$request_json"
+    local batch_count=${#batch_items[@]}
+    local new_errors=$((ERRORS - errors_before))
+    INSERTED=$((INSERTED + batch_count - new_errors))
+    echo "  Wrote batch of ${batch_count} items"
+  fi
+}
+
+echo "Scanning ${CACHE_TABLE}..."
+echo ""
+
+# Paginate through the full table using --starting-token
+PAGE=1
+NEXT_TOKEN=""
+
+while true; do
+  echo "Page ${PAGE}..."
+
+  SCAN_ARGS=(
+    dynamodb scan
+    --table-name "$CACHE_TABLE"
+    --region "$REGION"
+    --profile "$PROFILE"
+    --projection-expression "id"
+    --page-size "$PAGE_SIZE"
+    --max-items "$PAGE_SIZE"
+  )
+
+  if [[ -n "$NEXT_TOKEN" ]]; then
+    SCAN_ARGS+=(--starting-token "$NEXT_TOKEN")
+  fi
+
+  SCAN_RESULT=$(aws "${SCAN_ARGS[@]}")
+
+  process_page "$SCAN_RESULT"
+
+  NEXT_TOKEN=$(echo "$SCAN_RESULT" | jq -r '.NextToken // empty')
+  if [[ -z "$NEXT_TOKEN" ]]; then
+    break
+  fi
+
+  PAGE=$((PAGE + 1))
+done
+
+echo ""
+echo "Done."
+echo "  Total uploads processed: ${TOTAL}"
+echo "  Inserted:                ${INSERTED}"
+echo "  Skipped/already existed: ${SKIPPED}"
+echo "  Errors:                  ${ERRORS}"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?


**Depends on https://github.com/guardian/editorial-tools-platform/pull/1067.**

### Background

Media Atoms can have 'assets' (videos), and assets are mapped to atoms many-to-one.

We keep track of an atom's assets via 'asset version' numbers, incrementing each time a new asset is added. The problem is that there are two paths for adding a new asset to an atom which have inconsistent logic for assigning asset version numbers, leading to potential overwriting of data or false joins between assets and asset metadata.

#### Method 1: Adding via a pre-existing URL

If the user has already uploaded a video directly to YouTube, they can add the video to an atom using the YouTube URL.

When adding via URL, the `AddAssetCommand` looks at the existing assets array in the Atom model, finds the highest existing asset version number, and then increments it by 1.

<img width="278" height="253" alt="image" src="https://github.com/user-attachments/assets/7b780a7f-36b8-4b00-9e55-3cfd259272f0" />

#### Method 2: Adding via the upload pipeline

Most assets are added via the upload pipeline, which is run via an AWS Step Function. To initially calculate a version number, the `UploadController.create` method follows the same logic as Method 1 above. However, it also adds an additional check: if a Step Function execution already exists with the name `${atomId}-${assetVersionNumber}` then it will increment the proposed version number and then try again.

#### Consequences

* Race conditions: if `AddAssetCommand` and `UploadController.create` are invoked at roughly the same time, they can end up trying to claim the same asset version number. For instance, if you kick off an upload, and then add via URL before the upload pipeline has updated the atom model, then the URL asset will be added but then its data will be overwritten in the atom model by the upload pipeline once the latter has finished.
* False joins: if you add an asset via the upload pipeline, a record of the upload is kept in the uploads cache table. We use this table to provide metadata in the UI about when an asset was added and by whom. This upload metadata is joined to assets via the `${atomId}-${assetVersionNumber}` key. If you then delete the asset from the atom model, its version number is left available for the URL method to claim, but the UI will still join the new asset with the upload metadata for the previous asset because they share a version number. (Upload, delete, upload doesn't face this issue because it has the extra step function execution name check.)

### Proposed fix

Both asset-upload methods should use a shared version number claiming mechanism, instead.

```mermaid
flowchart TD
    subgraph UploadRoute[Upload pipeline]
        UploadPipeline[UploadController.create] --> UPCC[Claim version]
        UPCC --> OW1[Other work]
    end

    subgraph UrlRoute[URL route]
        URL[AddAssetCommand] --> URLCC[Claim version]
        URLCC --> OW2[Other work]
    end

    UPCC <--> VCC[VersionClaimChecker]
    VCC <--> URLCC

    OW1 --> Atom[Atom Model]
    OW2 --> Atom
```

The proposed implementation is to [create a new DynamoDB table](https://github.com/guardian/editorial-tools-platform/pull/1067) which both methods can use to conditionally write a 'claim' for a given asset version number for a given atom. If the conditional write fails, then we increment the proposed number and try again (similar to how the pipeline currently does with step function execution names). This makes the dynamo records the source of truth for both methods, and guarantees that the version id is already claimed before the atom model itself gets updated with the new version.

As a side benefit, we can store the upload metadata fields (who added it, when, and what was the original filename) in this new table. This means that we can display this metadata for assets added via upload pipeline (as we are already) and also for assets added via URL.

### Deployment plan

The new table only effectively becomes the source of truth once it has data for the most recent asset version in it.

If we just roll this code change out without backfilling the new table, it is expected to work as it currently does when calculating version numbers. So the failure case there is not catastrophic.

But to make it more likely that we'll avoid any future clashes due to the old logic, we can backfill the new table using the upload metadata cache. There is a backfill script in this branch which has been tested against CODE. Given that we're trying to sync two DynamoDB tables, I don't think there's an effective way to guarantee consistency, so there's a possibility of people adding new assets between the time we start running of the backfill script and the deployment of the new code. But again, the worst-case scenario here is effectively a regression to the existing behaviour until the new asset versions overtake the old ones.

Steps:

- [x] Merge the PR to create the new table (https://github.com/guardian/editorial-tools-platform/pull/1067)
- [x] Run the backfill script against PROD
- [x] Merge this PR
- [x] Check that everything is working as expected:
    - [x] Adding via Upload and URL still work
    - [x] Race conditions no longer cause overwrites
    - [x] Double check that we don't see any kind of runaway claiming process arising from the tail-recursive claim function


### What about subtitles?

Subtitles are added and deleted by re-running a pre-existing upload payload, to reprocess the video with new subtitle file. This edits the asset version 'in place', pointing it to a new hosted video, rather than adding a new asset version.

This runs a bit counter to the current PR, but the mechanism still works with the new code. Adding or removing subtitles doesn't involve making a new version claim; it just re-uses the existing version number for the asset in question. The upload pipeline executions which make the changes are created using a different schema from the original upload (`${atomId}-${assetVersionNumber}-${subtitleVersionNumber}` instead of `${atomId}-${assetVersionNumber}`) so they are not in competition for the same space.

That said, the same sort of race condition bugs exist for subtitle versions for the same reason as asset versions, so it would be nice to bring them into the same sort of claim system at some point if we have the chance.


## How has this change been tested?

- [x] Run backfill script
- [x] Deploy branch to CODE
- [x] Try to replicate the race condition described above, verify that it *doesn't* produce a conflict/overwrite anymore.

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
