### PR TITLE
Enable strictNullChecks and fix resulting type errors

### DIFF
--- a/public/video-ui/src/actions/VideoActions/deleteAsset.ts
+++ b/public/video-ui/src/actions/VideoActions/deleteAsset.ts
@@ -18,6 +18,10 @@ export function deleteAsset(video: Video, assetId: string) {
 
     const asset = video.assets.find(_ => _.id === assetId);
 
+    if (!asset) {
+      return Promise.resolve();
+    }
+
     return VideosApi.deleteAsset(video, asset)
       .then(res => {
         dispatch(setVideo(res));

--- a/public/video-ui/src/actions/VideoActions/updateVideo.ts
+++ b/public/video-ui/src/actions/VideoActions/updateVideo.ts
@@ -2,6 +2,6 @@
 import { setVideo } from '../../slices/video';
 import { Video } from '../../services/VideosApi';
 
-export function updateVideo(video?: Video) {
+export function updateVideo(video: Video) {
   return setVideo(video);
 }

--- a/public/video-ui/src/components/FormFields/DatePicker.jsx
+++ b/public/video-ui/src/components/FormFields/DatePicker.jsx
@@ -139,6 +139,16 @@ function Display({ date, placeholder, fieldName }) {
   );
 }
 
+/**
+ * @param {object} [props]
+ * @param {boolean} [props.editable]
+ * @param {((date: number | null) => void) | null} [props.onUpdateField]
+ * @param {number | string | null} [props.fieldValue]
+ * @param {string | null} [props.placeholder]
+ * @param {string} [props.fieldName]
+ * @param {boolean} [props.dayOnly]
+ * @param {boolean} [props.canCancel]
+ */
 export default function CustomDatePicker({
   editable = false,
   onUpdateField = null,

--- a/public/video-ui/src/components/FormFields/DraggableTagList.tsx
+++ b/public/video-ui/src/components/FormFields/DraggableTagList.tsx
@@ -72,7 +72,7 @@ const TagElement = ({
 );
 
 const shouldHandleEvent = (element: HTMLElement) => {
-  let cur = element;
+  let cur: HTMLElement | null = element;
 
   while (cur) {
     if (cur.dataset && cur.dataset.noDnd) {
@@ -115,7 +115,7 @@ export const DraggableTagList = ({
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
-    if (active.id !== over.id) {
+    if (over && active.id !== over.id) {
       const oldIndex = tags.findIndex(tag => active.id === tag.id);
       const newIndex = tags.findIndex(tag => over.id === tag.id);
       const newTags = arrayMove(tags, oldIndex, newIndex);

--- a/public/video-ui/src/components/Pluto/PlutoProjectPicker.tsx
+++ b/public/video-ui/src/components/Pluto/PlutoProjectPicker.tsx
@@ -39,7 +39,7 @@ export const PlutoProjectPicker = ({ video }: Props) => {
   useEffect(() => {
     const commissionId = video.plutoData?.commissionId;
     if (commissionId) {
-      dispatch(fetchProjects(video.plutoData.commissionId));
+      dispatch(fetchProjects(commissionId));
     }
   }, [video.plutoData?.commissionId]);
 

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.test.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.test.tsx
@@ -17,7 +17,7 @@ const defaultProps = {
   deleteAsset: jest.fn(),
   startSubtitleFileUpload: jest.fn(),
   deleteSubtitle: jest.fn(),
-  activatingAssetNumber: undefined as number
+  activatingAssetNumber: undefined
 };
 
 const defaultVideoAsset: VideoAsset = {
@@ -34,7 +34,8 @@ store.dispatch(
     permissions: {
       deleteAtom: true,
       setVideosOnAllChannelsPublic: true,
-      pinboard: true
+      pinboard: true,
+      addSelfHostedAsset: true
     }
   })
 );

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.tsx
@@ -49,7 +49,7 @@ function AssetControls({
   selectAsset: { (): void };
   deleteAsset: { (): void };
   children: ReactNode;
-  activatingAssetNumber: number;
+  activatingAssetNumber?: number;
   isActivating: boolean;
   isUploadInProgress?: boolean;
 }) {
@@ -166,7 +166,11 @@ function AssetDisplay({
   );
 }
 
-function AssetProgress({ failed, current, total }: ClientAsset['processing']) {
+function AssetProgress({
+  failed,
+  current,
+  total
+}: NonNullable<ClientAsset['processing']>) {
   if (failed) {
     return (
       <div>
@@ -202,11 +206,11 @@ function SubtitleActions({
   onUpload: { (file: File): void };
   onDelete: { (): void };
 }) {
-  const fileInputRef = React.useRef();
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
 
   const handleFileChange: ChangeEventHandler<HTMLInputElement> = event => {
     const input = event.target;
-    const file = event.target.files[0];
+    const file = event.target.files?.[0];
 
     if (!file) return;
     const isSRT =
@@ -220,7 +224,7 @@ function SubtitleActions({
 
     const reader = new FileReader();
     reader.onload = function (e) {
-      const text = e.target.result as string;
+      const text = e.target?.result as string;
 
       const isSRTFormat =
         /\d{2}:\d{2}:\d{2},\d{3} --> \d{2}:\d{2}:\d{2},\d{3}/.test(text);
@@ -239,7 +243,7 @@ function SubtitleActions({
   };
 
   const handleClick = () => {
-    (fileInputRef.current as HTMLInputElement)?.click();
+    fileInputRef.current?.click();
   };
 
   return (
@@ -277,7 +281,7 @@ export function Asset({
   isActive: boolean;
   selectAsset: { (): void };
   deleteAsset: { (): void };
-  activatingAssetNumber: number;
+  activatingAssetNumber?: number;
   videoPlayerFormat?: VideoPlayerFormat;
 }) {
   const dispatch = useDispatch<AppDispatch>();
@@ -289,7 +293,7 @@ export function Asset({
   const timestamp = metadata?.startTimestamp || false;
 
   const isSelfHosted = asset && asset.sources;
-  const subtitleFilename = metadata?.subtitleFilename;
+  const subtitleFilename = metadata?.subtitleFilename ?? '';
 
   /**
    * We support subtitles on Loops and NonYoutube videos, but not Cinemagraphs (designed to be silent and decorative).
@@ -380,7 +384,7 @@ export function Asset({
         <AssetDisplay
           isActive={isActive}
           id={asset.id}
-          sources={asset.sources}
+          sources={asset.sources ?? []}
         />
         <div className="video-trail__item__details">
           <AssetControls

--- a/public/video-ui/src/components/VideoUpload/VideoTrail.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoTrail.tsx
@@ -12,7 +12,7 @@ type Props = {
   video: Video;
   uploads: ClientAsset[];
   setAsset: (version: number) => void;
-  activatingAssetNumber: number;
+  activatingAssetNumber?: number;
   hasPendingUpload: boolean;
 };
 
@@ -46,6 +46,9 @@ export const VideoTrail = ({
   }, [dispatch, uploads, video.id]);
 
   const deleteAssetsInUpload = async (asset: ClientAsset['asset']) => {
+    if (!asset) {
+      return;
+    }
     if (asset.id) {
       // if "asset.id" property exists, it should be a Youtube video asset.
       // There should be one asset for Youtube video and we can delete
@@ -56,8 +59,8 @@ export const VideoTrail = ({
       // video asset.  There may be multiple assets for a self-hosted video.
       // We can extract the asset IDs from the "src" property of each member
       // of the "sources" property.
-      const assetsToDelete = asset?.sources?.map(source => source.src);
-      if (assetsToDelete?.length > 0) {
+      const assetsToDelete = asset.sources?.map(source => source.src);
+      if (assetsToDelete && assetsToDelete.length > 0) {
         dispatch(deleteAssets(video, assetsToDelete));
       }
     }

--- a/public/video-ui/src/components/utils/Modal.tsx
+++ b/public/video-ui/src/components/utils/Modal.tsx
@@ -18,12 +18,12 @@ export default class Modal extends React.Component {
   }
 
   showModal() {
-    this.state.dialogRef.current?.showModal();
+    this.state.dialogRef?.current?.showModal();
     this.setState({ isOpen: true });
   }
 
   close() {
-    this.state.dialogRef.current?.close();
+    this.state.dialogRef?.current?.close();
   }
 
   handleCloseEvent = () => {
@@ -32,13 +32,13 @@ export default class Modal extends React.Component {
   };
 
   componentDidMount() {
-    this.state.dialogRef.current.addEventListener(
+    this.state.dialogRef?.current?.addEventListener(
       'close',
       this.handleCloseEvent
     );
   }
   componentWillUnmount() {
-    this.state.dialogRef.current.removeEventListener(
+    this.state.dialogRef?.current?.removeEventListener(
       'close',
       this.handleCloseEvent
     );

--- a/public/video-ui/src/pages/Search/index.tsx
+++ b/public/video-ui/src/pages/Search/index.tsx
@@ -47,8 +47,10 @@ const Videos = ({
 }: VideosProps) => {
   const [mediaIds, setMediaIds] = useState<string[]>([]);
   const [videoPresences, setVideoPresences] = useState<VideoPresences[]>([]);
-  const [client, setClient] = useState<PresenceClient>(null);
-  const [presencesQueue, setPresencesQueue] = useState<PresenceData>(null);
+  const [client, setClient] = useState<PresenceClient | null>(null);
+  const [presencesQueue, setPresencesQueue] = useState<PresenceData | null>(
+    null
+  );
   const [prevSearch, setPrevSearch] = useState('');
 
   const dispatch = useDispatch<AppDispatch>();
@@ -69,8 +71,9 @@ const Videos = ({
       presenceClient => {
         presenceClient.startConnection();
         presenceClient.on('visitor-list-subscribe', visitorData => {
-          if (visitorData.data.subscribedTo) {
-            const initialState = visitorData.data.subscribedTo
+          const subscribedTo = visitorData?.data?.subscribedTo;
+          if (subscribedTo) {
+            const initialState = subscribedTo
               .map(subscribedTo => {
                 return {
                   mediaId: subscribedTo.subscriptionId,
@@ -82,7 +85,7 @@ const Videos = ({
           }
         });
         presenceClient.on('visitor-list-updated', data => {
-          if (data.subscriptionId && data.currentState) {
+          if (data?.subscriptionId && data?.currentState) {
             // We dump the data to a queue (which is picked up by a useEffect rather than directly modifying videoPresences
             // so we don't need to depend on videoPresences, which led to some cyclicality
             setPresencesQueue(data);
@@ -142,7 +145,7 @@ const Videos = ({
         {
           mediaId: presencesQueue.subscriptionId,
           presences: presencesQueue.currentState
-        }
+        } as VideoPresences
       ]);
       setPresencesQueue(null);
     }

--- a/public/video-ui/src/services/UploadsApi.js
+++ b/public/video-ui/src/services/UploadsApi.js
@@ -20,7 +20,7 @@ export function getUploads(atomId) {
  *
  * @param atomId {string}
  * @param file {File}
- * @param selfHost {boolean}
+ * @param selfHost {boolean=}
  * @returns {Promise<unknown>}
  */
 export function createUpload(atomId, file, selfHost) {

--- a/public/video-ui/src/services/VideosApi.ts
+++ b/public/video-ui/src/services/VideosApi.ts
@@ -173,7 +173,7 @@ function getUsages({
 }
 
 function splitUsages({ usages }: { usages: CapiContent[] }) {
-  return usages.reduce(
+  return usages.reduce<{ video: CapiContent[]; other: CapiContent[] }>(
     (all, usage) => {
       if (usage.type === 'video') {
         all.video = [...all.video, usage];
@@ -182,7 +182,7 @@ function splitUsages({ usages }: { usages: CapiContent[] }) {
       }
       return all;
     },
-    { video: [] as CapiContent[], other: [] as CapiContent[] }
+    { video: [], other: [] }
   );
 }
 

--- a/public/video-ui/src/services/VideosApi.ts
+++ b/public/video-ui/src/services/VideosApi.ts
@@ -155,7 +155,8 @@ function getUsages({
     return Promise.all(usagePaths.map(path => ContentApi.getByPath(path))).then(
       capiResponse => {
         const usages = capiResponse.reduce((all: CapiContent[], item) => {
-          return [...all, item.response.content];
+          const content = item.response.content;
+          return content ? [...all, content] : all;
         }, []);
 
         // sort by article creation date DESC
@@ -181,7 +182,7 @@ function splitUsages({ usages }: { usages: CapiContent[] }) {
       }
       return all;
     },
-    { video: [], other: [] }
+    { video: [] as CapiContent[], other: [] as CapiContent[] }
   );
 }
 
@@ -342,7 +343,7 @@ export default {
   updateCanonicalPages(video: Video, usageData: UsageData, updatesTo: Stage) {
     const composerData = getComposerData(video);
     const composerUrlBase = getComposerUrl();
-    const videoBlock = getVideoBlock(video.id, video.title, video.source);
+    const videoBlock = getVideoBlock(video.id, video.title, video.source ?? '');
 
     return Promise.all(
       (Object.keys(usageData) as Stage[]).map(stage => {

--- a/public/video-ui/src/slices/s3Upload.ts
+++ b/public/video-ui/src/slices/s3Upload.ts
@@ -143,7 +143,8 @@ const s3Upload = createSlice({
   initialState,
   reducers: {
     s3UploadStarted: (state, action: PayloadAction<Upload>) => {
-      const total = action.payload.parts[action.payload.parts.length - 1].end;
+      const parts = action.payload.parts;
+      const total = parts && parts.length > 0 ? parts[parts.length - 1].end : 0;
       Object.assign(state, {
         id: action.payload.id,
         total: total,

--- a/public/video-ui/src/slices/search.ts
+++ b/public/video-ui/src/slices/search.ts
@@ -16,7 +16,8 @@ const initialState: Search = {
   searchTerm: '',
   shouldUseCreatedDateForSort:
     searchParams.get(QUERY_PARAM_shouldUseCreatedDateForSort) === 'true',
-  videoPlayerFormatFilter: searchParams.get(QUERY_PARAM_videoPlayerFormatFilter)
+  videoPlayerFormatFilter:
+    searchParams.get(QUERY_PARAM_videoPlayerFormatFilter) ?? ''
 };
 
 const search = createSlice({

--- a/public/video-ui/src/slices/video.ts
+++ b/public/video-ui/src/slices/video.ts
@@ -4,7 +4,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 interface VideoState {
   video: Video;
-  publishedVideo: Video;
+  publishedVideo: Video | null;
   saving: boolean;
   publishing: boolean;
   addingAsset: boolean;

--- a/public/video-ui/src/test/models.ts
+++ b/public/video-ui/src/test/models.ts
@@ -65,7 +65,7 @@ export const emptyVideo: Video = {
   commissioningDesks: [],
   keywords: [],
   youtubeTitle: '',
-  blockAds: undefined,
+  blockAds: false,
   atomTagIds: []
 };
 export const videoAsset1: Asset = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
       "noImplicitAny": true,
+      "strictNullChecks": true,
       "module": "commonjs",
       "target": "es2019",
       "outDir": "public/video-ui/build",


### PR DESCRIPTION
> [!NOTE]  
> This PR was opened by Claude Opus 4.8 based on an interactive session but I have reviewed the output

## What

Enables `strictNullChecks` in `tsconfig.json` and resolves all resulting type errors.

## How

Minimal changes across the affected files. The `strictNullChecks` flag is flipped in the final commit so every intermediate commit passes `yarn typecheck`:

- **Actions** — guard against undefined asset/video in `deleteAsset`/`updateVideo`
- **DraggableTagList** — handle null `over`/`parentElement`
- **PlutoProjectPicker** — use narrowed `commissionId`
- **DatePicker** — add JSDoc prop types for nullable fields
- **VideoAsset (+ test)** — null/undefined handling; `activatingAssetNumber` optional
- **VideoTrail** — guard undefined asset; optional `activatingAssetNumber`
- **Modal** — optional chaining for `dialogRef`
- **Search** — nullable presence state
- **VideosApi** — filter undefined CAPI content; type reduce accumulators
- **Slices (s3Upload, search, video) + UploadsApi** — nullable value handling
- **Test model** — `blockAds` set to boolean

## Verification

`yarn typecheck` passes (0 errors, down from 60).