### PR TITLE
Maybe fix regex for getting first frame name

### DIFF
--- a/app/model/commands/ActiveAssetCommand.scala
+++ b/app/model/commands/ActiveAssetCommand.scala
@@ -75,7 +75,7 @@ case class ActiveAssetCommand(
     val baseName =
       mp4Name
         .stripSuffix(".mp4")
-        .replaceAll("_(\\d+)(h|w)(_q\\d+)?$", "")
+        .replaceAll("_(\\d+)(h|w)(_q\\d+)?(_h264|_av1)?$", "")
     baseName + VideoSource.firstFrameImageSuffix
   }
 

--- a/test/model/commands/ActiveAssetCommandTest.scala
+++ b/test/model/commands/ActiveAssetCommandTest.scala
@@ -68,6 +68,14 @@ class ActiveAssetCommandTest extends AnyFlatSpec with Matchers {
       "How_Trump_is_making_America_s_birthday_all_about_himself___video_--d5093b44-eecf-4a42-a2f5-fc187be09be7-2.1.0000000.jpg"
     command.firstFrameImageName(mp4Name) shouldBe expected
   }
+
+  "firstFrameImageName" should "return the name of the first frame image associated with an mp4 video that has a _480w, quality & codec suffix" in {
+    val mp4Name =
+      "How_Trump_is_making_America_s_birthday_all_about_himself___video_--d5093b44-eecf-4a42-a2f5-fc187be09be7-2.1_480w_q8_h264.mp4"
+    val expected =
+      "How_Trump_is_making_America_s_birthday_all_about_himself___video_--d5093b44-eecf-4a42-a2f5-fc187be09be7-2.1.0000000.jpg"
+    command.firstFrameImageName(mp4Name) shouldBe expected
+  }
   "autoFirstFrameImage" should "return the first frame of the requested video version, when there is no active video" in {
     val atom = mediaAtom(activeVersion = None)
     val newVersion: Long = 2L


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This is a CoPilot-generated fix for an issue with how we're trying to construct the path for the first frame of self-hosted videos. I can't vouch for the business logic as such, but I can confirm that it works for the particular case I was looking at, where the file couldn't be found because the wrong name was being generated as part of ActivateAssetCommand: `2026/08/17/xyz--76457731-e83a-4297-abd8-fc64ec495cb8-1.0_480w_q8_h264.0000000.jpg` doesn't exist. With this change, it was looking up `2026/08/17/xyz--76457731-e83a-4297-abd8-fc64ec495cb8-1.0.0000000.jpg`, which does work.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
