### PR TITLE
Define encoding config less verbosely

### DIFF
--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/EncodingConfig.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/EncodingConfig.scala
@@ -1,47 +1,40 @@
 package com.gu.media.upload.mediaconvert
 
+import com.gu.media.upload.mediaconvert.SharedCodecSettings.{h264Settings}
+import software.amazon.awssdk.services.mediaconvert.model.{
+  VideoCodec,
+  VideoCodecSettings
+}
+
 case class Dimensions(width: Option[Int], height: Option[Int])
 
 sealed trait EncodingConfig {
   def dimensions: Dimensions
-  def nameModifier: String
+  def nameModifier: String = {
+    val dimensionPart = List(
+      dimensions.width.map(w => s"${w}w"),
+      dimensions.height.map(h => s"${h}h")
+    ).flatten.mkString("_")
+
+    s"_${dimensionPart}_q${qualityLevel}"
+  }
   def qualityLevel: Int
+  def codecSettings: VideoCodecSettings
+}
+
+case class H264EncodingConfig(
+    dimensions: Dimensions,
+    qualityLevel: Int
+) extends EncodingConfig {
+  override def codecSettings: VideoCodecSettings = VideoCodecSettings
+    .builder()
+    .codec(VideoCodec.H_264)
+    .h264Settings(h264Settings(qualityLevel))
+    .build()
 }
 
 object EncodingConfigs {
-  case object Default extends EncodingConfig {
-    val dimensions = Dimensions(None, Some(720))
-    val nameModifier = "_720h"
-    val qualityLevel = 8
-  }
+  val Default = H264EncodingConfig(Dimensions(None, Some(720)), 8)
 
-  case object MobileWidth extends EncodingConfig {
-    val dimensions = Dimensions(Some(480), None)
-    val nameModifier = "_480w"
-    val qualityLevel = 8
-  }
-
-  case object LowQuality extends EncodingConfig {
-    val dimensions = Dimensions(None, Some(720))
-    val nameModifier = "_720h_q6"
-    val qualityLevel = 6
-  }
-
-  case object LowQualityMobileWidth extends EncodingConfig {
-    val dimensions = Dimensions(Some(480), None)
-    val nameModifier = "_480w_q6"
-    val qualityLevel = 6
-  }
-
-  case object VeryLowQuality extends EncodingConfig {
-    val dimensions = Dimensions(None, Some(720))
-    val nameModifier = "_720h_q4"
-    val qualityLevel = 4
-  }
-
-  case object VeryLowQualityMobileWidth extends EncodingConfig {
-    val dimensions = Dimensions(Some(480), None)
-    val nameModifier = "_480w_q4"
-    val qualityLevel = 4
-  }
+  val MobileWidth = H264EncodingConfig(Dimensions(Some(480), None), 8)
 }

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/HLSOutputGroup.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/HLSOutputGroup.scala
@@ -2,7 +2,12 @@ package com.gu.media.upload.mediaconvert.hls
 
 import com.gu.contentatom.thrift.atom.media.AssetType
 import com.gu.media.model.VideoSource
-import com.gu.media.upload.mediaconvert.{EncodingConfigs, OutputGroupDefinition}
+import com.gu.media.upload.mediaconvert.{
+  Dimensions,
+  EncodingConfig,
+  H264EncodingConfig,
+  OutputGroupDefinition
+}
 import software.amazon.awssdk.services.mediaconvert.model.{
   CmafGroupSettings,
   CmafWriteDASHManifest,
@@ -12,16 +17,29 @@ import software.amazon.awssdk.services.mediaconvert.model.{
 }
 
 object HLSOutputGroup {
+
+  private val commonDimensions = List(
+    Dimensions(Some(480), None),
+    Dimensions(None, Some(720))
+  )
+
+  private val outputDefinitions: List[
+    ((Dimensions, Int) => EncodingConfig, List[Dimensions], List[Int])
+  ] = List(
+    (H264EncodingConfig, commonDimensions, List(8, 6, 4))
+  )
+
+  private val videoOutputs = for {
+    (encodingConfig, dimensions, qualities) <- outputDefinitions
+    dimension <- dimensions
+    quality <- qualities
+  } yield VideoOutput(encodingConfig(dimension, quality))
+
   def apply(hasAudio: Boolean): OutputGroupDefinition = {
-    val outputs = List(
-      VideoOutput(EncodingConfigs.MobileWidth),
-      VideoOutput(EncodingConfigs.Default),
-      VideoOutput(EncodingConfigs.LowQuality),
-      VideoOutput(EncodingConfigs.LowQualityMobileWidth),
-      VideoOutput(EncodingConfigs.VeryLowQuality),
-      VideoOutput(EncodingConfigs.VeryLowQualityMobileWidth),
-      CaptionsOutput()
-    ) ++ (if (hasAudio) List(AudioOutput()) else Nil)
+    val outputs = videoOutputs ++
+      List(CaptionsOutput()) ++
+      List(AudioOutput()).filter(_ => hasAudio)
+
     OutputGroupDefinition(
       mimeType = Some(VideoSource.mimeTypeM3u8),
       assetType = Some(


### PR DESCRIPTION
### Summary

Refactor of `EncodingConfig` and `HLSOutputGroup` to eliminate the repetitive hand-enumerated encoding config objects, replacing them with a data-driven approach. The previous approach is not sustainable when we add AV1 as an additional codec. Also adds a quality suffix to the q8 outputs so they are identifiable in log analysis.

### Changes

#### `EncodingConfig.scala`

- `EncodingConfig` is now an abstract type with a derived `nameModifier` implementation — the name is computed from `dimensions` and `qualityLevel` rather than hardcoded per variant (e.g. `_480w_q8`, `_720h_q6`).
- Adds a concrete subclass `H264EncodingConfig(dimensions, qualityLevel)` which carries the `VideoCodecSettings` for H.264, making it straightforward to add other codecs (e.g. AV1) later by adding further subclasses.
- `EncodingConfigs` is simplified to just `Default` and `MobileWidth` as named aliases used by the FileOutputGrouo. The full matrix of quality variants used in HLS/M3U8 is now generated in `HLSOutputGroup`.
- The q8 outputs now include the quality in their name modifier (e.g. `_480w_q8` instead of `_480w`), making naming consistent and visible across all outputs in logs.

#### `HLSOutputGroup.scala`

- The explicit list of six `VideoOutput(...)` calls is replaced by a for-comprehension over `(codec factory, dimensions, quality levels)` tuples, currently containing a single entry for H.264 across `[480w, 720h]` × `[q8, q6, q4]`.
- Adding a new codec (e.g. AV1) will require adding one line to `outputDefinitions` rather than duplicating six more `VideoOutput` calls.
- Audio/captions output construction is unchanged in behaviour.