### PR TITLE
Support search for Iconik fields

### DIFF
--- a/public/video-ui/src/components/FormFields/StandTagPicker.tsx
+++ b/public/video-ui/src/components/FormFields/StandTagPicker.tsx
@@ -1,6 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { TagAutocomplete, TagTable } from '@guardian/stand/tag-picker';
+import {
+  tagTableTheme,
+  tagAutocompleteTheme
+} from '../../constants/themeOverrides';
 import type { Tag } from '../../services/tagmanager';
 import { getTagByPath, getTagsByType } from '../../services/tagmanager';
 import BinSvg from '../../../images/bin.svg?react';
@@ -81,57 +85,6 @@ const videoTagsFromStringList = (
   }
 };
 
-const nonEditableUiTheme = {
-  row: {
-    backgroundColor: '#00000000',
-    borderBottom: {
-      borderColor: '#BDBDBD'
-    },
-    backgroundHoverColor: '#00000000',
-    firstRowBackgroundColor: '#00000000',
-    firstRowBackgroundHoverColor: '#00000000'
-  },
-  cell: {
-    borderBetweenCells: {
-      borderColor: '#BDBDBD'
-    }
-  }
-};
-
-const editableUiTheme = {
-  row: {
-    backgroundColor: '#00000000',
-    borderBottom: {
-      borderColor: '#BDBDBD'
-    },
-    backgroundHoverColor: '#000',
-    firstRowBackgroundColor: '#00000000',
-    firstRowBackgroundHoverColor: '#000'
-  },
-  cell: {
-    borderBetweenCells: {
-      borderColor: '#BDBDBD'
-    }
-  },
-  input: {
-    color: '#BDBDBD',
-    backgroundColor: '#393939',
-    borderColor: '#BDBDBD',
-    disabledBackgroundColor: '#393939'
-  },
-  listbox: {
-    backgroundColor: '#393939',
-    borderColor: '#BDBDBD',
-    item: {
-      color: '#BDBDBD',
-      backgroundHoverColor: '#252525',
-      colorHover: '#BDBDBD',
-      backgroundFocusedColor: '#252525',
-      colorFocused: '#BDBDBD'
-    }
-  }
-};
-
 const tagPickerContainerStyle = {
   display: 'flex',
   alignItems: 'stretch',
@@ -140,7 +93,7 @@ const tagPickerContainerStyle = {
 };
 
 const tagPickerDropdownStyle = {
-  border: '1px solid #BDBDBD',
+  border: '1px solid #898984',
   backgroundColor: '#393939',
   color: 'inherit',
   font: 'inherit',
@@ -329,7 +282,7 @@ const StandTagPicker = ({
             filterRows={() => true}
             showTagType={true}
             showTagSectionName={true}
-            theme={nonEditableUiTheme}
+            theme={tagTableTheme}
           />
         </div>
       );
@@ -361,7 +314,7 @@ const StandTagPicker = ({
                 placeholder={''}
                 disabled={false}
                 value={value}
-                theme={editableUiTheme}
+                theme={tagAutocompleteTheme}
               />
             </div>
             {filters && filters.length > 0 && (
@@ -384,7 +337,7 @@ const StandTagPicker = ({
                 showTagSectionName={true}
                 onReorder={onUpdate}
                 removeAction={onTagRemoved}
-                theme={editableUiTheme}
+                theme={tagTableTheme}
               />
             </div>
           )}

--- a/public/video-ui/src/components/Iconik/IconikProjectPicker.tsx
+++ b/public/video-ui/src/components/Iconik/IconikProjectPicker.tsx
@@ -1,13 +1,17 @@
-import { orderBy, uniqueId, uniq } from 'lodash';
-import React, { useCallback, useEffect, useState } from 'react';
+import { orderBy, uniq } from 'lodash';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { css } from '@emotion/react';
+import { Autocomplete } from '@guardian/stand/tag-picker';
 import { getVideo } from '../../actions/VideoActions/getVideo';
 import { saveVideo } from '../../actions/VideoActions/saveVideo';
-import {
-  IconikCommission,
-  IconikProject,
-  IconikWorkingGroup
-} from '../../services/IconikApi';
+import { IconikCommission } from '../../services/IconikApi';
 import { IconikData, Video } from '../../services/VideosApi';
 import {
   fetchIconikCommissions,
@@ -16,7 +20,9 @@ import {
   resetCommissions,
   resetProjects
 } from '../../slices/iconik';
+import { tagAutocompleteTheme } from '../../constants/themeOverrides';
 import { AppDispatch, RootState } from '../../util/setupStore';
+import Icon from '../Icon';
 
 type Props = {
   video: Video;
@@ -148,33 +154,29 @@ export const IconikProjectPicker = ({ video }: Props) => {
   return (
     <div className="form__group">
       <header className="video__detailbox__header">Iconik</header>
-      <Select
-        fieldName={'Iconik Working Group'}
-        fieldValue={workingGroup}
-        selectOptions={sortProjects(workingGroups)}
-        notification={null}
-        onUpdateField={onWorkingGroupChange}
+      <IconikAutocomplete
+        label="Iconik Working Group"
+        items={workingGroups}
+        selectedId={workingGroup}
+        onSelect={onWorkingGroupChange}
       />
-      <Select
-        fieldName={'Commission Year'}
-        fieldValue={commissionYear}
-        selectOptions={commissionYearOptions}
-        notification={null}
-        onUpdateField={onCommissionYearChange}
+      <IconikAutocomplete
+        label="Commission Year"
+        items={commissionYearOptions}
+        selectedId={commissionYear}
+        onSelect={onCommissionYearChange}
       />
-      <Select
-        fieldName={'Iconik Commission'}
-        fieldValue={commission}
-        selectOptions={sortProjects(filteredCommissions)}
-        notification={null}
-        onUpdateField={onCommissionChange}
+      <IconikAutocomplete
+        label="Iconik Commission"
+        items={filteredCommissions}
+        selectedId={commission}
+        onSelect={onCommissionChange}
       />
-      <Select
-        fieldName={'Iconik Project'}
-        fieldValue={project}
-        selectOptions={sortProjects(projects)}
-        notification={null}
-        onUpdateField={onProjectChange}
+      <IconikAutocomplete
+        label="Iconik Project"
+        items={projects}
+        selectedId={project}
+        onSelect={onProjectChange}
       />
       {workingGroup && (!commission || !project) && (
         <p className="form__message form__message--error">
@@ -221,17 +223,117 @@ function startsWithNumber(str: string) {
   return /^\d/.test(str);
 }
 
-function sortProjects(
-  projects: Array<IconikWorkingGroup | IconikCommission | IconikProject>
-) {
-  const startWithNumber = projects.filter(project =>
-    startsWithNumber(project.title)
-  );
-  const rest = projects.filter(project => !startsWithNumber(project.title));
+function sortOptions<T extends { title: string }>(items: T[]): T[] {
+  const startWithNumber = items.filter(item => startsWithNumber(item.title));
+  const rest = items.filter(item => !startsWithNumber(item.title));
   return [
     ...startWithNumber.sort((a, b) => b.title.localeCompare(a.title)),
     ...rest.sort((a, b) => a.title.localeCompare(b.title))
   ];
+}
+
+type IconikAutocompleteItem = { id: string; title: string };
+
+type IconikAutocompleteProps = {
+  label: string;
+  items: IconikAutocompleteItem[];
+  selectedId: string | undefined;
+  onSelect: (id: string | undefined) => void;
+};
+
+function IconikAutocomplete({
+  label,
+  items,
+  selectedId,
+  onSelect
+}: IconikAutocompleteProps) {
+  const selectedItem = items.find(item => item.id === selectedId);
+
+  const [inputValue, setInputValue] = useState<string>(
+    selectedItem?.title ?? ''
+  );
+
+  // The underlying combobox calls `onTextInputChange('')` itself right
+  // after a selection is made (see addSelection below). We want to ignore
+  // that one forced call so the selected item's name stays visible in the
+  // input, instead of immediately being blanked out again.
+  const justSelectedRef = useRef(false);
+
+  // Keep the input text in sync when the selection changes externally -
+  // e.g. initial load, restore, or the underlying list being replaced
+  // after a parent selection (working group/commission) changes.
+  useEffect(() => {
+    setInputValue(selectedItem?.title ?? '');
+  }, [selectedItem?.title]);
+
+  const visibleOptions = useMemo(() => {
+    const query = inputValue.trim().toLowerCase();
+    const matches = query
+      ? items.filter(item => item.title.toLowerCase().includes(query))
+      : items;
+    return sortOptions(matches).map(item => ({
+      id: item.id,
+      name: item.title
+    }));
+  }, [items, inputValue]);
+
+  const handleTextInputChange = (text: string) => {
+    if (justSelectedRef.current) {
+      justSelectedRef.current = false;
+      if (text === '') {
+        return;
+      }
+    }
+    setInputValue(text);
+  };
+
+  const handleAddSelection = (selection: {
+    id: string | number;
+    name: string;
+  }) => {
+    onSelect(String(selection.id));
+    justSelectedRef.current = true;
+    setInputValue(selection.name);
+  };
+
+  return (
+    <div className="form-element">
+      <div className="form__row">
+        <label className="form__label">{label}</label>
+        <div className="form__autocomplete__container">
+          <Autocomplete
+            onTextInputChange={handleTextInputChange}
+            options={visibleOptions}
+            label={label}
+            addSelection={handleAddSelection}
+            loading={false}
+            placeholder={`Search ${label}`}
+            disabled={false}
+            value={inputValue}
+            cssOverrides={css`
+              input {
+                padding-right: 40px;
+              }
+            `}
+            theme={tagAutocompleteTheme}
+          />
+          {Boolean(selectedId && inputValue) && (
+            <button
+              type="button"
+              className="form__autocomplete__clear-button"
+              aria-label={`Clear ${label}`}
+              onClick={() => {
+                onSelect(undefined);
+                setInputValue('');
+              }}
+            >
+              <Icon icon="cancel" className="icon__edit" />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 const ALL_COMMISSION_YEARS_OPTION = 'all-commission-years';
@@ -253,80 +355,4 @@ function getCommissionYearOptions(commissions: IconikCommission[]) {
     ...commissionYearOptions,
     { id: ALL_COMMISSION_YEARS_OPTION, title: 'View all' }
   ];
-}
-
-type SelectProps = {
-  fieldName: string;
-  fieldValue: string | undefined;
-  selectOptions: { id: string; title: string }[];
-  notification: {
-    type: 'error' | 'info' | 'warning'; // we aren't doing anything with info or warning, but preserving this for now, for compatibility with pre-existing SelectBox component.
-    message: string;
-  } | null;
-  onUpdateField: (newValue: string | undefined) => void;
-  id?: string;
-};
-
-function Select({
-  fieldName,
-  fieldValue,
-  selectOptions,
-  notification,
-  onUpdateField,
-  id
-}: SelectProps) {
-  /**
-   * @todo replace with useId when we upgrade to React 18+
-   */
-  const [elementId] = useState(id ?? uniqueId('select-box-'));
-
-  const matchingValues =
-    fieldValue === undefined
-      ? []
-      : selectOptions.filter(option => option.id === fieldValue);
-
-  const hasError = notification && notification.type === 'error';
-
-  return (
-    <div className="form-element">
-      <div>
-        <div className="form__row">
-          <label className="form__label" htmlFor={elementId}>
-            {fieldName}
-          </label>
-          <select
-            className={
-              'form__field form__field--select ' +
-              (hasError ? 'form__field--error' : '')
-            }
-            value={fieldValue ?? ''}
-            onChange={e => {
-              if (e.target.value === '') {
-                onUpdateField(undefined);
-                return;
-              }
-              onUpdateField(e.target.value);
-            }}
-            id={elementId}
-          >
-            {(fieldValue === undefined || matchingValues.length === 0) && (
-              <option value={''}>Please select...</option>
-            )}
-            {selectOptions.map(function (option) {
-              return (
-                <option value={option.id} key={option.id}>
-                  {option.title}
-                </option>
-              );
-            })}
-          </select>
-          {hasError ? (
-            <p className="form__message form__message--error">
-              {notification.message}
-            </p>
-          ) : undefined}
-        </div>
-      </div>
-    </div>
-  );
 }

--- a/public/video-ui/src/constants/themeOverrides.ts
+++ b/public/video-ui/src/constants/themeOverrides.ts
@@ -1,0 +1,46 @@
+import { semanticColors } from '@guardian/stand';
+/**
+ * @fileoverview Manage theme overrides for adopting @guardian/stand components as
+ * Video Atom Maker has a dark theme and its colour tokens do not match those of @guardian/stand.
+ 
+ * @TODO:
+ * 1. Move hardcoded colours to using semantic colour tokens from @guardian/stand where possible
+ * 2. Move Video Atom Maker theme to match @guardian/stand theme
+ */
+
+export const tagTableTheme = {
+  row: {
+    backgroundColor: '#00000000',
+    borderBottom: {
+      borderColor: semanticColors.border.strong
+    },
+    backgroundHoverColor: '#00000000',
+    firstRowBackgroundColor: '#00000000',
+    firstRowBackgroundHoverColor: '#00000000'
+  },
+  cell: {
+    borderBetweenCells: {
+      borderColor: semanticColors.border.strong
+    }
+  }
+};
+
+export const tagAutocompleteTheme = {
+  input: {
+    color: semanticColors.text['strong-inverse'],
+    backgroundColor: '#393939',
+    borderColor: semanticColors.border.strong,
+    disabledBackgroundColor: '#393939'
+  },
+  listbox: {
+    backgroundColor: '#393939',
+    borderColor: semanticColors.border.strong,
+    item: {
+      color: semanticColors.text['strong-inverse'],
+      backgroundHoverColor: '#252525',
+      colorHover: semanticColors.text['strong-inverse'],
+      backgroundFocusedColor: '#252525',
+      colorFocused: semanticColors.text['strong-inverse']
+    }
+  }
+};

--- a/public/video-ui/styles/components/_forms.scss
+++ b/public/video-ui/styles/components/_forms.scss
@@ -62,7 +62,8 @@
   cursor: pointer;
   flex-wrap: wrap;
   min-height: 36px;
-  .form__field__tag--container, .form__field__tag--container input {
+  .form__field__tag--container,
+  .form__field__tag--container input {
     flex-grow: 1;
   }
 }
@@ -97,7 +98,7 @@
       padding: 5px 7px;
       margin-right: 8px;
       border: none;
-      &:hover{
+      &:hover {
         background-color: $color300Grey;
         cursor: pointer;
       }
@@ -119,7 +120,8 @@
     color: $textColor;
   }
 
-  ::-moz-placeholder {  /* Firefox 19+ */
+  ::-moz-placeholder {
+    /* Firefox 19+ */
     color: $textColor;
   }
 
@@ -129,13 +131,14 @@
 
   // Because select elements are THE WORST
   &--select {
-    background: url(../images/arrow.png) $color650Grey no-repeat right 10px center;
+    background: url(../images/arrow.png) $color650Grey no-repeat right 10px
+      center;
     background-size: 10px 10px;
     margin-right: 40px;
     -webkit-appearance: none;
     -moz-appearance: none;
     border-radius: 0;
-    text-indent: .01px;
+    text-indent: 0.01px;
     text-overflow: '';
     &:hover {
       cursor: pointer;
@@ -167,7 +170,6 @@
 
   &--pluto {
     margin: 5px 0px 5px 0px !important;
-
   }
 
   &--textarea {
@@ -179,6 +181,19 @@
     display: inline-block;
     width: auto;
   }
+}
+
+.form__autocomplete__container {
+  position: relative;
+}
+
+.form__autocomplete__clear-button {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
 }
 
 .form__description {
@@ -211,8 +226,8 @@
   gap: 12px;
 }
 
-.form__label__layout__expire-now-button{
-  display:inline-flex;
+.form__label__layout__expire-now-button {
+  display: inline-flex;
   align-items: center;
   gap: 12px;
 }
@@ -232,7 +247,6 @@
   &--display {
     color: $color300Grey;
   }
-
 }
 
 .form__image {
@@ -241,14 +255,12 @@
   background-color: inherit;
 }
 
-
-
 .form__image img {
   max-width: 100%;
   max-height: 250px;
 }
 
-.form-checkbox{
+.form-checkbox {
   &:hover {
     filter: brightness(90%);
     cursor: pointer;
@@ -302,7 +314,6 @@
   }
 }
 
-
 .form__field__tag__display {
   text-decoration: underline $textColor;
   padding-left: 3px;
@@ -327,7 +338,7 @@
   &__options {
     background: $color200Grey;
     border: 1px solid $color300Grey;
-    box-shadow: 2px 2px 2px 0px rgba(0,0,0,0.1);
+    box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.1);
     position: absolute;
     top: 48px;
     left: 0;
@@ -343,7 +354,7 @@
 
     &:not(:last-child) {
       border-bottom: 1px solid $color300Grey;
-    };
+    }
 
     &:hover {
       background: $color650Grey;
@@ -360,7 +371,6 @@
     font-weight: bold;
     cursor: pointer;
     flex-shrink: 0;
-
   }
 }
 
@@ -378,7 +388,6 @@
   padding-right: 2px;
   padding-top: 2px;
 }
-
 
 .form__field--multistring__last {
   margin-top: 2px;
@@ -470,7 +479,7 @@
     height: auto;
   }
 
-   &.create-form__option--disabled {
+  &.create-form__option--disabled {
     cursor: not-allowed;
     opacity: 0.5;
   }
@@ -621,5 +630,5 @@ progress::-moz-progress-bar {
 }
 
 .stand-tag-table-container {
-  border: 1px solid #DCDCDC;
+  border: 1px solid #dcdcdc;
 }


### PR DESCRIPTION
## What does this change?

Support search for Iconik fields via a combo box pattern. Search is fully client-side.

* Within `IconikProjectPicker`, replace regular select dropdowns with `Autocomplete` from `@guardian/stand`
* `Autocomplete` is wrapped within a `IconikAutocomplete` component with some custom UI behaviour, e.g. persisting selected text, adding a 'clear' button to remove current selection
* As there are some theme overrides added for `Autocomplete` usage within the tag picker to accommodate for MAM's theme, I've consolidated these into their own file. I've taken the liberty to use `@guardian/stand` colours where possible, and things seem pretty blended in


## How has this change been tested?

<img width="492" height="630" alt="combobox" src="https://github.com/user-attachments/assets/28b0e9cf-d0c0-49d8-a0ea-1fa2c92ca1cd" />



## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213725277372102