### PR TITLE
Add year field to IconikCommission table

### DIFF
--- a/common/src/main/scala/com/gu/media/iconik/IconikModels.scala
+++ b/common/src/main/scala/com/gu/media/iconik/IconikModels.scala
@@ -44,7 +44,8 @@ object IconikWorkingGroup {
 case class IconikCommission(
     workingGroupId: String,
     id: String,
-    title: String
+    title: String,
+    year: Option[String] = None
 ) extends IconikItemWithParentId {
   val parentId: String = workingGroupId
 }
@@ -60,7 +61,8 @@ object IconikCommission {
     IconikCommission(
       id = req.commissionId,
       title = req.commissionTitle,
-      workingGroupId = req.workingGroupId
+      workingGroupId = req.workingGroupId,
+      year = req.yearName
     )
   }
 }
@@ -126,7 +128,8 @@ case class IconikUpsertRequest(
     commissionTitle: String,
     workingGroupId: String,
     workingGroupTitle: String,
-    masterPlaceholderId: Option[String]
+    masterPlaceholderId: Option[String],
+    yearName: Option[String]
 //    productionOffice: String, // don't know if we need this in Iconik world?
 )
 

--- a/pluto-message-ingestion/src/process-record.test.ts
+++ b/pluto-message-ingestion/src/process-record.test.ts
@@ -122,7 +122,8 @@ describe('processRecord', () => {
       commissionTitle: 'Iconik Commission',
       workingGroupId: 'wg-1',
       workingGroupTitle: 'Working Group 1',
-      masterPlaceholderId: 'mp-1'
+      masterPlaceholderId: 'mp-1',
+      yearName: '2026'
     };
 
     const record = {

--- a/pluto-message-ingestion/src/types.ts
+++ b/pluto-message-ingestion/src/types.ts
@@ -70,7 +70,8 @@ const iconikUpsertMessageSchema = z.looseObject({
   commissionTitle: z.string(),
   workingGroupId: z.string(),
   workingGroupTitle: z.string(),
-  masterPlaceholderId: z.string().optional()
+  masterPlaceholderId: z.string().optional(),
+  yearName: z.string().optional()
 });
 
 export type IconikUpsertMessage = z.infer<typeof iconikUpsertMessageSchema>;

--- a/test/data/IconikDataStoreSpec.scala
+++ b/test/data/IconikDataStoreSpec.scala
@@ -42,7 +42,8 @@ class IconikDataStoreSpec extends AnyFlatSpec with Matchers {
         workingGroupId = "wg1",
         workingGroupTitle = "Working Group 1",
         status = "active",
-        masterPlaceholderId = Some("mp1")
+        masterPlaceholderId = Some("mp1"),
+        yearName = Some("2026")
       ),
       createdAtDateTimeOverride = Some(createdAt)
     )
@@ -61,7 +62,8 @@ class IconikDataStoreSpec extends AnyFlatSpec with Matchers {
     commissionStore.store.head shouldEqual IconikCommission(
       workingGroupId = "wg1",
       id = "comm1",
-      title = "Commission 1"
+      title = "Commission 1",
+      year = Some("2026")
     )
     workingGroupStore.store should have size 1
     workingGroupStore.store.head shouldEqual IconikWorkingGroup(
@@ -78,7 +80,8 @@ class IconikDataStoreSpec extends AnyFlatSpec with Matchers {
         workingGroupId = "wg1",
         workingGroupTitle = "Working Group 1-updated",
         status = "active",
-        masterPlaceholderId = Some("mp1-updated")
+        masterPlaceholderId = Some("mp1-updated"),
+        yearName = Some("2026")
       )
     )
 
@@ -97,7 +100,8 @@ class IconikDataStoreSpec extends AnyFlatSpec with Matchers {
     commissionStore.store.head shouldEqual IconikCommission(
       workingGroupId = "wg1",
       id = "comm1",
-      title = "Commission 1-updated"
+      title = "Commission 1-updated",
+      year = Some("2026")
     )
     workingGroupStore.store should have size 1
     workingGroupStore.store.head shouldEqual IconikWorkingGroup(


### PR DESCRIPTION
## What does this change?

[Asana for context](https://app.asana.com/1/1210045093164357/project/1213625402425263/task/1213633053967633?focus=true)

Add an optional `year` field to `IconikCommission` table, this will come from the `yearName` in the event stream payload when an Iconik project is created.

There are some thoughts around: 1) whether we'd want to keep this optional; 2) how strictly we want to parse and store this - and I've left them as comments below so we can 🧵 

## How has this change been tested?

I have tested by calling the endpoint to `/api/iconik/projects` locally, and can see the `year` field popping up in the new rows under `IconikCommission` table:

<img width="1113" height="124" alt="Screenshot 2026-07-16 at 16 14 20" src="https://github.com/user-attachments/assets/a6839a9e-75d2-4021-8a63-c43e9b29335c" />




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216599896468928