### PR TITLE
Update video options for non-youtube (default) videos

### DIFF
--- a/public/video-ui/src/constants/videoCreateOptions.ts
+++ b/public/video-ui/src/constants/videoCreateOptions.ts
@@ -94,25 +94,25 @@ export const videoCreateOptions: {
         {
           id: "Default",
           title: "Non-YouTube",
-          description: "Use in limited circumstances (eg avoiding age restriction on platform)",
+          description: "Use for on-platform self-hosted videos (i.e vertical ‘shorts’)",
           specifications: {
             positive: [
-              "Manual play",
+              "Autoplay on Fronts",
+              "Manual play in article",
               "Optional dedicated video page",
               "Play / pause controls",
               "Progress bar and timeline scrubber",
               "Audio track and mute controls",
-              "Fullscreen controls"
+              "Fullscreen controls",
+              "Subtitles support"
             ],
             negative: [
-              "No subtitles support",
               "No share button",
               "No support for livestreaming"
             ],
             info: [
-              "Can be used in Articles only",
-              "Self-hosted",
-              "Different browsers (eg Firefox, Chrome) will use their own player to render these videos"
+              "Can be used in Articles and Fronts",
+              "Self-hosted"
             ]
           }
         }


### PR DESCRIPTION
## What does this changes
Updates the list of supported / unsupported features for non-youtube videos.

## How has this change been tested?
Deployed to CODE and checked the list of supported / unsupported features was correct. 

## How can we measure success?
List is up-to-date
## Have we considered potential risks?
N/A

## Images

### Before
<img width="747" height="336" alt="Screenshot 2026-06-18 at 13 55 33" src="https://github.com/user-attachments/assets/ec997554-bd1e-43b0-8491-5024d6147948" />

### After
<img width="2568" height="626" alt="Screenshot 2026-06-18 at 15 51 54" src="https://github.com/user-attachments/assets/7c54a7f6-7776-42c9-ab3e-79afd11f7b86" />

