### PR TITLE
Only fetch youtube category and channels for youtube videos

### DIFF
--- a/public/video-ui/src/pages/Upload/index.tsx
+++ b/public/video-ui/src/pages/Upload/index.tsx
@@ -13,7 +13,10 @@ import AddSelfHostedAsset from '../../components/VideoUpload/AddSelfHostedAsset'
 import { VideoTrail } from '../../components/VideoUpload/VideoTrail';
 import YoutubeUpload from '../../components/VideoUpload/YoutubeUpload';
 import { startVideoUpload } from '../../slices/s3Upload';
-import { fetchCategories, fetchChannels } from '../../slices/youtube';
+import {
+  fetchCategories as fetchYoutubeCategories,
+  fetchChannels as fetchYoutubeChannels
+} from '../../slices/youtube';
 import { AppDispatch, RootState } from '../../util/setupStore';
 
 export const VideoUpload = (props: { params: { id: string } }) => {
@@ -48,17 +51,24 @@ export const VideoUpload = (props: { params: { id: string } }) => {
 
   useEffect(() => {
     dispatch(getVideo(props.params.id));
-    if (store.youtube.categories.length === 0) {
-      dispatch(fetchCategories());
+    if (
+      store.video.platform === 'Youtube' &&
+      store.youtube.categories.length === 0
+    ) {
+      dispatch(fetchYoutubeCategories());
     }
-    if (store.youtube.channels.length === 0) {
-      dispatch(fetchChannels());
+    if (
+      store.video.platform === 'Youtube' &&
+      store.youtube.channels.length === 0
+    ) {
+      dispatch(fetchYoutubeChannels());
     }
   }, [
     dispatch,
     props.params.id,
     store.youtube.categories,
-    store.youtube.channels
+    store.youtube.channels,
+    store.video.platform
   ]);
 
   const isUploading = store.s3Upload.status === 'uploading';


### PR DESCRIPTION
## What does this change?
[Asana ticket for context](https://app.asana.com/1/1210045093164357/project/1213625402425263/task/1215374293358916?focus=true)
We shouldn't need to fetch Youtube categories and channels for non-Youtube videos


## How has this change been tested?

* Go to a non-YouTube video in MAM
* Click on 'Edit Assets' CTA under 'Video Preview'
* You should no longer see the 'Could not get YouTube channels' error banner

| Before   | After   |
| :----- | :---------------------------------------------------------------------- |
| <img width="1134" height="775" alt="Screenshot 2026-07-09 at 14 13 45" src="https://github.com/user-attachments/assets/ae4fdeec-e305-4239-affe-e09313b382a5" /> | <img width="1134" height="734" alt="Screenshot 2026-07-09 at 14 13 30" src="https://github.com/user-attachments/assets/65fccb18-13c2-460b-a1d0-4c5fe6595122" /> |

