### PR TITLE
Make UploadMetadata.version non-optional

### DIFF
--- a/app/util/UploadBuilder.scala
+++ b/app/util/UploadBuilder.scala
@@ -42,7 +42,7 @@ object UploadBuilder {
         startTimestamp = Instant.ofEpochMilli(currentTimestamp)
       ),
       originalFilename = Some(request.filename),
-      version = Some(assetVersion),
+      version = assetVersion,
       startTimestamp = currentTimestamp,
       hasAudio = None
     )
@@ -69,7 +69,7 @@ object UploadBuilder {
       upload: Upload,
       newSubtitleSource: Option[VideoSource]
   ): Upload = {
-    val assetVersion = upload.metadata.version.getOrElse(1L)
+    val assetVersion = upload.metadata.version
     val subtitleVersion = Upload.getNextSubtitleVersion(upload)
     val updatedAsset = getAsset(
       upload.metadata.selfHost,

--- a/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/UploadMetadata.scala
@@ -18,7 +18,7 @@ case class UploadMetadata(
     pluto: PlutoSyncMetadataMessage,
     iconikData: Option[IconikData],
     runtime: RuntimeUploadMetadata,
-    version: Option[Long] = None,
+    version: Long,
     selfHost: Boolean = false,
     asset: Option[VideoAsset] = None,
     originalFilename: Option[String] = None,

--- a/common/src/test/scala/com/gu/media/upload/UploadTest.scala
+++ b/common/src/test/scala/com/gu/media/upload/UploadTest.scala
@@ -121,7 +121,8 @@ class UploadTest
     runtime = SelfHostedUploadMetadata(Some(Nil)),
     subtitleVersion = Some(12),
     subtitleSource =
-      Some(VideoSource("uploads/123xyz-1/subtitles.srt", "video/mp4"))
+      Some(VideoSource("uploads/123xyz-1/subtitles.srt", "video/mp4")),
+    version = 1L
   )
 
   private def metadataWithoutSubtitle = UploadMetadata(
@@ -132,6 +133,7 @@ class UploadTest
     pluto = plutoMessage,
     iconikData = None,
     startTimestamp = 123456789L,
-    runtime = SelfHostedUploadMetadata(Some(Nil))
+    runtime = SelfHostedUploadMetadata(Some(Nil)),
+    version = 1L
   )
 }

--- a/test/controllers/UploadControllerTest.scala
+++ b/test/controllers/UploadControllerTest.scala
@@ -451,7 +451,8 @@ class UploadControllerTest extends AnyFlatSpec with Matchers {
         subtitleVersion =
           if (subtitleVersion > 0) Some(subtitleVersion) else None,
         startTimestamp = millis(started),
-        selfHost = true
+        selfHost = true,
+        version = videoVersion
       ),
       UploadProgress(1, 0, true, true, 0)
     )

--- a/test/model/ClientAssetTest.scala
+++ b/test/model/ClientAssetTest.scala
@@ -135,7 +135,8 @@ class ClientAssetTest extends AnyFunSuite with Matchers {
       iconikData = None,
       null,
       originalFilename = Some("test.mp4"),
-      startTimestamp = 0L
+      startTimestamp = 0L,
+      version = 1L
     )
     val upload = Upload("test", parts, metadata, progress)
 

--- a/test/util/UploadBuilderTest.scala
+++ b/test/util/UploadBuilderTest.scala
@@ -95,7 +95,7 @@ class UploadBuilderTest extends AnyFlatSpec with Matchers {
         upload.metadata.runtime shouldBe SelfHostedUploadMetadata(jobs =
           Some(List())
         )
-        upload.metadata.version should contain(2L)
+        upload.metadata.version shouldBe 2L
         upload.metadata.selfHost shouldBe true
         upload.metadata.asset shouldBe Some(
           SelfHostedAsset(sources =

--- a/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/AddAssetToAtom.scala
@@ -61,9 +61,7 @@ class AddAssetToAtom
     val user = getUser(upload.metadata.user)
 
     val after = updateAtom(before, user) { mediaAtom =>
-      val assetVersion = upload.metadata.version.getOrElse(
-        getNextAssetVersion(mediaAtom)
-      )
+      val assetVersion = upload.metadata.version
 
       val asset = getAsset(upload, assetVersion)
 

--- a/uploader/src/main/scala/com/gu/media/upload/SendToTranscoderV2.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/SendToTranscoderV2.scala
@@ -38,7 +38,7 @@ class SendToTranscoderV2
     val key = TranscoderOutputKey(
       upload.metadata.title,
       upload.metadata.pluto.atomId,
-      upload.metadata.version.getOrElse(1L),
+      upload.metadata.version,
       upload.metadata.subtitleVersion.getOrElse(0L),
       None,
       Instant.ofEpochMilli(upload.metadata.startTimestamp)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Converts the `UploadMetadata.version` field from `Option[Long]` to `Long`.

As far as I can tell, we would *like* the version number to be required, rather than optional. It would also make it easier to make the way we version assets more consistent.

### Existing writes

There are no code paths in MAM where we had been constructing a `UploadMetadata` instance without providing a `Some(Long)` value.

### Existing reads

We read UploadMetadata from two places:

1. The `Upload` payload that's passed around as input for the step function steps.
2. The upload cache DynamoDB table.

The step functions consume inputs that are generated by other parts of this codebase. As mentioned above, it was never being set to `None` in the first instance. And on top of that, the step functions shouldn't be editing the version number.

The upload cache table is read in order to enhance the assets view in the MAM UI (populated by `GET /api/uploads    controllers.UploadController.list(atomId)`). If the `metadata.version` field is missing in the table, then Scanamo would fail to validate the item as an instance of `UploadMetadata`.

#### What happens if `metadata.version` is missing in the DynamoDB table?

The entry for a given asset version `n` for a given atom `A` will only be read on demand when hitting `/api/uploads/A`. If `A` currently has an asset with version `1`, it will look up `A-1` in the table. If the item is malformed, Scanamo will treat it the same as if the item wasn't present. In this case, the application code falls back to querying the step function history. If it finds a valid record in either case then it will add some metadata to `A-1` in the response, which populates the original filename and upload time in the UI.

<img width="421" height="339" alt="image" src="https://github.com/user-attachments/assets/73034203-dc69-4bbd-8eac-90339b7702d1" />

If it doesn't find a valid record, it defaults to a plain record without this extra metadata:

<img width="418" height="344" alt="image" src="https://github.com/user-attachments/assets/09a67720-0964-4c02-9ba8-c7f4daf2f78e" />

So, the fallback behaviour is sensible -- the worst case scenario is that we miss this bit of metadata.

#### Are there any records in the Dynamo table without this property?

I scanned the table and the only items I found in the DynamoDB table that were missing the `metadata.version` field had id keys of an unexpected format, e.g. `094f599d-609c-4d4a-9afd-70f388f290e2--56045e10-b84a-4940-8953-d7c97254ee47` instead of `094f599d-609c-4d4a-9afd-70f388f290e2-1`.

As a result, the uploads endpoint doesn't find these items anyway, so it doesn't show the extra metadata in the UI for these assets. It will continue to miss these items, so they won't actually fail to validate because they won't be read in at all. However, if they were read in and failed to validate then as described above the fallback behaviour would be equivalent to now: no extra metadata in the UI.

We considered backfilling these upload records to the recognised format, but we can't say with confidence which asset versions they each would apply to, so it feels more sensible for now to leave them as they are rather than potentially fabricating which belongs to which asset. The multimedia folks have expressed an interest in keeping this data though, so we're leaving it in the database table.

All of the problematic assets uploads are from 2017, and I believe they are all entries that were added before https://github.com/guardian/media-atom-maker/pull/618

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

- [x] Deploy to CODE
- [x] Find an old atom whose Upload pipeline runs won't be stored any more (e.g. `6e82d086-e34a-4a88-95ab-10d32821de11`)
- [x] Delete the `version` field from the `media-atom-pipeline-cache-CODE` for an asset associated with that atom
- [x] Refresh the page and note that the upload time and original filename no longer show, but other than that everything works as usual.

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
