### PR TITLE
Add assets table for DEV stack

### DIFF
--- a/cloudformation/media-atom-maker-dev.yml
+++ b/cloudformation/media-atom-maker-dev.yml
@@ -204,7 +204,21 @@ Resources:
             AllowedOrigins:
               -
                 !Join [ "", [ "https://", { "Ref": "Domain"} ]]
-
+  AtomAssetsTable:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      TableName:
+        !Sub "${App}-${Stage}-atom-assets"
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+      - AttributeName: id
+        AttributeType: S
+      KeySchema:
+      - AttributeName: id
+        KeyType: HASH
+      Tags:
+        - Key: devx-backup-enabled
+          Value: true
   LimitedUploadRole:
     Type: "AWS::IAM::Role"
     Properties:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

An asset version claim table was added for CODE and PROD in https://github.com/guardian/editorial-tools-platform/pull/1067. We need to add one to the DEV stack, too, for local running.

**nb.** The Dev stack is not deployed via RiffRaff, but rather via manually updating the Cloudformation template. I've deployed this change already and verified that it creates the table expected by the app when running locally.
