### PR TITLE
Add additional logging to audio check

### DIFF
--- a/uploader/src/main/scala/com/gu/media/upload/FfMpeg.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/FfMpeg.scala
@@ -60,6 +60,7 @@ object FfMpeg extends Logging {
 
     val cmd =
       s"${ffmpegPath} -seekable 1 -i \"$video\" -filter:a volumedetect -f null /dev/null"
+    log.info(s"Running FfMpeg audio detection with command: $cmd")
     val exitCode = Process(cmd, cwd = None).!(
       ProcessLogger(stdout.append(_), ffMpegStdErrLogger.append)
     )
@@ -82,6 +83,11 @@ object FfMpeg extends Logging {
         val audioStream = findRegexMatch(audioStreamRegex, output)
         val videoStream = findRegexMatch(videoStreamRegex, output)
 
+        log.info(
+          s"FfMpeg audio detection succeeded. maxVolume=${maxVolume
+              .getOrElse("not found")}, audioStreamPresent=${audioStream.isDefined}, videoStreamPresent=${videoStream.isDefined}"
+        )
+
         (maxVolume, audioStream, videoStream) match {
 
           case (Some(db), _, _) =>
@@ -92,7 +98,9 @@ object FfMpeg extends Logging {
             true /* Couldn't parse volume and there are no audio or video streams, so we return true for safety*/
         }
       case _ =>
-        log.error("FfMpeg audio detection failed")
+        log.error(
+          s"FfMpeg audio detection failed (exit code: $exitCode). FfMpeg output:\n${ffMpegStdErrLogger.getOutput}"
+        )
         true /* Audio detection failure is not a critical error, so we return true rather than throwing an exception */
     }
   }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
