### PR TITLE
On-demand billing for upload cache table

### DIFF
--- a/uploader/src/main/resources/cfn-template.yaml
+++ b/uploader/src/main/resources/cfn-template.yaml
@@ -383,9 +383,7 @@ Resources:
       KeySchema:
       - AttributeName: id
         KeyType: HASH
-      ProvisionedThroughput:
-        ReadCapacityUnits: '5'
-        WriteCapacityUnits: '5'
+      BillingMode: PAY_PER_REQUEST
       Tags:
         - Key: devx-backup-enabled
           Value: true


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Removes provisioning from the DynamoDB tables used for the uploads cache, in favour of on-demand billing. We don't use anything like the provisioned capacity, and we have cost anomaly alerts set up for this account.