### PR TITLE
Add clientside filtering by commission year

### DIFF
--- a/public/video-ui/src/components/Iconik/IconikProjectPicker.tsx
+++ b/public/video-ui/src/components/Iconik/IconikProjectPicker.tsx
@@ -38,15 +38,21 @@ export const IconikProjectPicker = ({ video }: Props) => {
   const [workingGroup, setWorkingGroup] = React.useState<string | undefined>(
     () => video.iconikData?.workingGroupId
   );
-  const [commissionYear, setCommissionYear] = React.useState<
+
+  const [selectedCommissionYear, setSelectedCommissionYear] = React.useState<
     string | undefined
-  >(existingCommission?.year ?? commissionYearOptions[0]?.id);
+  >();
   const [commission, setCommission] = React.useState<string | undefined>(
     () => video.iconikData?.commissionId
   );
   const [project, setProject] = React.useState<string | undefined>(
     () => video.iconikData?.projectId
   );
+
+  const commissionYear =
+    selectedCommissionYear ??
+    existingCommission?.year ??
+    commissionYearOptions[0]?.id;
 
   const filteredCommissions =
     commissionYear && commissionYear !== ALL_COMMISSION_YEARS_OPTION
@@ -59,12 +65,15 @@ export const IconikProjectPicker = ({ video }: Props) => {
     } else {
       dispatch(resetCommissions());
     }
+  }, [dispatch, workingGroup]);
+
+  useEffect(() => {
     if (commission) {
       dispatch(fetchIconikProjects(commission));
     } else {
       dispatch(resetProjects());
     }
-  }, [commission, dispatch, workingGroup]);
+  }, [dispatch, commission]);
 
   const hasBeenEdited =
     video.iconikData?.workingGroupId !== workingGroup ||
@@ -79,14 +88,10 @@ export const IconikProjectPicker = ({ video }: Props) => {
     [dispatch, video]
   );
 
-  useEffect(() => {
-    setCommissionYear(commissionYearOptions[0]?.id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [commissions]);
-
   const onWorkingGroupChange = useCallback(
     (selectedWorkingGroupId: string | undefined) => {
       setWorkingGroup(selectedWorkingGroupId);
+      setSelectedCommissionYear(undefined);
       setCommission(undefined);
       setProject(undefined);
     },
@@ -95,7 +100,7 @@ export const IconikProjectPicker = ({ video }: Props) => {
 
   const onCommissionYearChange = useCallback(
     (selectedCommissionYear: string | undefined) => {
-      setCommissionYear(selectedCommissionYear);
+      setSelectedCommissionYear(selectedCommissionYear);
       setCommission(undefined);
       setProject(undefined);
     },
@@ -119,14 +124,13 @@ export const IconikProjectPicker = ({ video }: Props) => {
 
   const restoreToSavedState = useCallback(() => {
     setWorkingGroup(video.iconikData?.workingGroupId);
-    setCommissionYear(existingCommission?.year);
+    setSelectedCommissionYear(undefined);
     setCommission(video.iconikData?.commissionId);
     setProject(video.iconikData?.projectId);
   }, [
     video.iconikData?.commissionId,
     video.iconikData?.projectId,
-    video.iconikData?.workingGroupId,
-    existingCommission?.year
+    video.iconikData?.workingGroupId
   ]);
 
   const deleteIconikDataFromStore = useCallback(() => {
@@ -136,6 +140,7 @@ export const IconikProjectPicker = ({ video }: Props) => {
       projectId: undefined
     });
     setWorkingGroup(undefined);
+    setSelectedCommissionYear(undefined);
     setCommission(undefined);
     setProject(undefined);
   }, [saveVideoUpdate]);

--- a/public/video-ui/src/components/Iconik/IconikProjectPicker.tsx
+++ b/public/video-ui/src/components/Iconik/IconikProjectPicker.tsx
@@ -1,4 +1,4 @@
-import { uniqueId } from 'lodash';
+import { orderBy, uniqueId, uniq } from 'lodash';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { getVideo } from '../../actions/VideoActions/getVideo';
@@ -30,15 +30,28 @@ export const IconikProjectPicker = ({ video }: Props) => {
     IconikState
   >(({ iconik }) => iconik);
 
+  const commissionYearOptions = getCommissionYearOptions(commissions);
+  const existingCommission = commissions.find(
+    commission => commission.id === video.iconikData?.commissionId
+  );
+
   const [workingGroup, setWorkingGroup] = React.useState<string | undefined>(
     () => video.iconikData?.workingGroupId
   );
+  const [commissionYear, setCommissionYear] = React.useState<
+    string | undefined
+  >(existingCommission?.year ?? commissionYearOptions[0]?.id);
   const [commission, setCommission] = React.useState<string | undefined>(
     () => video.iconikData?.commissionId
   );
   const [project, setProject] = React.useState<string | undefined>(
     () => video.iconikData?.projectId
   );
+
+  const filteredCommissions =
+    commissionYear && commissionYear !== ALL_COMMISSION_YEARS_OPTION
+      ? commissions.filter(commission => commission.year === commissionYear)
+      : commissions;
 
   useEffect(() => {
     if (workingGroup) {
@@ -66,9 +79,23 @@ export const IconikProjectPicker = ({ video }: Props) => {
     [dispatch, video]
   );
 
+  useEffect(() => {
+    setCommissionYear(commissionYearOptions[0]?.id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [commissions]);
+
   const onWorkingGroupChange = useCallback(
     (selectedWorkingGroupId: string | undefined) => {
       setWorkingGroup(selectedWorkingGroupId);
+      setCommission(undefined);
+      setProject(undefined);
+    },
+    []
+  );
+
+  const onCommissionYearChange = useCallback(
+    (selectedCommissionYear: string | undefined) => {
+      setCommissionYear(selectedCommissionYear);
       setCommission(undefined);
       setProject(undefined);
     },
@@ -92,12 +119,14 @@ export const IconikProjectPicker = ({ video }: Props) => {
 
   const restoreToSavedState = useCallback(() => {
     setWorkingGroup(video.iconikData?.workingGroupId);
+    setCommissionYear(existingCommission?.year);
     setCommission(video.iconikData?.commissionId);
     setProject(video.iconikData?.projectId);
   }, [
     video.iconikData?.commissionId,
     video.iconikData?.projectId,
-    video.iconikData?.workingGroupId
+    video.iconikData?.workingGroupId,
+    existingCommission?.year
   ]);
 
   const deleteIconikDataFromStore = useCallback(() => {
@@ -120,21 +149,28 @@ export const IconikProjectPicker = ({ video }: Props) => {
         selectOptions={sortProjects(workingGroups)}
         notification={null}
         onUpdateField={onWorkingGroupChange}
-      ></Select>
+      />
+      <Select
+        fieldName={'Commission Year'}
+        fieldValue={commissionYear}
+        selectOptions={commissionYearOptions}
+        notification={null}
+        onUpdateField={onCommissionYearChange}
+      />
       <Select
         fieldName={'Iconik Commission'}
         fieldValue={commission}
-        selectOptions={sortProjects(commissions)}
+        selectOptions={sortProjects(filteredCommissions)}
         notification={null}
         onUpdateField={onCommissionChange}
-      ></Select>
+      />
       <Select
         fieldName={'Iconik Project'}
         fieldValue={project}
         selectOptions={sortProjects(projects)}
         notification={null}
         onUpdateField={onProjectChange}
-      ></Select>
+      />
       {workingGroup && (!commission || !project) && (
         <p className="form__message form__message--error">
           Please select a project in order to save.
@@ -190,6 +226,27 @@ function sortProjects(
   return [
     ...startWithNumber.sort((a, b) => b.title.localeCompare(a.title)),
     ...rest.sort((a, b) => a.title.localeCompare(b.title))
+  ];
+}
+
+const ALL_COMMISSION_YEARS_OPTION = 'all-commission-years';
+function getCommissionYearOptions(commissions: IconikCommission[]) {
+  const commissionYears = orderBy(
+    uniq(
+      commissions
+        .map(commission => commission.year)
+        .filter((year): year is string => !!year)
+    ),
+    [year => year],
+    ['desc']
+  );
+  const commissionYearOptions = commissionYears.map(year => ({
+    id: year,
+    title: year
+  }));
+  return [
+    ...commissionYearOptions,
+    { id: ALL_COMMISSION_YEARS_OPTION, title: 'View all' }
   ];
 }
 

--- a/public/video-ui/src/services/IconikApi.ts
+++ b/public/video-ui/src/services/IconikApi.ts
@@ -11,6 +11,7 @@ export type IconikCommission = {
   id: string;
   title: string;
   workingGroupId: string;
+  year?: string;
 };
 
 export type IconikProject = {


### PR DESCRIPTION
## What does this change?
Now that we've added `year` field on `IconikCommission`, we can add clientside support for filtering commissions by year:

* Given that in the current implementation, we're always returning all commissions under a selected working group, and barring one working group that has ~200 commissions, most don't have a large amount, so I've opted for clientside filtering as payloads are reasonably small and for simplicity.
* This adds a simple select for commission year under a working group, in descending order, along with a 'View all' option
* If a project is already linked to a video, to show the correct commission year, we need to make an extra request to fetch the existing commission.


## How has this change been tested?
<img width="542" height="596" alt="commission year" src="https://github.com/user-attachments/assets/a3db24cb-4adb-4259-aa36-ac9de8300c09" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216599896468934