### PR TITLE
Revert "try running all lambdas, including ffmpeg calling lambdas, under arm64"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -200,9 +200,9 @@ lazy val uploader = (project in file("uploader"))
         log.info("Downloading statically compiled FFmpeg binary")
         IO.createDirectory(ffmpegFolder)
         import scala.sys.process.*
-        val archive = target.value / "ffmpeg" / "ffmpeg-release-arm64-static.tar.xz"
-        s"wget -nv https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.tar.xz -O $archive".!!
-        (s"tar xOf $archive ffmpeg-7.0.2-arm64-static/ffmpeg" #> binary).!!
+        val archive = target.value / "ffmpeg" / "ffmpeg-release-amd64-static.tar.xz"
+        s"wget -nv https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz -O $archive".!!
+        (s"tar xOf $archive ffmpeg-7.0.2-amd64-static/ffmpeg" #> binary).!!
       }
 
       binary -> "bin/ffmpeg"

--- a/uploader/src/main/resources/lambda-template.yaml
+++ b/uploader/src/main/resources/lambda-template.yaml
@@ -27,7 +27,7 @@
     MemorySize: {{memory}}
 # Architecture specified to match version of ffmpeg used to inject subtitles into mp4
     Architectures:
-      - "arm64"
+      - "x86_64"
     Role: !GetAtt LambdaExecutionRole.Arn
     Runtime: "java21"
     Timeout: {{timeout}}


### PR DESCRIPTION
Reverts guardian/media-atom-maker#1585

Reverted because ffmpeg on arm64 isn't happy with resolving domain names

`Failed to resolve hostname [REDACTED]: System error`

This matches the caveat noted on the static ffmpeg distribution url: `Notes:  A limitation of statically linking glibc is the loss of DNS resolution. Installing nscd through your package manager will fix this.` However this doesn't seem to apply when running on the x64 lambda image... we're not sure why.