### PR TITLE
Add confirmation step for activating an asset when there is already an active asset

### DIFF
--- a/public/video-ui/src/components/ActivateButton.tsx
+++ b/public/video-ui/src/components/ActivateButton.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useRef, useState } from 'react';
+import ReactTooltip from 'react-tooltip';
+
+type ActivateButtonProps = {
+  className: string;
+  onActivate: () => void;
+  disabled?: boolean;
+  videoHasActiveAsset: boolean;
+};
+
+export const ActivateButton = ({
+  className,
+  onActivate,
+  disabled,
+  videoHasActiveAsset
+}: ActivateButtonProps) => {
+  const [confirmActivate, setConfirmActivate] = useState(false);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleClick = () => {
+    setConfirmActivate(true);
+
+    if (resetTimerRef.current) {
+      clearTimeout(resetTimerRef.current);
+    }
+
+    resetTimerRef.current = setTimeout(() => {
+      setConfirmActivate(false);
+      resetTimerRef.current = null;
+    }, 4000);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current) {
+        clearTimeout(resetTimerRef.current);
+      }
+    };
+  }, []);
+
+  if (confirmActivate) {
+    return (
+      <>
+        <ReactTooltip />
+        <button
+          className={className}
+          onClick={onActivate}
+          data-tip="There is already an active asset. Continue activating?"
+          data-testid="activate-button"
+          disabled={disabled}
+        >
+          Confirm activate
+        </button>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <button
+        className={className}
+        onClick={videoHasActiveAsset ? handleClick : onActivate}
+        data-testid="activate-button"
+        disabled={disabled}
+      >
+        Activate
+      </button>
+    </>
+  );
+};

--- a/public/video-ui/src/components/ActivateButton.tsx
+++ b/public/video-ui/src/components/ActivateButton.tsx
@@ -46,7 +46,7 @@ export const ActivateButton = ({
           className={className}
           onClick={onActivate}
           data-tip="There is already an active asset. Continue activating?"
-          data-testid="activate-button"
+          data-testid="confirm-activate-button"
           disabled={disabled}
         >
           Confirm activate

--- a/public/video-ui/src/components/ActivateButton.tsx
+++ b/public/video-ui/src/components/ActivateButton.tsx
@@ -5,14 +5,14 @@ type ActivateButtonProps = {
   className: string;
   onActivate: () => void;
   disabled?: boolean;
-  videoHasActiveAsset: boolean;
+  confirmAssetActivation: boolean;
 };
 
 export const ActivateButton = ({
   className,
   onActivate,
   disabled,
-  videoHasActiveAsset
+  confirmAssetActivation
 }: ActivateButtonProps) => {
   const [confirmActivate, setConfirmActivate] = useState(false);
   const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -59,7 +59,7 @@ export const ActivateButton = ({
     <>
       <button
         className={className}
-        onClick={videoHasActiveAsset ? handleClick : onActivate}
+        onClick={confirmAssetActivation ? handleClick : onActivate}
         data-testid="activate-button"
         disabled={disabled}
       >

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.fixtures.ts
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.fixtures.ts
@@ -1,0 +1,132 @@
+import { blankVideoData } from '../../constants/blankVideoData';
+import { Asset as VideoAsset, Video } from '../../services/VideosApi';
+import { ClientAsset } from '../../slices/s3Upload';
+
+export const defaultProps = {
+  videoId: 'test-video-id',
+  isActive: false,
+  selectAsset: jest.fn(),
+  deleteAsset: jest.fn(),
+  startSubtitleFileUpload: jest.fn(),
+  deleteSubtitle: jest.fn(),
+  activatingAssetNumber: undefined
+};
+
+export const defaultStoreConfig = {
+  permissions: {
+    deleteAtom: true,
+    setVideosOnAllChannelsPublic: true,
+    pinboard: true,
+    addSelfHostedAsset: true
+  }
+};
+
+export const defaultVideoAsset: VideoAsset = {
+  version: 1,
+  id: 'AAAAAAAAAAA',
+  assetType: 'Video',
+  mimeType: 'video/youtube',
+  platform: 'Youtube'
+};
+
+export const unpublishedVideo: Video = {
+  ...blankVideoData,
+  id: 'test-video-id',
+  assets: [
+    {
+      ...defaultVideoAsset
+    },
+    {
+      ...defaultVideoAsset,
+      version: 2,
+      id: 'BBBBBBBBBBB'
+    }
+  ]
+};
+
+export const publishedVideo: Video = {
+  ...unpublishedVideo,
+  activeVersion: 2,
+  contentChangeDetails: {
+    revision: 1,
+    published: {
+      date: 1787309822
+    }
+  }
+};
+
+export const completedUpload: ClientAsset = {
+  id: '1',
+  asset: {
+    id: 'AAAAAAAAAAA'
+  },
+  metadata: {
+    originalFilename: 'test.mov',
+    startTimestamp: 1758557285850,
+    user: 'a.person@example.co.uk'
+  }
+};
+
+export const processingUpload: ClientAsset = {
+  id: '2',
+  processing: {
+    status: 'Uploading to YouTube',
+    failed: false,
+    current: 0,
+    total: 1
+  },
+  metadata: {
+    originalFilename: 'test.mov',
+    startTimestamp: 1758612923498,
+    user: 'a.person@example.co.uk'
+  }
+};
+
+export const failedUpload: ClientAsset = {
+  ...processingUpload,
+  processing: {
+    status: 'Upload failed',
+    failed: true
+  }
+};
+
+export const unknownProgressUpload: ClientAsset = {
+  ...processingUpload,
+  processing: {
+    status: 'Processing...',
+    failed: false
+  }
+};
+
+export const reprocessingUpload: ClientAsset = {
+  id: '2',
+  asset: {
+    sources: [
+      {
+        src: 'https://uploads.gu.com/test--264ef95d-ecb0-472e-9030-9e5ef678bf16-2.0.mp4',
+        mimeType: 'video/mp4'
+      },
+      {
+        src: 'https://uploads.gu.com/test--264ef95d-ecb0-472e-9030-9e5ef678bf16-2.1.m3u8',
+        mimeType: 'application/vnd.apple.mpegurl'
+      }
+    ]
+  },
+  processing: {
+    status: 'SendToTranscoderV2',
+    failed: false
+  },
+  metadata: {
+    originalFilename: 'Video.mp4',
+    startTimestamp: 1759499181730,
+    subtitleFilename: 'subtitle.srt',
+    user: 'a.person@example.co.uk'
+  }
+};
+
+export const emptyUpload: ClientAsset = {
+  id: '3',
+  metadata: {
+    user: 'a.person@example.co.uk'
+  }
+};

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.test.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.test.tsx
@@ -3,56 +3,27 @@ import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import React from 'react';
 import { Provider } from 'react-redux';
-import type { Asset as VideoAsset } from '../../services/VideosApi';
 import { setConfig } from '../../slices/config';
 import { setVideo } from '../../slices/video';
 import { setupStore } from '../../util/setupStore';
 import { setStore } from '../../util/storeAccessor';
 import { Asset } from './VideoAsset';
-import { blankVideoData } from '../../constants/blankVideoData';
-
-const defaultProps = {
-  videoId: 'test-video-id',
-  isActive: false,
-  selectAsset: jest.fn(),
-  deleteAsset: jest.fn(),
-  startSubtitleFileUpload: jest.fn(),
-  deleteSubtitle: jest.fn(),
-  activatingAssetNumber: undefined
-};
-
-const defaultVideoAsset: VideoAsset = {
-  version: 1,
-  id: 'AAAAAAAAAAA',
-  assetType: 'Video',
-  mimeType: 'video/youtube',
-  platform: 'Youtube'
-};
+import {
+  completedUpload,
+  defaultProps,
+  defaultStoreConfig,
+  emptyUpload,
+  failedUpload,
+  processingUpload,
+  publishedVideo,
+  reprocessingUpload,
+  unknownProgressUpload,
+  unpublishedVideo
+} from './VideoAsset.fixtures';
 
 const store = setupStore();
-store.dispatch(
-  setConfig({
-    permissions: {
-      deleteAtom: true,
-      setVideosOnAllChannelsPublic: true,
-      pinboard: true,
-      addSelfHostedAsset: true
-    }
-  })
-);
-store.dispatch(
-  setVideo({
-    ...blankVideoData,
-    id: 'test-video-id',
-    assets: [
-      {
-        ...defaultVideoAsset,
-        version: 1,
-        id: 'AAAAAAAAAAA'
-      }
-    ]
-  })
-);
+store.dispatch(setConfig(defaultStoreConfig));
+store.dispatch(setVideo(unpublishedVideo));
 setStore(store);
 
 describe('VideoAsset', () => {
@@ -60,19 +31,7 @@ describe('VideoAsset', () => {
     jest.clearAllMocks();
   });
 
-  describe('Asset with completed upload', () => {
-    const completedUpload = {
-      id: '1',
-      asset: {
-        id: 'AAAAAAAAAAA'
-      },
-      metadata: {
-        originalFilename: 'test.mov',
-        startTimestamp: 1758557285850,
-        user: 'a.person@example.co.uk'
-      }
-    };
-
+  describe('Asset with completed upload is inactive and video is unpublished', () => {
     it('renders completed asset with activate button enabled', () => {
       render(
         <Provider store={store}>
@@ -129,61 +88,16 @@ describe('VideoAsset', () => {
 
   describe('Asset is not the active asset and video is published', () => {
     const storeWithActiveAsset = setupStore();
-    storeWithActiveAsset.dispatch(
-      setConfig({
-        permissions: {
-          deleteAtom: true,
-          setVideosOnAllChannelsPublic: true,
-          pinboard: true,
-          addSelfHostedAsset: true
-        }
-      })
-    );
-    storeWithActiveAsset.dispatch(
-      setVideo({
-        ...blankVideoData,
-        id: 'test-video-id',
-        assets: [
-          {
-            ...defaultVideoAsset,
-            version: 1,
-            id: 'AAAAAAAAAAA'
-          },
-          {
-            ...defaultVideoAsset,
-            version: 2,
-            id: 'BBBBBBBBBBB'
-          }
-        ],
-        activeVersion: 2,
-        contentChangeDetails: {
-          revision: 1,
-          published: {
-            date: 1787309822
-          }
-        }
-      })
-    );
+    storeWithActiveAsset.dispatch(setConfig(defaultStoreConfig));
+    storeWithActiveAsset.dispatch(setVideo(publishedVideo));
     setStore(storeWithActiveAsset);
-
-    const inactiveAsset = {
-      id: '1',
-      asset: {
-        id: 'AAAAAAAAAAA'
-      },
-      metadata: {
-        originalFilename: 'test.mov',
-        startTimestamp: 1758557285850,
-        user: 'a.person@example.co.uk'
-      }
-    };
 
     it('does not call selectAsset when activate button is clicked once', async () => {
       const user = userEvent.setup();
 
       render(
         <Provider store={storeWithActiveAsset}>
-          <Asset {...defaultProps} upload={inactiveAsset} />
+          <Asset {...defaultProps} upload={completedUpload} />
         </Provider>
       );
 
@@ -198,18 +112,19 @@ describe('VideoAsset', () => {
 
       render(
         <Provider store={storeWithActiveAsset}>
-          <Asset {...defaultProps} upload={inactiveAsset} />
+          <Asset {...defaultProps} upload={completedUpload} />
         </Provider>
       );
 
       const activateButton = screen.getByTestId('activate-button');
       await user.click(activateButton);
+      const confirmButton = await screen.findByTestId(
+        'confirm-activate-button'
+      );
 
-      expect(defaultProps.selectAsset).not.toHaveBeenCalled();
+      // Only the confirm button should be visible
+      expect(activateButton).not.toBeInTheDocument();
 
-      const confirmButton = await screen.findByRole('button', {
-        name: /confirm activate/i
-      });
       await user.click(confirmButton);
 
       expect(defaultProps.selectAsset).toHaveBeenCalledTimes(1);
@@ -217,21 +132,6 @@ describe('VideoAsset', () => {
   });
 
   describe('Asset with processing upload', () => {
-    const processingUpload = {
-      id: '2',
-      processing: {
-        status: 'Uploading to YouTube',
-        failed: false,
-        current: 0,
-        total: 1
-      },
-      metadata: {
-        originalFilename: 'test.mov',
-        startTimestamp: 1758612923498,
-        user: 'a.person@example.co.uk'
-      }
-    };
-
     it('renders processing asset with activate and delete buttons disabled', () => {
       render(
         <Provider store={store}>
@@ -292,14 +192,6 @@ describe('VideoAsset', () => {
     });
 
     it('shows failed upload state', () => {
-      const failedUpload = {
-        ...processingUpload,
-        processing: {
-          status: 'Upload failed',
-          failed: true
-        }
-      };
-
       render(
         <Provider store={store}>
           <Asset {...defaultProps} upload={failedUpload} />
@@ -313,14 +205,6 @@ describe('VideoAsset', () => {
     });
 
     it('shows loading spinner when no progress information is available', () => {
-      const unknownProgressUpload = {
-        ...processingUpload,
-        processing: {
-          status: 'Processing...',
-          failed: false
-        }
-      };
-
       render(
         <Provider store={store}>
           <Asset {...defaultProps} upload={unknownProgressUpload} />
@@ -336,32 +220,6 @@ describe('VideoAsset', () => {
   });
 
   describe('Self-hosted asset with reprocessing subtitles', () => {
-    const reprocessingUpload = {
-      id: '2',
-      asset: {
-        sources: [
-          {
-            src: 'https://uploads.gu.com/test--264ef95d-ecb0-472e-9030-9e5ef678bf16-2.0.mp4',
-            mimeType: 'video/mp4'
-          },
-          {
-            src: 'https://uploads.gu.com/test--264ef95d-ecb0-472e-9030-9e5ef678bf16-2.1.m3u8',
-            mimeType: 'application/vnd.apple.mpegurl'
-          }
-        ]
-      },
-      processing: {
-        status: 'SendToTranscoderV2',
-        failed: false
-      },
-      metadata: {
-        originalFilename: 'Video.mp4',
-        startTimestamp: 1759499181730,
-        subtitleFilename: 'subtitle.srt',
-        user: 'a.person@example.co.uk'
-      }
-    };
-
     it('renders reprocessing asset with activate button disabled', () => {
       render(
         <Provider store={store}>
@@ -386,13 +244,6 @@ describe('VideoAsset', () => {
   });
 
   it('returns null when upload has no asset or processing state', () => {
-    const emptyUpload = {
-      id: '3',
-      metadata: {
-        user: 'a.person@example.co.uk'
-      }
-    };
-
     const { container } = render(
       <Provider store={store}>
         <Asset {...defaultProps} upload={emptyUpload} />

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.test.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.test.tsx
@@ -3,12 +3,13 @@ import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import React from 'react';
 import { Provider } from 'react-redux';
-import type { Video, Asset as VideoAsset } from '../../services/VideosApi';
+import type { Asset as VideoAsset } from '../../services/VideosApi';
 import { setConfig } from '../../slices/config';
 import { setVideo } from '../../slices/video';
 import { setupStore } from '../../util/setupStore';
 import { setStore } from '../../util/storeAccessor';
 import { Asset } from './VideoAsset';
+import { blankVideoData } from '../../constants/blankVideoData';
 
 const defaultProps = {
   videoId: 'test-video-id',
@@ -41,6 +42,7 @@ store.dispatch(
 );
 store.dispatch(
   setVideo({
+    ...blankVideoData,
     id: 'test-video-id',
     assets: [
       {
@@ -49,7 +51,7 @@ store.dispatch(
         id: 'AAAAAAAAAAA'
       }
     ]
-  } as Video)
+  })
 );
 setStore(store);
 
@@ -139,6 +141,7 @@ describe('VideoAsset', () => {
     );
     storeWithActiveAsset.dispatch(
       setVideo({
+        ...blankVideoData,
         id: 'test-video-id',
         assets: [
           {
@@ -153,7 +156,7 @@ describe('VideoAsset', () => {
           }
         ],
         activeVersion: 2
-      } as Video)
+      })
     );
     setStore(storeWithActiveAsset);
 

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.test.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.test.tsx
@@ -79,7 +79,7 @@ describe('VideoAsset', () => {
       );
 
       // Check that activate button is present and enabled
-      const activateButton = screen.getByRole('button', { name: 'Activate' });
+      const activateButton = screen.getByTestId('activate-button');
       expect(activateButton).toBeInTheDocument();
       expect(activateButton).not.toBeDisabled();
 
@@ -95,7 +95,7 @@ describe('VideoAsset', () => {
         </Provider>
       );
 
-      const activateButton = screen.getByRole('button', { name: 'Activate' });
+      const activateButton = screen.getByTestId('activate-button');
       await user.click(activateButton);
 
       expect(defaultProps.selectAsset).toHaveBeenCalledTimes(1);
@@ -108,9 +108,7 @@ describe('VideoAsset', () => {
         </Provider>
       );
 
-      expect(
-        screen.queryByRole('button', { name: 'Activate' })
-      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('activate-button')).not.toBeInTheDocument();
       expect(screen.getByText('Active')).toBeInTheDocument();
     });
 
@@ -124,6 +122,88 @@ describe('VideoAsset', () => {
       const deleteButton = screen.getByTestId('delete-button');
       expect(deleteButton).toBeInTheDocument();
       expect(deleteButton).not.toBeDisabled();
+    });
+  });
+
+  describe('Asset is not the active asset', () => {
+    const storeWithActiveAsset = setupStore();
+    storeWithActiveAsset.dispatch(
+      setConfig({
+        permissions: {
+          deleteAtom: true,
+          setVideosOnAllChannelsPublic: true,
+          pinboard: true,
+          addSelfHostedAsset: true
+        }
+      })
+    );
+    storeWithActiveAsset.dispatch(
+      setVideo({
+        id: 'test-video-id',
+        assets: [
+          {
+            ...defaultVideoAsset,
+            version: 1,
+            id: 'AAAAAAAAAAA'
+          },
+          {
+            ...defaultVideoAsset,
+            version: 2,
+            id: 'BBBBBBBBBBB'
+          }
+        ],
+        activeVersion: 2
+      } as Video)
+    );
+    setStore(storeWithActiveAsset);
+
+    const inactiveAsset = {
+      id: '1',
+      asset: {
+        id: 'AAAAAAAAAAA'
+      },
+      metadata: {
+        originalFilename: 'test.mov',
+        startTimestamp: 1758557285850,
+        user: 'a.person@example.co.uk'
+      }
+    };
+
+    it('does not call selectAsset when activate button is clicked once', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Provider store={storeWithActiveAsset}>
+          <Asset {...defaultProps} upload={inactiveAsset} />
+        </Provider>
+      );
+
+      const activateButton = screen.getByTestId('activate-button');
+      await user.click(activateButton);
+
+      expect(defaultProps.selectAsset).not.toHaveBeenCalled();
+    });
+
+    it('calls selectAsset when user clicks activate button and confirm activate', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Provider store={storeWithActiveAsset}>
+          <Asset {...defaultProps} upload={inactiveAsset} />
+        </Provider>
+      );
+
+      const activateButton = screen.getByTestId('activate-button');
+      await user.click(activateButton);
+
+      expect(defaultProps.selectAsset).not.toHaveBeenCalled();
+
+      const confirmButton = await screen.findByRole('button', {
+        name: /confirm activate/i
+      });
+      await user.click(confirmButton);
+
+      expect(defaultProps.selectAsset).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -157,14 +237,12 @@ describe('VideoAsset', () => {
       expect(progress).toHaveAttribute('max', '1');
 
       // Check that activate button is present but disabled
-      const activateButton = screen.getByRole('button', { name: 'Activate' });
+      const activateButton = screen.getByTestId('activate-button');
       expect(activateButton).toBeInTheDocument();
       expect(activateButton).toBeDisabled();
 
       // Check that delete button is present but disabled
-      const deleteButton = screen.getByRole('button', {
-        name: 'delete Delete'
-      });
+      const deleteButton = screen.getByTestId('delete-button');
       expect(deleteButton).toBeInTheDocument();
       expect(deleteButton).toBeDisabled();
 
@@ -182,7 +260,7 @@ describe('VideoAsset', () => {
         </Provider>
       );
 
-      const activateButton = screen.getByRole('button', { name: 'Activate' });
+      const activateButton = screen.getByTestId('activate-button');
       await user.click(activateButton);
 
       // Should not be called because button is disabled
@@ -200,7 +278,7 @@ describe('VideoAsset', () => {
         </Provider>
       );
 
-      const activateButton = screen.getByRole('button', { name: 'Activate' });
+      const activateButton = screen.getByTestId('activate-button');
       expect(activateButton).toHaveClass('btn--loading');
     });
 
@@ -221,7 +299,7 @@ describe('VideoAsset', () => {
 
       expect(screen.getByText('Upload Failed')).toBeInTheDocument();
 
-      const activateButton = screen.getByRole('button', { name: 'Activate' });
+      const activateButton = screen.getByTestId('activate-button');
       expect(activateButton).toBeDisabled();
     });
 
@@ -243,7 +321,7 @@ describe('VideoAsset', () => {
       // Should show spinner (loader class)
       expect(document.querySelector('.loader')).toBeInTheDocument();
 
-      const activateButton = screen.getByRole('button', { name: 'Activate' });
+      const activateButton = screen.getByTestId('activate-button');
       expect(activateButton).toBeDisabled();
     });
   });
@@ -286,7 +364,7 @@ describe('VideoAsset', () => {
       expect(document.querySelector('.loader')).toBeInTheDocument();
 
       // Check that activate button is present but disabled
-      const activateButton = screen.getByRole('button', { name: 'Activate' });
+      const activateButton = screen.getByTestId('activate-button');
       expect(activateButton).toBeInTheDocument();
       expect(activateButton).not.toBeDisabled();
 

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.test.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.test.tsx
@@ -127,7 +127,7 @@ describe('VideoAsset', () => {
     });
   });
 
-  describe('Asset is not the active asset', () => {
+  describe('Asset is not the active asset and video is published', () => {
     const storeWithActiveAsset = setupStore();
     storeWithActiveAsset.dispatch(
       setConfig({
@@ -155,7 +155,13 @@ describe('VideoAsset', () => {
             id: 'BBBBBBBBBBB'
           }
         ],
-        activeVersion: 2
+        activeVersion: 2,
+        contentChangeDetails: {
+          revision: 1,
+          published: {
+            date: 1787309822
+          }
+        }
       })
     );
     setStore(storeWithActiveAsset);

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.tsx
@@ -14,6 +14,7 @@ import Icon, { SubtitlesIcon } from '../Icon';
 import { VideoEmbed } from '../utils/VideoEmbed';
 import { YouTubeEmbed } from '../utils/YouTubeEmbed';
 import type { VideoPlayerFormat } from '../../constants/videoCreateOptions';
+import { ActivateButton } from '../ActivateButton';
 
 function presenceInitials(email: string) {
   if (!email) return;
@@ -56,6 +57,7 @@ function AssetControls({
   const className = isActivating ? 'btn btn--loading' : 'btn';
 
   const video = useSelector(selectVideo);
+  const videoHasActiveAsset = Boolean(video.activeVersion);
 
   const cannotActivateAsset =
     typeof activatingAssetNumber === 'number' || isUploadInProgress;
@@ -71,14 +73,12 @@ function AssetControls({
   );
 
   const activateButton = (
-    <button
+    <ActivateButton
       className={className}
-      style={{ paddingRight: 20 }}
       disabled={cannotActivateAsset}
-      onClick={selectAsset}
-    >
-      Activate
-    </button>
+      onActivate={selectAsset}
+      videoHasActiveAsset={videoHasActiveAsset}
+    />
   );
 
   const deleteButton = (

--- a/public/video-ui/src/components/VideoUpload/VideoAsset.tsx
+++ b/public/video-ui/src/components/VideoUpload/VideoAsset.tsx
@@ -57,7 +57,9 @@ function AssetControls({
   const className = isActivating ? 'btn btn--loading' : 'btn';
 
   const video = useSelector(selectVideo);
-  const videoHasActiveAsset = Boolean(video.activeVersion);
+  const confirmAssetActivation = Boolean(
+    video.activeVersion && video.contentChangeDetails.published
+  );
 
   const cannotActivateAsset =
     typeof activatingAssetNumber === 'number' || isUploadInProgress;
@@ -77,7 +79,7 @@ function AssetControls({
       className={className}
       disabled={cannotActivateAsset}
       onActivate={selectAsset}
-      videoHasActiveAsset={videoHasActiveAsset}
+      confirmAssetActivation={confirmAssetActivation}
     />
   );
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

If a video has an active asset, this could be published and live on the site, so activating another asset could have an impact on live content. Currently, a user can activate a different asset with just one click. This PR adds a confirmation step: when there is already an active asset and the video is published, the user must click the `Activate asset` button twice, and a tooltip informs the user why this is necessary.

## How has this change been tested?

I have added test coverage for the new behaviour. I have also checked locally that:
- when there is no active asset, an asset can be activated with one click only
- when there is an active asset and the video's status is `published`, the `Confirm activation` step must be completed and the tooltip appears explaining the reason

## Have we considered potential risks?

It could be annoying for users who are used to having to click only once. On the other hand, it is only a small change in behaviour and helpfully guards against assets being accidentally activated and live content being affected.

## Images

<img width="863" height="429" alt="Screenshot 2026-08-19 at 16 58 04" src="https://github.com/user-attachments/assets/9855c3a7-6bfd-498c-9a99-fea1b89d443b" />

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
