### PR TITLE
Fix first frame image name mismatch

### DIFF
--- a/app/model/commands/ActiveAssetCommand.scala
+++ b/app/model/commands/ActiveAssetCommand.scala
@@ -75,8 +75,7 @@ case class ActiveAssetCommand(
     val baseName =
       mp4Name
         .stripSuffix(".mp4")
-        .replaceAll("_(\\d+)(h|w)$", "")
-
+        .replaceAll("_(\\d+)(h|w)(_q\\d+)?$", "")
     baseName + VideoSource.firstFrameImageSuffix
   }
 

--- a/test/model/commands/ActiveAssetCommandTest.scala
+++ b/test/model/commands/ActiveAssetCommandTest.scala
@@ -61,6 +61,13 @@ class ActiveAssetCommandTest extends AnyFlatSpec with Matchers {
     command.firstFrameImageName(mp4Name) shouldBe expected
   }
 
+  "firstFrameImageName" should "return the name of the first frame image associated with an mp4 video that has a _480w & quality suffix" in {
+    val mp4Name =
+      "How_Trump_is_making_America_s_birthday_all_about_himself___video_--d5093b44-eecf-4a42-a2f5-fc187be09be7-2.1_480w_q8.mp4"
+    val expected =
+      "How_Trump_is_making_America_s_birthday_all_about_himself___video_--d5093b44-eecf-4a42-a2f5-fc187be09be7-2.1.0000000.jpg"
+    command.firstFrameImageName(mp4Name) shouldBe expected
+  }
   "autoFirstFrameImage" should "return the first frame of the requested video version, when there is no active video" in {
     val atom = mediaAtom(activeVersion = None)
     val newVersion: Long = 2L


### PR DESCRIPTION
## What does this change?
Add an optional quality suffix match to the regex for image name stripper along with a test. 

This is required as the image name is created on dynamically from the mp4 video name. As the mp4 can be appended with various suffixes, these need to be stripped out to ensure the names match. Without this, poster images aren't stored on the atom as the image can't be found. 

As the legacy comment states, the process should be made less brittle by using the MediaConvert event for the jpeg name, rather than dynamically building it. 
