### PR TITLE
Add loading state when uploading

### DIFF
--- a/public/video-ui/src/components/Header.jsx
+++ b/public/video-ui/src/components/Header.jsx
@@ -45,27 +45,6 @@ export default class Header extends React.Component {
     });
   };
 
-  renderProgress() {
-    if (this.props.s3Upload.status === 'uploading') {
-      // Start prompting the user about reloading the page
-      window.onbeforeunload = () => {
-        return false;
-      };
-
-      return (
-        <progress
-          className="topbar__progress"
-          max={this.props.s3Upload.total}
-          value={this.props.s3Upload.progress}
-        />
-      );
-    } else {
-      // Stop prompting the user. The upload continues server-side
-      window.onbeforeunload = undefined;
-      return false;
-    }
-  }
-
   renderHome() {
     return (
       <div className="flex-container topbar__global">
@@ -256,7 +235,6 @@ export default class Header extends React.Component {
     if (this.props.currentPath.endsWith('/upload')) {
       return (
         <header className={className}>
-          {this.renderProgress()}
           {this.renderHeaderBack()}
           {this.renderPresence()}
         </header>
@@ -276,8 +254,6 @@ export default class Header extends React.Component {
     if (!this.props.showPublishedState) {
       return (
         <header className={className}>
-          {this.renderProgress()}
-
           {this.renderHome()}
           {this.renderSearch()}
           {this.renderPresence()}
@@ -296,7 +272,6 @@ export default class Header extends React.Component {
     } else {
       return (
         <header className={className}>
-          {this.renderProgress()}
           {this.renderHome()}
           <VideoPublishState video={this.props.publishedVideo} />
           {this.renderPresence()}

--- a/public/video-ui/src/components/VideoUpload/AddAssetFromURL.jsx
+++ b/public/video-ui/src/components/VideoUpload/AddAssetFromURL.jsx
@@ -46,7 +46,7 @@ export default class AddAssetFromURL extends React.Component {
                 className="btn"
                 type="button"
                 onClick={this.addAsset}
-                disabled={disabled}
+                disabled={disabled || this.props.isAdding}
               >
                 Add
               </button>

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.tsx
@@ -13,7 +13,7 @@ type Props = {
   uploads: ClientAsset[];
   setAsset: (version: number) => void;
   activatingAssetNumber: number;
-  showPendingUpload: boolean;
+  hasPendingUpload: boolean;
 };
 
 export const VideoTrail = ({
@@ -21,7 +21,7 @@ export const VideoTrail = ({
   uploads,
   setAsset,
   activatingAssetNumber,
-  showPendingUpload
+  hasPendingUpload
 }: Props) => {
   const dispatch = useDispatch<AppDispatch>();
 
@@ -70,7 +70,7 @@ export const VideoTrail = ({
       </div>
       <div className="grid">
         <div className="grid__list grid__list__trail grid__list__wrap">
-          {showPendingUpload && (
+          {hasPendingUpload && (
             <div className="video-trail__item">
               <div className="video-trail__upload">
                 <span className="loader" />

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.tsx
@@ -13,13 +13,15 @@ type Props = {
   uploads: ClientAsset[];
   setAsset: (version: number) => void;
   activatingAssetNumber: number;
+  showPendingUpload: boolean;
 };
 
 export const VideoTrail = ({
   video,
   uploads,
   setAsset,
-  activatingAssetNumber
+  activatingAssetNumber,
+  showPendingUpload
 }: Props) => {
   const dispatch = useDispatch<AppDispatch>();
 
@@ -68,6 +70,14 @@ export const VideoTrail = ({
       </div>
       <div className="grid">
         <div className="grid__list grid__list__trail grid__list__wrap">
+          {showPendingUpload && (
+            <div className="video-trail__item">
+              <div className="video-trail__upload">
+                <span className="loader" />
+                <div>Uploading…</div>
+              </div>
+            </div>
+          )}
           {uploads.map(upload => (
             <Asset
               key={upload.id}

--- a/public/video-ui/src/pages/Upload/index.tsx
+++ b/public/video-ui/src/pages/Upload/index.tsx
@@ -45,7 +45,8 @@ export const VideoUpload = (props: { params: { id: string } }) => {
       youtube,
       video: video.video,
       uploads,
-      activatingAssetNumber: video.activatingAssetNumber
+      activatingAssetNumber: video.activatingAssetNumber,
+      addingAsset: video.addingAsset
     })
   );
 
@@ -71,7 +72,9 @@ export const VideoUpload = (props: { params: { id: string } }) => {
     store.video.platform
   ]);
 
-  const isUploading = store.s3Upload.status === 'uploading';
+  const isUploading =
+    store.addingAsset ||
+    store.s3Upload.status === 'uploading';
 
   const projectId = store.video.plutoData?.projectId;
 
@@ -120,6 +123,7 @@ export const VideoUpload = (props: { params: { id: string } }) => {
                 />
                 <AddAssetFromURL
                   video={store.video}
+                  isAdding={store.addingAsset}
                   createAsset={bindActionCreators(createAsset, dispatch)}
                 />
               </>

--- a/public/video-ui/src/pages/Upload/index.tsx
+++ b/public/video-ui/src/pages/Upload/index.tsx
@@ -73,7 +73,7 @@ export const VideoUpload = (props: { params: { id: string } }) => {
   ]);
 
   const isUploading =
-    store.addingAsset ||
+    store.s3Upload.status === 'starting' ||
     store.s3Upload.status === 'uploading';
 
   const projectId = store.video.plutoData?.projectId;
@@ -87,6 +87,12 @@ export const VideoUpload = (props: { params: { id: string } }) => {
     },
     [dispatch, store.video.id, store.activatingAssetNumber]
   );
+
+  const showPendingUpload =
+    store.addingAsset ||
+    store.s3Upload.status == 'starting' ||
+    (store.s3Upload.status === 'uploading' &&
+      !store.uploads.some(u => u.id === store.s3Upload.id));
 
   // Prevent rendering until the correct video is loaded
   if (store.video.id !== props.params.id) {
@@ -141,6 +147,7 @@ export const VideoUpload = (props: { params: { id: string } }) => {
             uploads={store.uploads}
             setAsset={setAsset}
             activatingAssetNumber={store.activatingAssetNumber}
+            showPendingUpload={showPendingUpload}
           />
         </div>
       </div>

--- a/public/video-ui/src/pages/Upload/index.tsx
+++ b/public/video-ui/src/pages/Upload/index.tsx
@@ -88,7 +88,7 @@ export const VideoUpload = (props: { params: { id: string } }) => {
     [dispatch, store.video.id, store.activatingAssetNumber]
   );
 
-  const showPendingUpload =
+  const hasPendingUpload =
     store.addingAsset ||
     store.s3Upload.status == 'starting' ||
     (store.s3Upload.status === 'uploading' &&
@@ -147,7 +147,7 @@ export const VideoUpload = (props: { params: { id: string } }) => {
             uploads={store.uploads}
             setAsset={setAsset}
             activatingAssetNumber={store.activatingAssetNumber}
-            showPendingUpload={showPendingUpload}
+            hasPendingUpload={hasPendingUpload}
           />
         </div>
       </div>

--- a/public/video-ui/src/slices/s3Upload.ts
+++ b/public/video-ui/src/slices/s3Upload.ts
@@ -69,13 +69,14 @@ export interface S3UploadState {
   id: string | null;
   progress: number;
   total: number;
-  status: 'idle' | 'uploading' | 'complete' | 'error';
+  status: 'idle' | 'starting' | 'uploading' | 'complete' | 'error';
 }
 
 export const startVideoUpload = createAsyncThunk<
   unknown,
   { id: string; file: File; selfHost?: boolean }
 >('s3Upload/startVideoUpload', ({ id, file, selfHost }, { dispatch }) => {
+  dispatch(setS3UploadStatusToStarting());
   return createUpload(id, file, selfHost)
     .then((upload: Upload) => {
       dispatch(s3UploadStarted(upload));
@@ -84,9 +85,9 @@ export const startVideoUpload = createAsyncThunk<
         dispatch(s3UploadProgress(completed));
 
       return uploadParts(upload, upload.parts, file, progress)
-        .then(() => {
+        .then(async () => {
+          await dispatch(getUploads(id));
           dispatch(setS3UploadStatusToComplete());
-          dispatch(getUploads(id));
           dispatch(getVideo(id));
         })
         .catch(err => {
@@ -158,6 +159,9 @@ const s3Upload = createSlice({
     setS3UploadStatusToError: state => {
       state.status = 'error';
     },
+    setS3UploadStatusToStarting: state => {
+      state.status = 'starting';
+    },
     resetS3UploadState: () => ({
       ...initialState
     })
@@ -171,5 +175,6 @@ export const {
   s3UploadProgress,
   setS3UploadStatusToComplete,
   setS3UploadStatusToError,
+  setS3UploadStatusToStarting,
   resetS3UploadState
 } = s3Upload.actions;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

After clicking on 'upload' / 'upload to YouTube' for a new asset, there's a lag before a new asset container appears. It'd be good to have an interim loading state to give more immediate user feedback.

This PR introduces changes two changes to indicate to the user that the upload is happening: the upload buttons are disabled straight after click and a placeholder asset container appears instantly before being populated with the real data when that becomes available.

This PR also removes the progress bar from the header. The progress bar was appearing in the UI before but only as a light grey (empty) progress bar that disappeared when the asset container appeared. After these changes, due to reordering the steps in the s3Upload slice, it was 'working' by showing as a yellow 100% bar very briefly before disappearing again. Since it doesn't seem necessary any more, removing it seemed reasonable. Happy to discuss further.

## How has this change been tested?

Tested locally on this branch using YouTube and self-hosted workflows, with throttling.

## Images
<img width="2640" height="1710" alt="upload" src="https://github.com/user-attachments/assets/67d42d4d-fe70-4363-8521-ab546ef9f466" />

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
