### PR TITLE
Fix clientside state around scheduling and embargo

### DIFF
--- a/public/video-ui/src/actions/VideoActions/saveVideo.ts
+++ b/public/video-ui/src/actions/VideoActions/saveVideo.ts
@@ -11,14 +11,13 @@ import { AppDispatch } from '../../util/setupStore';
 const errorMessages = {
   saveVideoDefault: 'Could not save video',
   saveVideoConflict:
-    'Could not save video as another user (or tab) is currently editing this video',
+    'Could not save video as another user (or tab) has made changes to this video. Please refresh the page and try again.',
   fetchUsagesRejected: 'Could not fetch usages to update canonical page',
   canonicalPageUpdate: 'Could not update canonical page'
 };
 
 export const saveVideo = (video: Video) => async (dispatch: AppDispatch) => {
   dispatch(setSaving(true));
-  dispatch(setVideo(video));
 
   const savedVideo: Video = await VideosApi.saveVideo(video.id, video).catch(
     error => {

--- a/public/video-ui/src/components/ScheduledLaunch/ScheduledLaunch.jsx
+++ b/public/video-ui/src/components/ScheduledLaunch/ScheduledLaunch.jsx
@@ -123,7 +123,10 @@ class ScheduledLaunch extends React.Component {
         })
       })
     );
-    this.setState({ showDatePicker: false, [propertyName]: null });
+    this.setState({
+      showDatePicker: false,
+      [propertyName]: null
+    });
   };
 
   removeDate = propertyName => {
@@ -139,7 +142,10 @@ class ScheduledLaunch extends React.Component {
         })
       })
     );
-    this.setState({ showDatePicker: false, [propertyName]: null });
+    this.setState({
+      showDatePicker: false,
+      [propertyName]: null
+    });
   };
 
   getNoScheduleReason = () => {
@@ -308,7 +314,7 @@ class ScheduledLaunch extends React.Component {
   };
 
   render() {
-    const { video, videoEditOpen, hasPublishedVideoPageUsages } = this.props;
+    const { video, videoEditOpen } = this.props;
     const {
       selectedScheduleDate,
       selectedEmbargoDate,


### PR DESCRIPTION
## What does this change?
[Asana for context](https://app.asana.com/1/1210045093164357/project/1213625402425263/task/1213633225640663?focus=true)
* When a video is opened in multiple tabs, the UI state around scheduling and embargo isn't synced with BE response if the API call fails
* Currently, we set an optimistic update in the state, but that state isn't reverted when the API returns an error. Ideally, without a robust rollback mechanism, we should avoid optimistic update and point to BE as source of truth and only update the state if the API request is successful

To solve this particular problem: 
* I've removed the optimistic state update when saving the video. In a downstack PR (https://github.com/guardian/media-atom-maker/pull/1629) I've added some loading states to make up for that.
* I've updated the error message in case of this 409 error to `Could not save video as another user (or tab) has made changes to this video. Please refresh the page and try again.` to prompt user to refresh and sync to the latest video state. Alternatively we could also refetch the video for the user and update the state, but this seems to be a simple and clear solution.



## How has this change been tested?

<img width="1396" height="990" alt="fix fe state for scheduling and embargo" src="https://github.com/user-attachments/assets/b02f0b08-980d-4bcc-81a5-d4f19541a900" />


