### PR TITLE
Revert "Revert "Switch HLS output to CMAF (in preparation for AV1)""

### DIFF
--- a/app/util/StepFunctions.scala
+++ b/app/util/StepFunctions.scala
@@ -46,6 +46,8 @@ class StepFunctions(awsConfig: AWSConfig) {
         try {
           Some((Json.parse(cause) \ "errorMessage").as[String])
         } catch {
+          case _: NullPointerException =>
+            Some("Execution failed but no error message was provided")
           case _: JsonParseException | _: JsResultException =>
             Some(cause)
         }

--- a/common/src/main/scala/com/gu/media/upload/model/MediaConvertEvent.scala
+++ b/common/src/main/scala/com/gu/media/upload/model/MediaConvertEvent.scala
@@ -83,7 +83,7 @@ object MediaConvertVideoDetails {
 }
 
 case class MediaConvertOutputDetails(
-    outputFilePaths: List[String],
+    outputFilePaths: Option[List[String]],
     durationInMs: Long,
     videoDetails: Option[MediaConvertVideoDetails]
 )

--- a/common/src/test/scala/com/gu/media/upload/model/MediaConvertEventTest.scala
+++ b/common/src/test/scala/com/gu/media/upload/model/MediaConvertEventTest.scala
@@ -218,4 +218,218 @@ class MediaConvertEventTest extends AnyFlatSpec with Matchers {
     val parsedJson = Json.parse(json)
     Json.toJson(parsedJson.as[MediaConvertEvent]) shouldBe parsedJson
   }
+
+  "MediaConvertEvent" should "transparently deserialise and serialise CMAF event which does not have outputFilePaths" in {
+    val json =
+      """{
+        |  "version": "0",
+        |  "id": "20b3a8db-8153-b68c-824e-6c970c8565c4",
+        |  "detail-type": "MediaConvert Job State Change",
+        |  "source": "aws.mediaconvert",
+        |  "account": "563563610310",
+        |  "time": "2026-06-16T15:26:14Z",
+        |  "region": "eu-west-1",
+        |  "resources": [
+        |    "arn:aws:mediaconvert:eu-west-1:563563610310:jobs/1781623407306-4bov8h"
+        |  ],
+        |  "detail": {
+        |    "timestamp": 1781623574418,
+        |    "accountId": "563563610310",
+        |    "queue": "arn:aws:mediaconvert:eu-west-1:563563610310:queues/Default",
+        |    "jobId": "1781623407306-4bov8h",
+        |    "status": "COMPLETE",
+        |    "userMetadata": {
+        |      "stage": "DEV",
+        |      "executionId": "arn:aws:states:eu-west-1:563563610310:execution:VideoPipelineDEV-PGZ5E0CNI0QG:7da36eb3-442f-4b56-a411-0031956343d7-8",
+        |      "hasAudio": "true"
+        |    },
+        |    "outputGroupDetails": [
+        |      {
+        |        "outputDetails": [
+        |          {
+        |            "outputFilePaths": [
+        |              "s3://uploads-origin.code.dev-guim.co.uk/2026/06/16/WS_Change_tags_label--7da36eb3-442f-4b56-a411-0031956343d7-8.0_480w_q8_h264.mp4"
+        |            ],
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 480,
+        |              "heightInPx": 854,
+        |              "averageBitrate": 1676481,
+        |              "qvbrAvgQuality": 8.0,
+        |              "qvbrMinQuality": 8.0,
+        |              "qvbrMaxQuality": 8.0,
+        |              "qvbrMinQualityLocation": 0,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "outputFilePaths": [
+        |              "s3://uploads-origin.code.dev-guim.co.uk/2026/06/16/WS_Change_tags_label--7da36eb3-442f-4b56-a411-0031956343d7-8.0_720h_q8_h264.mp4"
+        |            ],
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 406,
+        |              "heightInPx": 720,
+        |              "averageBitrate": 1297659,
+        |              "qvbrAvgQuality": 8.0,
+        |              "qvbrMinQuality": 8.0,
+        |              "qvbrMaxQuality": 8.0,
+        |              "qvbrMinQualityLocation": 0,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "outputFilePaths": [
+        |              "s3://uploads-origin.code.dev-guim.co.uk/2026/06/16/WS_Change_tags_label--7da36eb3-442f-4b56-a411-0031956343d7-8.0.0000000.jpg"
+        |            ],
+        |            "durationInMs": 1000,
+        |            "videoDetails": {
+        |              "widthInPx": 1080,
+        |              "heightInPx": 1920,
+        |              "averageBitrate": 467499
+        |            }
+        |          },
+        |          {
+        |            "outputFilePaths": [
+        |              "s3://uploads-origin.code.dev-guim.co.uk/2026/06/16/WS_Change_tags_label--7da36eb3-442f-4b56-a411-0031956343d7-8.0.vtt"
+        |            ],
+        |            "durationInMs": 0
+        |          }
+        |        ],
+        |        "type": "FILE_GROUP"
+        |      },
+        |      {
+        |        "outputDetails": [
+        |          {
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 480,
+        |              "heightInPx": 854,
+        |              "averageBitrate": 1689527,
+        |              "qvbrAvgQuality": 8.0,
+        |              "qvbrMinQuality": 8.0,
+        |              "qvbrMaxQuality": 8.0,
+        |              "qvbrMinQualityLocation": 0,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 406,
+        |              "heightInPx": 720,
+        |              "averageBitrate": 1306322,
+        |              "qvbrAvgQuality": 8.0,
+        |              "qvbrMinQuality": 8.0,
+        |              "qvbrMaxQuality": 8.0,
+        |              "qvbrMinQualityLocation": 0,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 480,
+        |              "heightInPx": 854,
+        |              "averageBitrate": 607638,
+        |              "qvbrAvgQuality": 8.0,
+        |              "qvbrMinQuality": 7.86,
+        |              "qvbrMaxQuality": 8.0,
+        |              "qvbrMinQualityLocation": 79320,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 406,
+        |              "heightInPx": 720,
+        |              "averageBitrate": 479797,
+        |              "qvbrAvgQuality": 8.0,
+        |              "qvbrMinQuality": 7.86,
+        |              "qvbrMaxQuality": 8.0,
+        |              "qvbrMinQualityLocation": 41800,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 406,
+        |              "heightInPx": 720,
+        |              "averageBitrate": 572952,
+        |              "qvbrAvgQuality": 6.0,
+        |              "qvbrMinQuality": 6.0,
+        |              "qvbrMaxQuality": 6.0,
+        |              "qvbrMinQualityLocation": 0,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 480,
+        |              "heightInPx": 854,
+        |              "averageBitrate": 715475,
+        |              "qvbrAvgQuality": 6.0,
+        |              "qvbrMinQuality": 6.0,
+        |              "qvbrMaxQuality": 6.0,
+        |              "qvbrMinQualityLocation": 0,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 406,
+        |              "heightInPx": 720,
+        |              "averageBitrate": 262457,
+        |              "qvbrAvgQuality": 4.0,
+        |              "qvbrMinQuality": 4.0,
+        |              "qvbrMaxQuality": 4.0,
+        |              "qvbrMinQualityLocation": 0,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "durationInMs": 84360,
+        |            "videoDetails": {
+        |              "widthInPx": 480,
+        |              "heightInPx": 854,
+        |              "averageBitrate": 323519,
+        |              "qvbrAvgQuality": 4.0,
+        |              "qvbrMinQuality": 4.0,
+        |              "qvbrMaxQuality": 4.0,
+        |              "qvbrMinQualityLocation": 0,
+        |              "qvbrMaxQualityLocation": 0
+        |            }
+        |          },
+        |          {
+        |            "durationInMs": 0
+        |          },
+        |          {
+        |            "durationInMs": 84358
+        |          }
+        |        ],
+        |        "playlistFilePaths": [
+        |          "s3://uploads-origin.code.dev-guim.co.uk/2026/06/16/WS_Change_tags_label--7da36eb3-442f-4b56-a411-0031956343d7-8.0.mpd",
+        |          "s3://uploads-origin.code.dev-guim.co.uk/2026/06/16/WS_Change_tags_label--7da36eb3-442f-4b56-a411-0031956343d7-8.0.m3u8"
+        |        ],
+        |        "type": "CMAF_GROUP"
+        |      }
+        |    ],
+        |    "paddingInserted": 0,
+        |    "blackVideoDetected": 0,
+        |    "warnings": [
+        |      {
+        |        "code": 250003,
+        |        "count": 1
+        |      }
+        |    ]
+        |  }
+        |}
+        |""".stripMargin
+    val parsedJson = Json.parse(json)
+    Json.toJson(parsedJson.as[MediaConvertEvent]) shouldBe parsedJson
+  }
 }

--- a/uploader/src/main/scala/com/gu/media/upload/AddSubtitlesToMP4.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/AddSubtitlesToMP4.scala
@@ -60,7 +60,7 @@ class AddSubtitlesToMP4
   ): Option[String] = {
     // todo: use the mime type from the OutputDefinition instead of checking the file extension
     outputGroupDetails.outputDetails.view
-      .flatMap(_.outputFilePaths.find(_.endsWith(".vtt")))
+      .flatMap(_.outputFilePaths.flatMap(_.find(_.endsWith(".vtt"))))
       .headOption
   }
 
@@ -76,7 +76,8 @@ class AddSubtitlesToMP4
       if upload.metadata.subtitleSource.isDefined;
       outputDetails <- outputGroupDetails.outputDetails;
       // todo: use the mime type from the OutputDefinition instead of checking the file extension
-      path <- outputDetails.outputFilePaths.headOption if path.endsWith(".mp4")
+      path <- outputDetails.outputFilePaths.flatMap(_.headOption)
+      if path.endsWith(".mp4")
     ) {
       val subtitlesFile = createTempPath("input-subtitles-", ".srt")
       val videoFile = createTempPath("input-video-", ".mp4")

--- a/uploader/src/main/scala/com/gu/media/upload/FfMpeg.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/FfMpeg.scala
@@ -87,13 +87,19 @@ object FfMpeg extends Logging {
           case (Some(db), _, _) =>
             db > SILENT_THRESHOLD /* We treat near-silence as no audio */
           case (None, None, Some(video)) =>
-            false /* Couldn't parse volume, audio streams are absent, but video streams are present. We assume from this that the video is silent */
+            false /* No volume reading and no audio stream, but a video stream is present. Treat as silent (no AudioOutput added to HLS group) */
           case (None, _, _) =>
-            true /* Couldn't parse volume and there are no audio or video streams, so we return true for safety*/
+            false /* No volume reading and no audio/video streams detected. Default to false so no empty AudioOutput is added to the HLS group */
         }
       case _ =>
         log.error("FfMpeg audio detection failed")
-        true /* Audio detection failure is not a critical error, so we return true rather than throwing an exception */
+        /*
+         * Default to false on detection failure (rather than throwing).
+         * `hasAudio` decides whether an AudioOutput is added to the HLSOutputGroup
+         * (see HLSOutputGroup.scala).
+         * Default to false so no empty AudioOutput is added to the HLS group *
+         */
+        false
     }
   }
 

--- a/uploader/src/main/scala/com/gu/media/upload/TranscoderComplete.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/TranscoderComplete.scala
@@ -139,7 +139,7 @@ class TranscoderComplete
     (for {
       group <- outputGroups
       output <- group.outputDetails
-      filename <- output.outputFilePaths.headOption
+      filename <- output.outputFilePaths.flatMap(_.headOption)
       videoDetails <- output.videoDetails
       extension <- filename.split('.').lastOption
     } yield {

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/AudioOutput.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/AudioOutput.scala
@@ -1,0 +1,30 @@
+package com.gu.media.upload.mediaconvert.hls
+
+import com.gu.media.model.VideoSource
+import com.gu.media.upload.mediaconvert.OutputDefinition
+import com.gu.media.upload.mediaconvert.SharedCodecSettings.aacAudioDescription
+import software.amazon.awssdk.services.mediaconvert.model._
+
+object AudioOutput {
+  def apply(): OutputDefinition =
+    OutputDefinition(
+      mimeType = None,
+      assetType =
+        None, // Not currently used as an asset, as the m3u8 playlist is used instead
+      output = () => {
+        Output
+          .builder()
+          .containerSettings(
+            ContainerSettings
+              .builder()
+              .container(ContainerType.CMFC)
+              .cmfcSettings(CmfcSettings.builder().build())
+              .build()
+          )
+          .nameModifier("_audio")
+          .audioDescriptions(aacAudioDescription)
+          .build()
+      }
+    )
+
+}

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/CaptionsOutput.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/CaptionsOutput.scala
@@ -15,11 +15,11 @@ object CaptionsOutput {
         .containerSettings(
           ContainerSettings
             .builder()
-            .container(ContainerType.M3_U8)
-            .m3u8Settings(M3u8Settings.builder().build())
+            .container(ContainerType.CMFC)
+            .cmfcSettings(CmfcSettings.builder().build())
             .build()
         )
-        .nameModifier("captions")
+        .nameModifier("_captions")
         .captionDescriptions(
           CaptionDescription
             .builder()

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/HLSOutputGroup.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/HLSOutputGroup.scala
@@ -4,7 +4,8 @@ import com.gu.contentatom.thrift.atom.media.AssetType
 import com.gu.media.model.VideoSource
 import com.gu.media.upload.mediaconvert.{EncodingConfigs, OutputGroupDefinition}
 import software.amazon.awssdk.services.mediaconvert.model.{
-  HlsGroupSettings,
+  CmafGroupSettings,
+  CmafWriteDASHManifest,
   OutputGroup,
   OutputGroupSettings,
   OutputGroupType
@@ -13,14 +14,14 @@ import software.amazon.awssdk.services.mediaconvert.model.{
 object HLSOutputGroup {
   def apply(hasAudio: Boolean): OutputGroupDefinition = {
     val outputs = List(
-      VideoOutput(EncodingConfigs.MobileWidth, hasAudio),
-      VideoOutput(EncodingConfigs.Default, hasAudio),
-      VideoOutput(EncodingConfigs.LowQuality, hasAudio),
-      VideoOutput(EncodingConfigs.LowQualityMobileWidth, hasAudio),
-      VideoOutput(EncodingConfigs.VeryLowQuality, hasAudio),
-      VideoOutput(EncodingConfigs.VeryLowQualityMobileWidth, hasAudio),
+      VideoOutput(EncodingConfigs.MobileWidth),
+      VideoOutput(EncodingConfigs.Default),
+      VideoOutput(EncodingConfigs.LowQuality),
+      VideoOutput(EncodingConfigs.LowQualityMobileWidth),
+      VideoOutput(EncodingConfigs.VeryLowQuality),
+      VideoOutput(EncodingConfigs.VeryLowQualityMobileWidth),
       CaptionsOutput()
-    )
+    ) ++ (if (hasAudio) List(AudioOutput()) else Nil)
     OutputGroupDefinition(
       mimeType = Some(VideoSource.mimeTypeM3u8),
       assetType = Some(
@@ -30,17 +31,18 @@ object HLSOutputGroup {
       outputGroup = (destination: String) =>
         OutputGroup
           .builder()
-          .name("Apple HLS")
+          .name("CMAF HLS")
           .outputs(outputs.map(_.output()): _*)
           .outputGroupSettings(
             OutputGroupSettings
               .builder()
-              .`type`(OutputGroupType.HLS_GROUP_SETTINGS)
-              .hlsGroupSettings(
-                HlsGroupSettings
+              .`type`(OutputGroupType.CMAF_GROUP_SETTINGS)
+              .cmafGroupSettings(
+                CmafGroupSettings
                   .builder()
+                  .writeDashManifest(CmafWriteDASHManifest.DISABLED)
                   .segmentLength(10)
-                  .minSegmentLength(0)
+                  .fragmentLength(2)
                   .destination(destination)
                   .build()
               )

--- a/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/VideoOutput.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/mediaconvert/hls/VideoOutput.scala
@@ -1,31 +1,27 @@
 package com.gu.media.upload.mediaconvert.hls
 
 import com.gu.media.model.VideoSource
-import com.gu.media.upload.mediaconvert.OutputDefinition
-import com.gu.media.upload.mediaconvert.SharedCodecSettings.{
-  aacAudioDescription,
-  h264Settings
-}
+import com.gu.media.upload.mediaconvert.SharedCodecSettings.h264Settings
+import com.gu.media.upload.mediaconvert.{EncodingConfig, OutputDefinition}
 import software.amazon.awssdk.services.mediaconvert.model._
-import com.gu.media.upload.mediaconvert.EncodingConfig
 
 object VideoOutput {
-  def apply(config: EncodingConfig, hasAudio: Boolean): OutputDefinition =
+  def apply(config: EncodingConfig): OutputDefinition =
     OutputDefinition(
       mimeType = Some(VideoSource.mimeTypeM3u8),
       assetType =
         None, // Not currently used as an asset, as the m3u8 playlist which combines this and subtitles is used instead
       output = () => {
-        val outputBuilder = Output
+        Output
           .builder()
           .containerSettings(
             ContainerSettings
               .builder()
-              .container(ContainerType.M3_U8)
-              .m3u8Settings(M3u8Settings.builder().build())
+              .container(ContainerType.CMFC)
+              .cmfcSettings(CmfcSettings.builder().build())
               .build()
           )
-          .nameModifier(s"hls${config.nameModifier}")
+          .nameModifier(config.nameModifier)
           .videoDescription(
             VideoDescription
               .builder()
@@ -54,11 +50,7 @@ object VideoOutput {
               )
               .build()
           )
-
-        if (hasAudio)
-          outputBuilder.audioDescriptions(aacAudioDescription).build()
-        else outputBuilder.build()
+          .build()
       }
     )
-
 }


### PR DESCRIPTION
Reverts guardian/media-atom-maker#1607

Re-introduces https://github.com/guardian/media-atom-maker/pull/1600 which was reverted in https://github.com/guardian/media-atom-maker/pull/1607 whilst an error with uploading atoms was investigated.

This branch also introduces change to `hasAudio`, detailed below.

**Fix audio detection logic so that it default to false for hasAudio on detection failure.**

hasAudio decides whether an AudioOutput is added to the HLSOutputGroup (see HLSOutputGroup.scala). Defaulting to true would adds an empty audio output to the HLS outputs and produce a broken transcode, so false is the safe fallback when we can't determine whether audio is present.

The caveat here is that if audio detection check fails for a video that actually does have audio, the outputted video would be outputted without audio.