### PR TITLE
Revert "Define encoding config less verbosely"

### DIFF
--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/EncodingConfig.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/EncodingConfig.scala
@@ -1,40 +1,47 @@
 package com.gu.media.upload.mediaconvert
 
-import com.gu.media.upload.mediaconvert.SharedCodecSettings.{h264Settings}
-import software.amazon.awssdk.services.mediaconvert.model.{
-  VideoCodec,
-  VideoCodecSettings
-}
-
 case class Dimensions(width: Option[Int], height: Option[Int])
 
 sealed trait EncodingConfig {
   def dimensions: Dimensions
-  def nameModifier: String = {
-    val dimensionPart = List(
-      dimensions.width.map(w => s"${w}w"),
-      dimensions.height.map(h => s"${h}h")
-    ).flatten.mkString("_")
-
-    s"_${dimensionPart}_q${qualityLevel}"
-  }
+  def nameModifier: String
   def qualityLevel: Int
-  def codecSettings: VideoCodecSettings
-}
-
-case class H264EncodingConfig(
-    dimensions: Dimensions,
-    qualityLevel: Int
-) extends EncodingConfig {
-  override def codecSettings: VideoCodecSettings = VideoCodecSettings
-    .builder()
-    .codec(VideoCodec.H_264)
-    .h264Settings(h264Settings(qualityLevel))
-    .build()
 }
 
 object EncodingConfigs {
-  val Default = H264EncodingConfig(Dimensions(None, Some(720)), 8)
+  case object Default extends EncodingConfig {
+    val dimensions = Dimensions(None, Some(720))
+    val nameModifier = "_720h"
+    val qualityLevel = 8
+  }
 
-  val MobileWidth = H264EncodingConfig(Dimensions(Some(480), None), 8)
+  case object MobileWidth extends EncodingConfig {
+    val dimensions = Dimensions(Some(480), None)
+    val nameModifier = "_480w"
+    val qualityLevel = 8
+  }
+
+  case object LowQuality extends EncodingConfig {
+    val dimensions = Dimensions(None, Some(720))
+    val nameModifier = "_720h_q6"
+    val qualityLevel = 6
+  }
+
+  case object LowQualityMobileWidth extends EncodingConfig {
+    val dimensions = Dimensions(Some(480), None)
+    val nameModifier = "_480w_q6"
+    val qualityLevel = 6
+  }
+
+  case object VeryLowQuality extends EncodingConfig {
+    val dimensions = Dimensions(None, Some(720))
+    val nameModifier = "_720h_q4"
+    val qualityLevel = 4
+  }
+
+  case object VeryLowQualityMobileWidth extends EncodingConfig {
+    val dimensions = Dimensions(Some(480), None)
+    val nameModifier = "_480w_q4"
+    val qualityLevel = 4
+  }
 }

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/HLSOutputGroup.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/HLSOutputGroup.scala
@@ -2,12 +2,7 @@ package com.gu.media.upload.mediaconvert.hls
 
 import com.gu.contentatom.thrift.atom.media.AssetType
 import com.gu.media.model.VideoSource
-import com.gu.media.upload.mediaconvert.{
-  Dimensions,
-  EncodingConfig,
-  H264EncodingConfig,
-  OutputGroupDefinition
-}
+import com.gu.media.upload.mediaconvert.{EncodingConfigs, OutputGroupDefinition}
 import software.amazon.awssdk.services.mediaconvert.model.{
   CmafGroupSettings,
   CmafWriteDASHManifest,
@@ -17,29 +12,16 @@ import software.amazon.awssdk.services.mediaconvert.model.{
 }
 
 object HLSOutputGroup {
-
-  private val commonDimensions = List(
-    Dimensions(Some(480), None),
-    Dimensions(None, Some(720))
-  )
-
-  private val outputDefinitions: List[
-    ((Dimensions, Int) => EncodingConfig, List[Dimensions], List[Int])
-  ] = List(
-    (H264EncodingConfig, commonDimensions, List(8, 6, 4))
-  )
-
-  private val videoOutputs = for {
-    (encodingConfig, dimensions, qualities) <- outputDefinitions
-    dimension <- dimensions
-    quality <- qualities
-  } yield VideoOutput(encodingConfig(dimension, quality))
-
   def apply(hasAudio: Boolean): OutputGroupDefinition = {
-    val outputs = videoOutputs ++
-      List(CaptionsOutput()) ++
-      List(AudioOutput()).filter(_ => hasAudio)
-
+    val outputs = List(
+      VideoOutput(EncodingConfigs.MobileWidth),
+      VideoOutput(EncodingConfigs.Default),
+      VideoOutput(EncodingConfigs.LowQuality),
+      VideoOutput(EncodingConfigs.LowQualityMobileWidth),
+      VideoOutput(EncodingConfigs.VeryLowQuality),
+      VideoOutput(EncodingConfigs.VeryLowQualityMobileWidth),
+      CaptionsOutput()
+    ) ++ (if (hasAudio) List(AudioOutput()) else Nil)
     OutputGroupDefinition(
       mimeType = Some(VideoSource.mimeTypeM3u8),
       assetType = Some(


### PR DESCRIPTION
Reverts guardian/media-atom-maker#1605 as a CMAF bug is preventing atoms from being updated. 

