### PR TITLE
Testing : audio detection

### DIFF
--- a/uploader/src/main/scala/com/gu/media/upload/FfMpeg.scala
+++ b/uploader/src/main/scala/com/gu/media/upload/FfMpeg.scala
@@ -85,11 +85,11 @@ object FfMpeg extends Logging {
         (maxVolume, audioStream, videoStream) match {
 
           case (Some(db), _, _) =>
-            db > SILENT_THRESHOLD /* We treat near-silence as no audio */
+            true
           case (None, None, Some(video)) =>
-            false /* No volume reading and no audio stream, but a video stream is present. Treat as silent (no AudioOutput added to HLS group) */
+            true
           case (None, _, _) =>
-            false /* No volume reading and no audio/video streams detected. Default to false so no empty AudioOutput is added to the HLS group */
+            true
         }
       case _ =>
         log.error("FfMpeg audio detection failed")
@@ -99,7 +99,7 @@ object FfMpeg extends Logging {
          * (see HLSOutputGroup.scala).
          * Default to false so no empty AudioOutput is added to the HLS group *
          */
-        false
+        true
     }
   }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
