### PR TITLE
Fix intermittent CI / Test run failures (WIP)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -200,8 +200,57 @@ lazy val uploader = (project in file("uploader"))
         log.info("Downloading statically compiled FFmpeg binary")
         IO.createDirectory(ffmpegFolder)
         import scala.sys.process.*
+        import scala.util.Try
         val archive = target.value / "ffmpeg" / "ffmpeg-release-amd64-static.tar.xz"
-        s"wget -nv https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz -O $archive".!!
+        val archiveUrl =
+          "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz"
+
+        val downloadedWithCurl = Try {
+          Seq(
+            "curl",
+            "-fL",
+            "--retry",
+            "5",
+            "--retry-delay",
+            "2",
+            "-o",
+            archive.getAbsolutePath,
+            archiveUrl
+          ).!
+        }.getOrElse(-1) == 0
+
+        val downloadedWithWget =
+          if (downloadedWithCurl) {
+            false
+          } else {
+            log.warn(
+              "curl download failed or unavailable, falling back to wget"
+            )
+            Try {
+              Seq(
+                "wget",
+                "-nv",
+                "--tries=5",
+                "--waitretry=2",
+                "-O",
+                archive.getAbsolutePath,
+                archiveUrl
+              ).!
+            }.getOrElse(-1) == 0
+          }
+
+        if (!downloadedWithCurl && !downloadedWithWget) {
+          throw new RuntimeException(
+            "Could not download FFmpeg archive: curl and wget both failed"
+          )
+        }
+
+        if (downloadedWithCurl) {
+          log.info("Downloaded FFmpeg archive with curl")
+        } else {
+          log.info("Downloaded FFmpeg archive with wget")
+        }
+
         (s"tar xOf $archive ffmpeg-7.0.2-amd64-static/ffmpeg" #> binary).!!
       }
 

--- a/pluto-message-ingestion/eslint.config.mjs
+++ b/pluto-message-ingestion/eslint.config.mjs
@@ -4,7 +4,7 @@ import { defineConfig, globalIgnores } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig([
-  globalIgnores(['target/*', 'eslint.config.mjs']),
+  globalIgnores(['target/*', 'eslint.config.mjs', 'scripts/*']),
   ...guardian.configs.recommended,
   ...guardian.configs.jest,
   eslintPluginPrettierRecommended,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

At the moment, the test suite will fail intermittently / is not behaving deterministically.  This is diagnosed as:

pluto-message-ingestion/scripts/aws.js is a development utility script.
It imports @aws-sdk/* packages.

The @aws-sdk packages live in pluto-message-ingestion/scripts/node_modules/

(the scripts/ subdirectory has its own package.json and separate yarn install).

When ESLint runs from pluto-message-ingestion/ via yarn lint:ci, the import/no-unresolved rule (from @guardian/eslint-config) can't find @aws-sdk/* in pluto-message-ingestion/node_modules/ — because they were only installed in the nested scripts/node_modules/.


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
