### PR TITLE
Convert VideoItemIndex to typescript

### DIFF
--- a/public/video-ui/src/components/VideoItem/VideoItem.tsx
+++ b/public/video-ui/src/components/VideoItem/VideoItem.tsx
@@ -10,8 +10,15 @@ import Youtube from '../../../images/youtube.svg?react';
 import Loop from '../../../images/loop.svg?react';
 import Cinemagraph from '../../../images/cinemagraph.svg?react';
 import NonYoutube from '../../../images/nonyoutube.svg?react';
+import type { Presence } from '../../services/presence';
+import type { MediaAtomSummary } from '../../services/VideosApi';
 
-export default class VideoItem extends React.Component {
+type VideoItemProps = {
+  video: MediaAtomSummary;
+  presences: Presence[];
+};
+
+export class VideoItem extends React.Component<VideoItemProps> {
   renderPublishStatus() {
     if (VideoUtils.hasExpired(this.props.video)) {
       return <span className="publish__label label__expired">Expired</span>;
@@ -33,12 +40,14 @@ export default class VideoItem extends React.Component {
   }
 
   renderItemImage() {
-    const maybeThumbnailImage = this.props.video.posterImage
-      ? findAssetToUseAsThumbnail(this.props.video.posterImage)
+    const { video } = this.props;
+    const maybeThumbnailImage = video.posterImage
+      ? findAssetToUseAsThumbnail(video.posterImage)
       : undefined;
-    if (maybeThumbnailImage && maybeThumbnailImage.file) {
+
+    if (maybeThumbnailImage?.file) {
       return (
-        <img src={maybeThumbnailImage.file} alt={this.props.video.title} />
+        <img src={maybeThumbnailImage.file} alt={video.title ?? 'Video'} />
       );
     }
 
@@ -46,7 +55,7 @@ export default class VideoItem extends React.Component {
   }
 
   render() {
-    const video = this.props.video;
+    const { video, presences } = this.props;
     const platform = VideoUtils.getPlatformFromSummary(video);
     const scheduledLaunch = VideoUtils.getScheduledLaunch(video);
     const scheduledLaunchMoment = moment(scheduledLaunch);
@@ -54,18 +63,28 @@ export default class VideoItem extends React.Component {
     const embargoMoment = moment(embargo);
     const hasPreventedPublication =
       embargo && embargoMoment.valueOf() >= impossiblyDistantDate;
-    const iconMap = {
+
+    const iconMap: Record<string, React.ReactNode> = {
       Youtube: <Youtube />,
       Loop: <Loop />,
       Cinemagraph: <Cinemagraph />,
       Default: <NonYoutube />
     };
 
+    const isYoutubePlatform =
+      typeof platform === 'string' && platform.toLowerCase() === 'youtube';
+    const iconKey =
+      video.videoPlayerFormat && iconMap[video.videoPlayerFormat]
+        ? video.videoPlayerFormat
+        : isYoutubePlatform
+          ? 'Youtube'
+          : 'Default';
+
     return (
       <li className="grid__item">
         <div className="presence-section presence-section-front">
           <ul className="presence-list presence-list-front">
-            {this.props.presences.map(presence => {
+            {presences.map(presence => {
               const id = presence.clientId.connId;
               const { firstName, lastName } = presence.clientId.person;
               const initials = `${firstName.slice(0, 1)}${lastName.slice(0, 1)}`;
@@ -96,9 +115,7 @@ export default class VideoItem extends React.Component {
                   data-tip={
                     hasPreventedPublication
                       ? 'This video has been embargoed indefinitely'
-                      : `Embargoed until ${embargoMoment.format(
-                          'Do MMM YYYY HH:mm'
-                        )}`
+                      : `Embargoed until ${embargoMoment.format('Do MMM YYYY HH:mm')}`
                   }
                   className="publish__label label__frontpage__embargo label__frontpage__overlay"
                 >
@@ -111,9 +128,7 @@ export default class VideoItem extends React.Component {
               )}
               {scheduledLaunch && (
                 <span
-                  data-tip={`Scheduled to launch ${scheduledLaunchMoment.format(
-                    'Do MMM YYYY HH:mm'
-                  )}`}
+                  data-tip={`Scheduled to launch ${scheduledLaunchMoment.format('Do MMM YYYY HH:mm')}`}
                   className="publish__label label__frontpage__scheduledLaunch label__frontpage__overlay"
                 >
                   <Icon textClass="always-show" icon="access_time">
@@ -123,15 +138,7 @@ export default class VideoItem extends React.Component {
               )}
             </div>
             <div className="platform__icons">
-              <div className="platform__icon">
-                {video.videoPlayerFormat
-                  ? iconMap[video.videoPlayerFormat]
-                  : iconMap[
-                      platform?.toLowerCase() === 'youtube'
-                        ? 'Youtube'
-                        : 'Default'
-                    ]}
-              </div>
+              <div className="platform__icon">{iconMap[iconKey]}</div>
             </div>
             <div className="grid__item__footer">
               <span className="grid__item__title">{video.title}</span>

--- a/public/video-ui/src/pages/Search/index.tsx
+++ b/public/video-ui/src/pages/Search/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import VideoItem from '../../components/VideoItem';
+import { VideoItem } from '../../components/VideoItem/VideoItem';
 import { frontPageSize } from '../../constants/frontPageSize';
 import {
   Presence,
@@ -8,16 +8,13 @@ import {
   PresenceData,
   safelyStartPresence
 } from '../../services/presence';
+import type { MediaAtomSummary } from '../../services/VideosApi';
 import { getStore } from '../../util/storeAccessor';
 import { ErrorBoundary } from '../../components/ErrorBoundary/ErrorBoundary';
 import VideoItemError from '../../components/VideoItem/VideoItemError';
 
-type Video = {
-  id: string;
-};
-
 type VideosProps = {
-  videos: Video[];
+  videos: MediaAtomSummary[];
   total: number;
   presenceActions: {
     reportPresenceClientError: (err: unknown) => void;

--- a/public/video-ui/src/services/VideosApi.ts
+++ b/public/video-ui/src/services/VideosApi.ts
@@ -125,7 +125,12 @@ export type Video = {
 
 export type MediaAtomSummary = Pick<
   Video,
-  'id' | 'title' | 'contentChangeDetails' | 'posterImage'
+  | 'id'
+  | 'title'
+  | 'contentChangeDetails'
+  | 'posterImage'
+  | 'platform'
+  | 'videoPlayerFormat'
 >;
 
 export type VideoWithoutId = Omit<Video, 'id'>;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates Video item index to TS and changes it to a named export

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
