### PR TITLE
Fix audio detection logic to default to  false for hasAudio on detect…

### DIFF
--- a/uploader/src/main/scala/com/gu/media/upload/FfMpeg.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/FfMpeg.scala
@@ -23,9 +23,9 @@ object FfMpeg extends Logging {
   private val AWSLambdaFfmpegPath = "/var/task/bin/ffmpeg"
 
   private case class FfMpegSubprocessCrashedException(
-      exitCode: Int,
-      stderr: String
-  ) extends Exception(s"Exit code: $exitCode: ${stderr}")
+                                                       exitCode: Int,
+                                                       stderr: String
+                                                     ) extends Exception(s"Exit code: $exitCode: ${stderr}")
 
   def addSubtitlesToMP4(video: Path, subtitles: Path, output: Path): Path = {
     val ffMpegStdErrLogger = new BasicStdErrLogger()
@@ -49,9 +49,9 @@ object FfMpeg extends Logging {
   }
 
   def checkAudioExists(
-      video: String,
-      ffmpegPath: String = AWSLambdaFfmpegPath
-  ): Boolean = {
+                        video: String,
+                        ffmpegPath: String = AWSLambdaFfmpegPath
+                      ): Boolean = {
 
     /* @see https://aws.amazon.com/blogs/media/detect-silent-audio-tracks-in-vod-content-with-aws-elemental-mediaconvert/ */
     val SILENT_THRESHOLD = -50
@@ -87,13 +87,18 @@ object FfMpeg extends Logging {
           case (Some(db), _, _) =>
             db > SILENT_THRESHOLD /* We treat near-silence as no audio */
           case (None, None, Some(video)) =>
-            false /* Couldn't parse volume, audio streams are absent, but video streams are present. We assume from this that the video is silent */
+            false /* No volume reading and no audio stream, but a video stream is present. Treat as silent (no AudioOutput added to HLS group) */
           case (None, _, _) =>
-            true /* Couldn't parse volume and there are no audio or video streams, so we return true for safety*/
-        }
+            false /* No volume reading and no audio/video streams detected. Default to false so no empty AudioOutput is added to the HLS group */        }
       case _ =>
         log.error("FfMpeg audio detection failed")
-        true /* Audio detection failure is not a critical error, so we return true rather than throwing an exception */
+        /*
+        * Default to false on detection failure (rather than throwing).
+        * `hasAudio` decides whether an AudioOutput is added to the HLSOutputGroup
+        * (see HLSOutputGroup.scala).
+        * Default to false so no empty AudioOutput is added to the HLS group *
+        */
+        false
     }
   }
 


### PR DESCRIPTION
## What does this change?
Re-introduces https://github.com/guardian/media-atom-maker/pull/1600  which was reverted in https://github.com/guardian/media-atom-maker/pull/1607 whilst an error with uploading atoms was investigated. 
This branch also introduces change to hasAudio, detailed below.

Fix audio detection logic so that it default to false for hasAudio on detection failure.

`hasAudio` decides whether an AudioOutput is added to the HLSOutputGroup (see HLSOutputGroup.scala). Defaulting to true would adds an empty audio output to the HLS outputs and produce a broken transcode, so false is the safe fallback when we can't determine whether audio is present.

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
